### PR TITLE
fix: during streaming fetch at complete

### DIFF
--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -268,7 +268,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
   );
 
   const switchCurrentThread = useCallback(
-    async (threadId: string) => {
+    async (threadId: string, fetch = true) => {
       if (threadId === PLACEHOLDER_THREAD.id) {
         console.warn("Switching to placeholder thread, may be a bug");
         return;
@@ -286,7 +286,9 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           };
         });
       }
-      await fetchThread(threadId);
+      if (fetch) {
+        await fetchThread(threadId);
+      }
     },
     [fetchThread, threadMap],
   );
@@ -385,7 +387,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
             chunk.responseMessageDto.threadId !== currentThread?.id
           ) {
             hasSetThreadId = true;
-            switchCurrentThread(chunk.responseMessageDto.threadId);
+            switchCurrentThread(chunk.responseMessageDto.threadId, false);
           }
 
           if (!finalMessage) {
@@ -410,6 +412,9 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       }
 
       updateThreadStatus(GenerationStage.COMPLETE);
+      if (finalMessage) {
+        await fetchThread(finalMessage.threadId);
+      }
       return (
         finalMessage ?? {
           threadId: "",
@@ -424,6 +429,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       toolRegistry,
       client,
       currentThread?.id,
+      currentThreadId,
       switchCurrentThread,
       componentList,
       addThreadMessage,


### PR DESCRIPTION
Previously during the first streamed message was fetching the remote thread during switching the local currentThreadId, which would sometimes return an "older" thread state than was currently available through returned chunks.

Fixes that by switching the thread without fetching, and fetching the remote thread for final state after chunks complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved thread switching with conditional loading that retrieves the latest thread data only when needed, reducing unnecessary refreshes and enhancing performance during live updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->