### PR TITLE
chore: Expose thread generation stage/status values from threadsprovider

### DIFF
--- a/react/src/providers/tambo-component-provider.tsx
+++ b/react/src/providers/tambo-component-provider.tsx
@@ -1,9 +1,5 @@
 "use client";
-import React, {
-  createContext,
-  PropsWithChildren,
-  useContext,
-} from "react";
+import React, { createContext, PropsWithChildren, useContext } from "react";
 import { TamboTool } from "../model/component-metadata";
 import { useTamboClient } from "./tambo-client-provider";
 import {
@@ -19,22 +15,18 @@ export interface TamboComponentContextProps {
 }
 
 const TamboComponentContext = createContext<TamboComponentContextProps>({
-  registerComponent: () => { },
-  registerTool: () => { },
-  registerTools: () => { },
-  addToolAssociation: () => { },
+  registerComponent: () => {},
+  registerTool: () => {},
+  registerTools: () => {},
+  addToolAssociation: () => {},
 });
 
 export const TamboComponentProvider: React.FC<PropsWithChildren> = ({
   children,
 }) => {
   const client = useTamboClient();
-  const {
-    registerComponent,
-    addToolAssociation,
-    registerTool,
-    registerTools,
-  } = useTamboRegistry();
+  const { registerComponent, addToolAssociation, registerTool, registerTools } =
+    useTamboRegistry();
 
   const value = {
     client,

--- a/react/src/providers/tambo-component-provider.tsx
+++ b/react/src/providers/tambo-component-provider.tsx
@@ -3,13 +3,8 @@ import React, {
   createContext,
   PropsWithChildren,
   useContext,
-  useState,
 } from "react";
 import { TamboTool } from "../model/component-metadata";
-import {
-  GenerationStage,
-  isIdleStage,
-} from "../model/generate-component-response";
 import { useTamboClient } from "./tambo-client-provider";
 import {
   RegisterComponentOptions,
@@ -18,37 +13,32 @@ import {
 
 export interface TamboComponentContextProps {
   registerComponent: (options: RegisterComponentOptions) => void;
-  generationStage: GenerationStage;
-  isIdle: boolean;
   registerTool: (tool: TamboTool) => void;
   registerTools: (tools: TamboTool[]) => void;
   addToolAssociation: (componentName: string, tool: TamboTool) => void;
 }
 
 const TamboComponentContext = createContext<TamboComponentContextProps>({
-  generationStage: GenerationStage.IDLE,
-  isIdle: true,
-  registerComponent: () => {},
-  registerTool: () => {},
-  registerTools: () => {},
-  addToolAssociation: () => {},
+  registerComponent: () => { },
+  registerTool: () => { },
+  registerTools: () => { },
+  addToolAssociation: () => { },
 });
 
 export const TamboComponentProvider: React.FC<PropsWithChildren> = ({
   children,
 }) => {
   const client = useTamboClient();
-
-  const { registerComponent, addToolAssociation, registerTool, registerTools } =
-    useTamboRegistry();
-  const [generationStage] = useState<GenerationStage>(GenerationStage.IDLE);
-  const isIdle = isIdleStage(generationStage);
+  const {
+    registerComponent,
+    addToolAssociation,
+    registerTool,
+    registerTools,
+  } = useTamboRegistry();
 
   const value = {
     client,
     registerComponent,
-    generationStage,
-    isIdle,
     registerTool,
     registerTools,
     addToolAssociation,

--- a/react/src/providers/tambo-thread-provider.tsx
+++ b/react/src/providers/tambo-thread-provider.tsx
@@ -301,7 +301,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       const headMessages = prevMap[currentThreadId].messages.slice(0, -1);
       const lastMessage =
         prevMap[currentThreadId].messages[
-        prevMap[currentThreadId].messages.length - 1
+          prevMap[currentThreadId].messages.length - 1
         ];
       const updatedLastMessage = {
         ...lastMessage,
@@ -349,16 +349,16 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
             toolRegistry,
           );
           const toolCallResponseParams: TamboAI.Beta.Threads.ThreadAdvanceParams =
-          {
-            ...params,
-            messageToAppend: {
-              content: [{ type: "text", text: "tool response" }],
-              role: "tool",
-              actionType: "tool_response",
-              toolResponse: toolCallResponse,
-              component: chunk.responseMessageDto.component,
-            },
-          };
+            {
+              ...params,
+              messageToAppend: {
+                content: [{ type: "text", text: "tool response" }],
+                role: "tool",
+                actionType: "tool_response",
+                toolResponse: toolCallResponse,
+                component: chunk.responseMessageDto.component,
+              },
+            };
           updateThreadStatus(GenerationStage.STREAMING_RESPONSE);
           const toolCallResponseStream = await advanceStream(
             client,
@@ -382,18 +382,18 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           if (!finalMessage) {
             finalMessage = chunk.responseMessageDto.component?.componentName
               ? renderComponentIntoMessage(
-                chunk.responseMessageDto,
-                componentList,
-              )
+                  chunk.responseMessageDto,
+                  componentList,
+                )
               : chunk.responseMessageDto;
             addThreadMessage(finalMessage, false);
           } else {
             const previousId = finalMessage.id;
             finalMessage = chunk.responseMessageDto.component?.componentName
               ? renderComponentIntoMessage(
-                chunk.responseMessageDto,
-                componentList,
-              )
+                  chunk.responseMessageDto,
+                  componentList,
+                )
               : chunk.responseMessageDto;
             updateThreadMessage(previousId, finalMessage, false);
           }
@@ -489,17 +489,17 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           toolRegistry,
         );
         const toolCallResponseParams: TamboAI.Beta.Threads.ThreadAdvanceParams =
-        {
-          ...params,
-          messageToAppend: {
-            ...params.messageToAppend,
-            content: [{ type: "text", text: "tool response" }],
-            role: "tool",
-            actionType: "tool_response",
-            toolResponse: toolCallResponse,
-            component: advanceResponse.responseMessageDto.component,
-          },
-        };
+          {
+            ...params,
+            messageToAppend: {
+              ...params.messageToAppend,
+              content: [{ type: "text", text: "tool response" }],
+              role: "tool",
+              actionType: "tool_response",
+              toolResponse: toolCallResponse,
+              component: advanceResponse.responseMessageDto.component,
+            },
+          };
         updateThreadStatus(GenerationStage.HYDRATING_COMPONENT);
         advanceResponse = await client.beta.threads.advanceById(
           advanceResponse.responseMessageDto.threadId,
@@ -510,9 +510,9 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       const finalMessage = advanceResponse.responseMessageDto.component
         ?.componentName
         ? renderComponentIntoMessage(
-          advanceResponse.responseMessageDto,
-          componentList,
-        )
+            advanceResponse.responseMessageDto,
+            componentList,
+          )
         : advanceResponse.responseMessageDto;
       await switchCurrentThread(advanceResponse.responseMessageDto.threadId);
       updateThreadStatus(GenerationStage.COMPLETE);
@@ -542,9 +542,13 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         inputValue,
         setInputValue,
         sendThreadMessage,
-        generationStage: (currentThread?.generationStage || GenerationStage.IDLE) as GenerationStage,
-        generationStatusMessage: currentThread?.statusMessage || "",
-        isIdle: isIdleStage((currentThread?.generationStage || GenerationStage.IDLE) as GenerationStage),
+        generationStage: (currentThread?.generationStage ??
+          GenerationStage.IDLE) as GenerationStage,
+        generationStatusMessage: currentThread?.statusMessage ?? "",
+        isIdle: isIdleStage(
+          (currentThread?.generationStage ??
+            GenerationStage.IDLE) as GenerationStage,
+        ),
       }}
     >
       {children}


### PR DESCRIPTION
Removes thread status values from componentsprovider and instead exposes them from threadsprovider, using the currentThread state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced process status tracking now provides real-time updates and detailed feedback during user operations, offering clearer insights into system activities.

- **Refactor**
  - Streamlined internal state management by removing redundant properties, leading to a more efficient and maintainable system that improves overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->