### PR TITLE
fix: Remove many uses of currentThreadId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
     },
     "cli": {
       "name": "tambo",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@tambo-ai/react": "*",
         "chalk": "^5.3.0",

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -477,7 +477,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         threadId: string;
         streamResponse?: boolean;
         contextKey?: string;
-      },
+      } = { threadId: PLACEHOLDER_THREAD.id },
     ): Promise<TamboThreadMessage> => {
       const { threadId, streamResponse } = options;
       updateThreadStatus(threadId, GenerationStage.CHOOSING_COMPONENT);

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -216,13 +216,12 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       };
       const threadId = message.threadId;
       // optimistically update the thread in the local state
-      const prevMessages = threadMap[threadId]?.messages || [];
-      const updatedMessages = [...prevMessages, chatMessage];
-
       setThreadMap((prevMap) => {
         if (!threadId) {
           return prevMap;
         }
+        const prevMessages = prevMap[threadId]?.messages || [];
+        const updatedMessages = [...prevMessages, chatMessage];
         return {
           ...prevMap,
           [threadId]: {
@@ -240,9 +239,9 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           // additionalContext: chatMessage.additionalContext,
         });
       }
-      return updatedMessages;
+      return threadMap[threadId]?.messages || [];
     },
-    [client.beta.threads.messages, currentThread],
+    [client.beta.threads.messages, currentThread, threadMap],
   );
 
   const updateThreadMessage = useCallback(

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -242,7 +242,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       }
       return updatedMessages;
     },
-    [client.beta.threads.messages, currentThread, currentThreadId],
+    [client.beta.threads.messages, currentThread],
   );
 
   const updateThreadMessage = useCallback(
@@ -285,7 +285,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         });
       }
     },
-    [client.beta.threads.messages, currentThreadId],
+    [client.beta.threads.messages],
   );
 
   const deleteThreadMessage = useCallback(

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -278,7 +278,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       });
       if (sendToServer) {
         // TODO: if this fails, we need to revert the local state update
-        await client.beta.threads.messages.create(currentThreadId, {
+        await client.beta.threads.messages.create(message.threadId, {
           content: message.content,
           role: message.role,
           // additionalContext: chatMessage.additionalContext,

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -487,7 +487,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           content: [{ type: "text", text: message }],
           renderedComponent: null,
           role: "user",
-          threadId: currentThread.id,
+          threadId: threadId,
           id: crypto.randomUUID(),
           createdAt: new Date().toISOString(),
           componentState: {},

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -562,7 +562,10 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           )
         : advanceResponse.responseMessageDto;
       await switchCurrentThread(advanceResponse.responseMessageDto.threadId);
-      updateThreadStatus(threadId, GenerationStage.COMPLETE);
+      updateThreadStatus(
+        advanceResponse.responseMessageDto.threadId,
+        GenerationStage.COMPLETE,
+      );
       return finalMessage;
     },
     [

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -289,20 +289,20 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
   );
 
   const deleteThreadMessage = useCallback(
-    (messageId: string) => {
-      if (!currentThread) return;
+    (messageId: string, threadId: string) => {
+      if (!threadMap[threadId]) return;
 
       setThreadMap((prevMap) => ({
         ...prevMap,
-        [currentThread.id]: {
-          ...prevMap[currentThread.id],
-          messages: prevMap[currentThread.id].messages.filter(
+        [threadId]: {
+          ...prevMap[threadId],
+          messages: prevMap[threadId].messages.filter(
             (msg) => msg.id !== messageId,
           ),
         },
       }));
     },
-    [currentThread],
+    [threadMap],
   );
 
   const startNewThread = useCallback(() => {
@@ -371,7 +371,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
 
       for await (const chunk of stream) {
         if (isFirstChunk && messageIdToRemove) {
-          deleteThreadMessage(messageIdToRemove);
+          deleteThreadMessage(messageIdToRemove, threadId);
         }
         isFirstChunk = false;
 


### PR DESCRIPTION
Makes threadId required for `sendThreadMessage` (sets default value to placeholder thread's id).
Updates thread functions to take in and use threadId rather than assuming the currentThreadId state value is correct.

So then it's up to the caller of sendThreadMessage to use the correct threadId (or none if they start a new thread), which they can get using the exposed `thread` state value, and switch using `switchCurrentThread`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the messaging system by requiring an explicit thread identifier for all thread-related operations.
  - Streamlined thread management to ensure more reliable and consistent handling of threaded messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->