### PR TITLE
feat: support default prod/staging urls in react client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2371,9 +2371,9 @@
       "link": true
     },
     "node_modules/@tambo-ai/typescript-sdk": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.31.0.tgz",
-      "integrity": "sha512-T2N6lcTyY9eMgBSRoGDduk0TUGcC6FYyRlinoeIVOIhVl+KyPb7oOTMt9xdFtnRJtOcU2iWMIGUrOsAfq8tIgA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.32.0.tgz",
+      "integrity": "sha512-a11409twy9I6PHGV8Kt5zU6MSb7zmxQYbtbMSmywpt3Z0klky3WecevkCmtZ47PiahAJzWk3Ee5PLCYF3me+5w==",
       "license": "Apache-2.0",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -13604,7 +13604,7 @@
       "name": "@tambo-ai/react",
       "version": "0.12.1",
       "dependencies": {
-        "@tambo-ai/typescript-sdk": "^0.31.0",
+        "@tambo-ai/typescript-sdk": "^0.32.0",
         "@tanstack/react-query": "^5.67.3",
         "partial-json": "^0.1.7",
         "zod": "^3.24.1",

--- a/react/package.json
+++ b/react/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@tambo-ai/typescript-sdk": "^0.31.0",
+    "@tambo-ai/typescript-sdk": "^0.32.0",
     "@tanstack/react-query": "^5.67.3",
     "partial-json": "^0.1.7",
     "zod": "^3.24.1",

--- a/react/src/providers/tambo-client-provider.tsx
+++ b/react/src/providers/tambo-client-provider.tsx
@@ -1,4 +1,4 @@
-import TamboAI from "@tambo-ai/typescript-sdk";
+import TamboAI, { ClientOptions } from "@tambo-ai/typescript-sdk";
 import { QueryClient } from "@tanstack/react-query";
 import React, { createContext, PropsWithChildren, useState } from "react";
 
@@ -19,7 +19,11 @@ const TamboClientContext = createContext<TamboClientContextProps | undefined>(
 export const TamboClientProvider: React.FC<
   PropsWithChildren<TamboClientProviderProps>
 > = ({ children, tamboUrl, apiKey }) => {
-  const [client] = useState(() => new TamboAI({ baseURL: tamboUrl, apiKey }));
+  const tamboConfig: ClientOptions = { apiKey };
+  if (tamboUrl) {
+    tamboConfig.baseURL = tamboUrl;
+  }
+  const [client] = useState(() => new TamboAI(tamboConfig));
   const [queryClient] = useState(() => new QueryClient());
   return (
     <TamboClientContext.Provider value={{ client, queryClient }}>

--- a/react/src/providers/tambo-client-provider.tsx
+++ b/react/src/providers/tambo-client-provider.tsx
@@ -3,8 +3,9 @@ import { QueryClient } from "@tanstack/react-query";
 import React, { createContext, PropsWithChildren, useState } from "react";
 
 export interface TamboClientProviderProps {
-  tamboUrl: string;
+  tamboUrl?: string;
   apiKey: string;
+  environment?: "production" | "staging";
 }
 export interface TamboClientContextProps {
   client: TamboAI;
@@ -18,10 +19,13 @@ const TamboClientContext = createContext<TamboClientContextProps | undefined>(
 
 export const TamboClientProvider: React.FC<
   PropsWithChildren<TamboClientProviderProps>
-> = ({ children, tamboUrl, apiKey }) => {
+> = ({ children, tamboUrl, apiKey, environment }) => {
   const tamboConfig: ClientOptions = { apiKey };
   if (tamboUrl) {
     tamboConfig.baseURL = tamboUrl;
+  }
+  if (environment) {
+    tamboConfig.environment = environment;
   }
   const [client] = useState(() => new TamboAI(tamboConfig));
   const [queryClient] = useState(() => new QueryClient());


### PR DESCRIPTION
- **fix: if no url is provided, do not set it**
- **get latest sdk with default urls**
- **also support environnment**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the SDK dependency to the latest release.
  
- **New Features**
  - Enhanced client configuration options for more flexible integrations by allowing an optional service URL and environment selection (production or staging).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->