### PR TITLE
chore: show renderedComponent in Message component

### DIFF
--- a/cli/src/registry/chat-thread/chat-thread.tsx
+++ b/cli/src/registry/chat-thread/chat-thread.tsx
@@ -77,6 +77,7 @@ const ChatThread = React.forwardRef<HTMLDivElement, ChatThreadProps>(
                       : "Empty message"
                 }
                 variant={variant}
+                message={message}
               />
             </div>
           </div>

--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import type { TamboThreadMessage } from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import sanitizeHtml from "sanitize-html";
@@ -51,12 +52,13 @@ const bubbleVariants = cva(
 export interface MessageProps {
   role: "user" | "assistant";
   content: string | { type: string; text?: string }[];
+  message: TamboThreadMessage;
   variant?: VariantProps<typeof messageVariants>["variant"];
   className?: string;
 }
 
 const Message = React.forwardRef<HTMLDivElement, MessageProps>(
-  ({ className, role, content, variant, ...props }, ref) => {
+  ({ className, role, content, variant, message, ...props }, ref) => {
     return (
       <div
         ref={ref}
@@ -79,6 +81,9 @@ const Message = React.forwardRef<HTMLDivElement, MessageProps>(
               ))
             )}
           </p>
+          {message.renderedComponent && (
+            <div className="mt-2">{message.renderedComponent}</div>
+          )}
         </div>
       </div>
     );

--- a/cli/src/types/components.d.ts
+++ b/cli/src/types/components.d.ts
@@ -19,6 +19,7 @@ declare module "@/components/ui/message" {
     role: "user" | "assistant";
     content: string | { type: string; text?: string }[];
     variant?: ComponentVariant;
+    message: TamboThreadMessage;
   }
   export const Message: React.ForwardRefExoticComponent<
     MessageProps & React.RefAttributes<HTMLDivElement>


### PR DESCRIPTION
Adds a TamboThreadMessage prop to the Message component so we can access `renderedComponent` and show it in the Message.

Maybe Message component doesn't need role or content props anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat messages now include additional content details, enhancing the display and presentation of conversations.
  - An extra visual element is introduced beneath message text when extra details are available, offering an enriched browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->