### PR TITLE
fix: only initialize component state value once

### DIFF
--- a/react-sdk/src/hooks/use-component-state.tsx
+++ b/react-sdk/src/hooks/use-component-state.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTamboClient, useTamboThread } from "../providers";
 import {
   useTamboCurrentMessage,
@@ -69,18 +69,20 @@ export function useTamboComponentState<S>(
     threadId,
     updateThreadMessage,
   ]);
+  const [haveInitialized, setHaveInitialized] = useState(false);
+  const shouldInitialize =
+    !haveInitialized &&
+    message &&
+    initialValue !== undefined &&
+    (!message.componentState || !(keyName in message.componentState));
 
   // send initial state
   useEffect(() => {
-    const shouldInitialize =
-      message &&
-      initialValue !== undefined &&
-      (!message.componentState || !(keyName in message.componentState));
-
     if (shouldInitialize) {
       initializeState();
+      setHaveInitialized(true);
     }
-  }, [messageId, initializeState, message, initialValue, keyName]);
+  }, [initializeState, shouldInitialize]);
 
   const setValue = useCallback(
     async (newValue: S) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the component’s state management to improve initialization logic, ensuring it executes only once for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->