### PR TITLE
fix: avoid first message flicker

### DIFF
--- a/react/src/providers/tambo-thread-provider.tsx
+++ b/react/src/providers/tambo-thread-provider.tsx
@@ -288,7 +288,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       }
       await fetchThread(threadId);
     },
-    [fetchThread, threadMap, currentThreadId],
+    [fetchThread, threadMap],
   );
 
   const setLastThreadStatus = (status: GenerationStage) => {

--- a/react/src/providers/tambo-thread-provider.tsx
+++ b/react/src/providers/tambo-thread-provider.tsx
@@ -104,9 +104,6 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
   const [currentThreadId, setCurrentThreadId] = useState<string>(
     PLACEHOLDER_THREAD.id,
   );
-  const [unresolvedThreadId, setUnresolvedThreadId] = useState<
-    string | undefined
-  >(PLACEHOLDER_THREAD.id);
   const currentThread: TamboThread | undefined = threadMap[currentThreadId];
 
   // Use existing messages from the current thread to avoid re-generating any components
@@ -270,44 +267,28 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
     [currentThread],
   );
 
-  useEffect(() => {
-    if (unresolvedThreadId && currentThreadId !== unresolvedThreadId) {
-      setThreadMap((prevMap) => {
-        const unresolvedThread = prevMap[unresolvedThreadId];
-        const currentThread = prevMap[currentThreadId];
-        return {
-          ...prevMap,
-          [unresolvedThreadId]: PLACEHOLDER_THREAD,
-          [currentThreadId]: {
-            ...currentThread,
-            id: currentThreadId,
-            messages: [...unresolvedThread.messages, ...currentThread.messages],
-          },
-        };
-      });
-      setUnresolvedThreadId(undefined);
-    }
-  }, [currentThreadId, unresolvedThreadId]);
-
   const switchCurrentThread = useCallback(
     async (threadId: string) => {
       if (threadId === PLACEHOLDER_THREAD.id) {
         console.warn("Switching to placeholder thread, may be a bug");
         return;
       }
+
       setCurrentThreadId(threadId);
       if (!threadMap[threadId]) {
-        setThreadMap((prevMap) => ({
-          ...prevMap,
-          [threadId]: {
-            ...PLACEHOLDER_THREAD,
-            id: threadId,
-          },
-        }));
+        setThreadMap((prevMap) => {
+          return {
+            ...prevMap,
+            [threadId]: {
+              ...prevMap[PLACEHOLDER_THREAD.id],
+              id: threadId,
+            },
+          };
+        });
       }
       await fetchThread(threadId);
     },
-    [fetchThread, threadMap],
+    [fetchThread, threadMap, currentThreadId],
   );
 
   const setLastThreadStatus = (status: GenerationStage) => {


### PR DESCRIPTION
The first message is added to the local placeholder thread.

When the response comes back and we have a real threadID, we switch to that thread.

To get the original user message from the placeholder thread into the local new thread, we were using a useEffect to watch for a change to the currentThreadId and then add placeholder messages to the new thread.

But, the switch to the new thread would happen before the placeholder messages were put into the new thread, so there would be a moment where the original user message was not seen.

Fixes that by moving the messages over during the thread switch. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the thread switching behavior to deliver smoother and more consistent navigation between threads. This improvement refines internal processing, allowing for quicker responsiveness and more stable updates as users navigate the application. Overall, these adjustments help maintain high performance during interactions and bolster the reliability of the thread navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->