### PR TITLE
docs: add a bunch of jsdocs for components

### DIFF
--- a/cli/src/registry/control-bar/control-bar.tsx
+++ b/cli/src/registry/control-bar/control-bar.tsx
@@ -1,26 +1,38 @@
 "use client";
 
-import * as React from "react";
-import { useRef, useEffect } from "react";
-import { cn } from "@/lib/utils";
-import { ThreadContent } from "@/components/ui/thread-content";
 import { MessageInput } from "@/components/ui/message-input";
-import { useTambo } from "@tambo-ai/react";
+import { ThreadContent } from "@/components/ui/thread-content";
+import { cn } from "@/lib/utils";
 import * as Dialog from "@radix-ui/react-dialog";
+import { useTambo } from "@tambo-ai/react";
+import * as React from "react";
+import { useEffect, useRef } from "react";
 
 /**
- * A control bar component for managing Tambo threads
- * @property {string} className - Optional className for custom styling
- * @property {string} contextKey - Tambo thread context key for message routing
- * @property {string} hotkey - Keyboard shortcut for opening the control bar
+ * Props for the ControlBar component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
  */
-
 export interface ControlBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Optional context key for the thread */
   contextKey?: string;
+  /** Keyboard shortcut for toggling the control bar (default: "mod+k") */
   hotkey?: string;
 }
 
-const ControlBar = React.forwardRef<HTMLDivElement, ControlBarProps>(
+/**
+ * A floating control bar component for quick access to chat functionality
+ * @component
+ * @example
+ * ```tsx
+ * <ControlBar
+ *   contextKey="my-thread"
+ *   hotkey="mod+k"
+ *   className="custom-styles"
+ * />
+ * ```
+ */
+export const ControlBar = React.forwardRef<HTMLDivElement, ControlBarProps>(
   ({ className, contextKey, hotkey = "mod+k", ...props }, ref) => {
     const [open, setOpen] = React.useState(false);
     const isMac =
@@ -101,5 +113,3 @@ const ControlBar = React.forwardRef<HTMLDivElement, ControlBarProps>(
   },
 );
 ControlBar.displayName = "ControlBar";
-
-export { ControlBar };

--- a/cli/src/registry/form/form.tsx
+++ b/cli/src/registry/form/form.tsx
@@ -38,26 +38,71 @@ const formVariants = cva("w-full rounded-lg transition-all duration-200", {
  * @property {boolean} [required] - Whether the field is required
  * @property {string} [description] - Additional description text for the field
  */
-
 export interface FormField {
+  /**
+   * The unique identifier for the field
+   */
   id: string;
+  /**
+   * The type of form field
+   */
   type: "text" | "number" | "select" | "textarea";
+  /**
+   * The display label for the field
+   */
   label: string;
+  /**
+   * The placeholder text for the field
+   */
   placeholder?: string;
+  /**
+   * The options for select fields
+   */
   options?: string[];
+  /**
+   * Whether the field is required
+   */
   required?: boolean;
+  /**
+   * The description text for the field
+   */
   description?: string;
 }
 
 export interface FormProps
   extends Omit<React.HTMLAttributes<HTMLFormElement>, "onSubmit" | "onError">,
     VariantProps<typeof formVariants> {
+  /**
+   * The fields for the form component
+   */
   fields: FormField[];
+  /**
+   * The function to call when the form is submitted
+   */
   onSubmit: (data: Record<string, string>) => void;
+  /**
+   * The error message to display if the form is submitted with errors
+   */
   onError?: string;
+  /**
+   * The text to display on the submit button
+   */
   submitText?: string;
 }
 
+/**
+ * Represents a simple form component that can be used to create and submit forms based on a list of fields.
+ *
+ * This allows for a generic form field that can be used to create a form field for any type of data.
+ *
+ * @param {FormProps} props - The props for the form component
+ * @param {string} props.className - The class name for the form component
+ * @param {string} props.variant - The variant for the form component
+ * @param {string} props.layout - The layout style for the form component, can be "default", "compact", or "relaxed"
+ * @param {FormField[]} props.fields - The fields for the form component
+ * @param {Function} props.onSubmit - The function to call when the form is submitted
+ * @param {string} props.onError - The error message to display if the form is submitted with errors
+ */
 const FormComponent = React.forwardRef<HTMLFormElement, FormProps>(
   (
     {

--- a/cli/src/registry/form/form.tsx
+++ b/cli/src/registry/form/form.tsx
@@ -72,8 +72,6 @@ export interface FormField {
 /**
  * Props for the Form component
  * @interface
- * @extends Omit<React.HTMLAttributes<HTMLFormElement>, "onSubmit" | "onError">
- * @extends VariantProps<typeof formVariants>
  */
 export interface FormProps
   extends Omit<React.HTMLAttributes<HTMLFormElement>, "onSubmit" | "onError">,

--- a/cli/src/registry/form/form.tsx
+++ b/cli/src/registry/form/form.tsx
@@ -69,39 +69,50 @@ export interface FormField {
   description?: string;
 }
 
+/**
+ * Props for the Form component
+ * @interface
+ * @extends Omit<React.HTMLAttributes<HTMLFormElement>, "onSubmit" | "onError">
+ * @extends VariantProps<typeof formVariants>
+ */
 export interface FormProps
   extends Omit<React.HTMLAttributes<HTMLFormElement>, "onSubmit" | "onError">,
     VariantProps<typeof formVariants> {
-  /**
-   * The fields for the form component
-   */
+  /** Array of form fields to display */
   fields: FormField[];
-  /**
-   * The function to call when the form is submitted
-   */
+  /** Callback function called when the form is submitted */
   onSubmit: (data: Record<string, string>) => void;
-  /**
-   * The error message to display if the form is submitted with errors
-   */
+  /** Optional error message to display */
   onError?: string;
-  /**
-   * The text to display on the submit button
-   */
+  /** Text to display on the submit button (default: "Submit") */
   submitText?: string;
 }
 
 /**
- * Represents a simple form component that can be used to create and submit forms based on a list of fields.
- *
- * This allows for a generic form field that can be used to create a form field for any type of data.
- *
- * @param {FormProps} props - The props for the form component
- * @param {string} props.className - The class name for the form component
- * @param {string} props.variant - The variant for the form component
- * @param {string} props.layout - The layout style for the form component, can be "default", "compact", or "relaxed"
- * @param {FormField[]} props.fields - The fields for the form component
- * @param {Function} props.onSubmit - The function to call when the form is submitted
- * @param {string} props.onError - The error message to display if the form is submitted with errors
+ * A flexible form component that supports various field types and layouts
+ * @component
+ * @example
+ * ```tsx
+ * <Form
+ *   fields={[
+ *     {
+ *       id: "name",
+ *       type: "text",
+ *       label: "Name",
+ *       required: true
+ *     },
+ *     {
+ *       id: "age",
+ *       type: "number",
+ *       label: "Age"
+ *     }
+ *   ]}
+ *   onSubmit={(data) => console.log(data)}
+ *   variant="solid"
+ *   layout="compact"
+ *   className="custom-styles"
+ * />
+ * ```
  */
 const FormComponent = React.forwardRef<HTMLFormElement, FormProps>(
   (

--- a/cli/src/registry/form/form.tsx
+++ b/cli/src/registry/form/form.tsx
@@ -112,7 +112,7 @@ export interface FormProps
  * />
  * ```
  */
-export const Form = React.forwardRef<HTMLFormElement, FormProps>(
+export const FormComponent = React.forwardRef<HTMLFormElement, FormProps>(
   (
     {
       className,
@@ -357,6 +357,6 @@ export const Form = React.forwardRef<HTMLFormElement, FormProps>(
   },
 );
 
-Form.displayName = "Form";
+FormComponent.displayName = "Form";
 
 export { formVariants };

--- a/cli/src/registry/form/form.tsx
+++ b/cli/src/registry/form/form.tsx
@@ -114,7 +114,7 @@ export interface FormProps
  * />
  * ```
  */
-const FormComponent = React.forwardRef<HTMLFormElement, FormProps>(
+export const Form = React.forwardRef<HTMLFormElement, FormProps>(
   (
     {
       className,
@@ -358,6 +358,7 @@ const FormComponent = React.forwardRef<HTMLFormElement, FormProps>(
     );
   },
 );
-FormComponent.displayName = "FormComponent";
 
-export { FormComponent, formVariants };
+Form.displayName = "Form";
+
+export { formVariants };

--- a/cli/src/registry/graph/graph.tsx
+++ b/cli/src/registry/graph/graph.tsx
@@ -46,11 +46,20 @@ export interface GraphData {
   }[];
 }
 
+/**
+ * Props for the Graph component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
+ * @extends VariantProps<typeof graphVariants>
+ */
 export interface GraphProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof graphVariants> {
+  /** Data object containing chart configuration and values */
   data: GraphData;
+  /** Optional title for the chart */
   title?: string;
+  /** Whether to show the legend (default: true) */
   showLegend?: boolean;
 }
 
@@ -61,7 +70,28 @@ const defaultColors = [
   "hsl(340, 82%, 66%)", // Pink
 ];
 
-const Graph = React.forwardRef<HTMLDivElement, GraphProps>(
+/**
+ * A component that renders various types of charts using Recharts
+ * @component
+ * @example
+ * ```tsx
+ * <Graph
+ *   data={{
+ *     type: "bar",
+ *     labels: ["Jan", "Feb", "Mar"],
+ *     datasets: [{
+ *       label: "Sales",
+ *       data: [100, 200, 300]
+ *     }]
+ *   }}
+ *   title="Monthly Sales"
+ *   variant="solid"
+ *   size="lg"
+ *   className="custom-styles"
+ * />
+ * ```
+ */
+export const Graph = React.forwardRef<HTMLDivElement, GraphProps>(
   (
     { className, variant, size, data, title, showLegend = true, ...props },
     ref,
@@ -272,5 +302,3 @@ const Graph = React.forwardRef<HTMLDivElement, GraphProps>(
   },
 );
 Graph.displayName = "Graph";
-
-export { Graph, graphVariants };

--- a/cli/src/registry/input-fields/input-fields.tsx
+++ b/cli/src/registry/input-fields/input-fields.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 const inputFieldsVariants = cva(
   "w-full rounded-lg transition-all duration-200",
@@ -46,7 +46,6 @@ const inputFieldsVariants = cva(
  * @property {string} [autoComplete] - Autocomplete attribute value
  * @property {string} [error] - Error message for the field
  */
-
 export interface Field {
   id: string;
   type: "text" | "number" | "email" | "password";
@@ -64,12 +63,41 @@ export interface Field {
   error?: string;
 }
 
+/**
+ * Props for the InputFields component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
+ * @extends VariantProps<typeof inputFieldsVariants>
+ */
 export interface InputFieldsProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof inputFieldsVariants> {
+  /** Array of field configurations to render */
   fields: Field[];
 }
 
+/**
+ * A component that renders a collection of form input fields with validation and accessibility features
+ * @component
+ * @example
+ * ```tsx
+ * <InputFields
+ *   fields={[
+ *     {
+ *       id: "email",
+ *       type: "email",
+ *       label: "Email",
+ *       value: email,
+ *       onChange: setEmail,
+ *       required: true
+ *     }
+ *   ]}
+ *   variant="solid"
+ *   size="lg"
+ *   className="custom-styles"
+ * />
+ * ```
+ */
 const InputFields = React.forwardRef<HTMLDivElement, InputFieldsProps>(
   ({ className, variant, size, fields, ...props }, ref) => {
     return (

--- a/cli/src/registry/input-fields/input-fields.tsx
+++ b/cli/src/registry/input-fields/input-fields.tsx
@@ -98,7 +98,7 @@ export interface InputFieldsProps
  * />
  * ```
  */
-const InputFields = React.forwardRef<HTMLDivElement, InputFieldsProps>(
+export const InputFields = React.forwardRef<HTMLDivElement, InputFieldsProps>(
   ({ className, variant, size, fields, ...props }, ref) => {
     return (
       <div
@@ -170,5 +170,3 @@ const InputFields = React.forwardRef<HTMLDivElement, InputFieldsProps>(
   },
 );
 InputFields.displayName = "InputFields";
-
-export { InputFields, inputFieldsVariants };

--- a/cli/src/registry/input-fields/input-fields.tsx
+++ b/cli/src/registry/input-fields/input-fields.tsx
@@ -66,8 +66,6 @@ export interface Field {
 /**
  * Props for the InputFields component
  * @interface
- * @extends React.HTMLAttributes<HTMLDivElement>
- * @extends VariantProps<typeof inputFieldsVariants>
  */
 export interface InputFieldsProps
   extends React.HTMLAttributes<HTMLDivElement>,

--- a/cli/src/registry/message-input/message-input.tsx
+++ b/cli/src/registry/message-input/message-input.tsx
@@ -31,7 +31,6 @@ const messageInputVariants = cva("w-full", {
 /**
  * Props for the MessageInput component
  * @interface
- * @extends React.HTMLAttributes<HTMLFormElement>
  */
 export interface MessageInputProps
   extends React.HTMLAttributes<HTMLFormElement> {

--- a/cli/src/registry/message-input/message-input.tsx
+++ b/cli/src/registry/message-input/message-input.tsx
@@ -29,19 +29,6 @@ const messageInputVariants = cva("w-full", {
 });
 
 /**
- * A form component for submitting messages to a Tambo thread with keyboard shortcuts and loading states
- * @component
- * @example
- * ```tsx
- * <MessageInput
- *   contextKey="my-thread"
- *   variant="solid"
- *   className="custom-styles"
- * />
- * ```
- */
-
-/**
  * Props for the MessageInput component
  * @interface
  * @extends React.HTMLAttributes<HTMLFormElement>
@@ -57,121 +44,134 @@ export interface MessageInputProps
   contextKey: string | undefined;
 }
 
-const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>(
-  ({ className, variant, contextKey, ...props }, ref) => {
-    const { value, setValue, submit, isPending, error } =
-      useTamboThreadInput(contextKey);
-    const [displayValue, setDisplayValue] = React.useState("");
-    const [submitError, setSubmitError] = React.useState<string | null>(null);
-    const isMac =
-      typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
-    const inputRef = React.useRef<HTMLInputElement>(null);
+/**
+ * A form component for submitting messages to a Tambo thread with keyboard shortcuts and loading states
+ * @component
+ * @example
+ * ```tsx
+ * <MessageInput
+ *   contextKey="my-thread"
+ *   variant="solid"
+ *   className="custom-styles"
+ * />
+ * ```
+ */
+export const MessageInput = React.forwardRef<
+  HTMLInputElement,
+  MessageInputProps
+>(({ className, variant, contextKey, ...props }, ref) => {
+  const { value, setValue, submit, isPending, error } =
+    useTamboThreadInput(contextKey);
+  const [displayValue, setDisplayValue] = React.useState("");
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+  const isMac =
+    typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
-    // Handle the forwarded ref
-    React.useImperativeHandle(ref, () => inputRef.current!, []);
+  // Handle the forwarded ref
+  React.useImperativeHandle(ref, () => inputRef.current!, []);
 
-    React.useEffect(() => {
+  React.useEffect(() => {
+    setDisplayValue(value);
+    // Focus the input when value changes and is not empty
+    if (value && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+    setDisplayValue(e.target.value);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!value.trim()) return;
+
+    setSubmitError(null);
+    setDisplayValue("");
+    try {
+      await submit({
+        contextKey,
+        streamResponse: true,
+      });
+      setValue("");
+    } catch (error) {
+      console.error("Failed to submit message:", error);
       setDisplayValue(value);
-      // Focus the input when value changes and is not empty
-      if (value && inputRef.current) {
-        inputRef.current.focus();
-      }
-    }, [value]);
+      setSubmitError(
+        error instanceof Error
+          ? error.message
+          : "Failed to send message. Please try again.",
+      );
+    }
+  };
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      setValue(e.target.value);
-      setDisplayValue(e.target.value);
-    };
-
-    const handleSubmit = async (e: React.FormEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
       e.preventDefault();
-      if (!value.trim()) return;
-
-      setSubmitError(null);
-      setDisplayValue("");
-      try {
-        await submit({
-          contextKey,
-          streamResponse: true,
-        });
-        setValue("");
-      } catch (error) {
-        console.error("Failed to submit message:", error);
-        setDisplayValue(value);
-        setSubmitError(
-          error instanceof Error
-            ? error.message
-            : "Failed to send message. Please try again.",
-        );
+      if (value.trim()) {
+        handleSubmit(e as unknown as React.FormEvent);
       }
-    };
+    }
+  };
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-        e.preventDefault();
-        if (value.trim()) {
-          handleSubmit(e as unknown as React.FormEvent);
-        }
-      }
-    };
+  const modKey = isMac ? "⌘" : "Ctrl";
 
-    const modKey = isMac ? "⌘" : "Ctrl";
+  const Spinner = () => (
+    <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
+  );
 
-    const Spinner = () => (
-      <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
-    );
-
-    return (
-      <form
-        onSubmit={handleSubmit}
-        className={cn(messageInputVariants({ variant }), className)}
-        {...props}
-      >
-        <div className="flex gap-2">
-          <input
-            ref={inputRef}
-            type="text"
-            value={displayValue}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            className="flex-1 p-2 rounded-lg border bg-background text-foreground border-border"
-            disabled={isPending}
-            placeholder="Type your message..."
-            aria-label="Chat Message Input"
-          />
-          <button
-            type="submit"
-            disabled={isPending}
-            className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 flex items-center justify-center min-w-[70px]"
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className={cn(messageInputVariants({ variant }), className)}
+      {...props}
+    >
+      <div className="flex gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={displayValue}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          className="flex-1 p-2 rounded-lg border bg-background text-foreground border-border"
+          disabled={isPending}
+          placeholder="Type your message..."
+          aria-label="Chat Message Input"
+        />
+        <button
+          type="submit"
+          disabled={isPending}
+          className="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 flex items-center justify-center min-w-[70px]"
+        >
+          {isPending ? <Spinner /> : "Send"}
+        </button>
+      </div>
+      <div className="flex flex-col items-center mt-2 text-xs">
+        <div className="flex items-center gap-1 text-muted-foreground">
+          <span>Press</span>
+          <kbd
+            className="px-1.5 py-0.5 rounded border border-border bg-muted font-mono text-xs"
+            suppressHydrationWarning
           >
-            {isPending ? <Spinner /> : "Send"}
-          </button>
+            {modKey}
+          </kbd>
+          <span>+</span>
+          <kbd className="px-1.5 py-0.5 rounded border border-border bg-muted font-mono text-xs">
+            Enter
+          </kbd>
+          <span>to send</span>
         </div>
-        <div className="flex flex-col items-center mt-2 text-xs">
-          <div className="flex items-center gap-1 text-muted-foreground">
-            <span>Press</span>
-            <kbd
-              className="px-1.5 py-0.5 rounded border border-border bg-muted font-mono text-xs"
-              suppressHydrationWarning
-            >
-              {modKey}
-            </kbd>
-            <span>+</span>
-            <kbd className="px-1.5 py-0.5 rounded border border-border bg-muted font-mono text-xs">
-              Enter
-            </kbd>
-            <span>to send</span>
-          </div>
-          {(error ?? submitError) && (
-            <p className="text-sm text-[hsl(var(--destructive))] mt-1">
-              {error?.message ?? submitError}
-            </p>
-          )}
-        </div>
-      </form>
-    );
-  },
-);
+        {(error ?? submitError) && (
+          <p className="text-sm text-[hsl(var(--destructive))] mt-1">
+            {error?.message ?? submitError}
+          </p>
+        )}
+      </div>
+    </form>
+  );
+});
 MessageInput.displayName = "MessageInput";
 
-export { MessageInput, messageInputVariants };
+export { messageInputVariants };

--- a/cli/src/registry/message-input/message-input.tsx
+++ b/cli/src/registry/message-input/message-input.tsx
@@ -5,6 +5,13 @@ import { useTamboThreadInput } from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
+/**
+ * CSS variants for the message input container
+ * @typedef {Object} MessageInputVariants
+ * @property {string} default - Default styling
+ * @property {string} solid - Solid styling with shadow effects
+ * @property {string} bordered - Bordered styling with border emphasis
+ */
 const messageInputVariants = cva("w-full", {
   variants: {
     variant: {
@@ -22,15 +29,31 @@ const messageInputVariants = cva("w-full", {
 });
 
 /**
- * A form component for submitting messages to a Tambo thread
- * @property {string} className - Optional className for custom styling
- * @property {VariantProps<typeof messageInputVariants>["variant"]} variant - Optional styling variant
- * @property {string | undefined} contextKey - Tambo thread context key for message routing
+ * A form component for submitting messages to a Tambo thread with keyboard shortcuts and loading states
+ * @component
+ * @example
+ * ```tsx
+ * <MessageInput
+ *   contextKey="my-thread"
+ *   variant="solid"
+ *   className="custom-styles"
+ * />
+ * ```
  */
 
+/**
+ * Props for the MessageInput component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLFormElement>
+ */
 export interface MessageInputProps
   extends React.HTMLAttributes<HTMLFormElement> {
+  /** Optional styling variant for the input container */
   variant?: VariantProps<typeof messageInputVariants>["variant"];
+  /**
+   * Tambo thread context key for message routing
+   * Used to identify which thread the message should be sent to
+   */
   contextKey: string | undefined;
 }
 

--- a/cli/src/registry/message-suggestions/message-suggestions.tsx
+++ b/cli/src/registry/message-suggestions/message-suggestions.tsx
@@ -14,16 +14,32 @@ import { useEffect, useRef } from "react";
  * @property {number} maxSuggestions - Maximum number of suggestions to show
  */
 
+/**
+ * Props for the MessageSuggestions component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
+ */
 export interface MessageSuggestionsProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  /** Maximum number of suggestions to display (default: 3) */
   maxSuggestions?: number;
 }
 
-export function MessageSuggestions({
-  className,
-  maxSuggestions = 3,
-  ...props
-}: MessageSuggestionsProps) {
+/**
+ * A component that displays AI-generated message suggestions with keyboard shortcuts
+ * @component
+ * @example
+ * ```tsx
+ * <MessageSuggestions
+ *   maxSuggestions={3}
+ *   className="custom-styles"
+ * />
+ * ```
+ */
+export const MessageSuggestions = React.forwardRef<
+  HTMLDivElement,
+  MessageSuggestionsProps
+>(({ className, maxSuggestions = 3, ...props }, ref) => {
   const { thread } = useTambo();
   const {
     suggestions,
@@ -103,6 +119,7 @@ export function MessageSuggestions({
     <TooltipProvider>
       <div
         className={cn("px-4 py-2 border-t border-gray-200", className)}
+        ref={ref}
         {...props}
       >
         {/* Error state */}
@@ -173,4 +190,4 @@ export function MessageSuggestions({
       </div>
     </TooltipProvider>
   );
-}
+});

--- a/cli/src/registry/message-thread-collapsible/message-thread-collapsible.tsx
+++ b/cli/src/registry/message-thread-collapsible/message-thread-collapsible.tsx
@@ -12,17 +12,31 @@ import * as React from "react";
 import { useEffect, useRef } from "react";
 
 /**
- * Represents a collapsible message thread component
- * @property {string} className - Optional className for custom styling
+ * Props for the MessageThreadCollapsible component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
  */
-
 export interface MessageThreadCollapsibleProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  /** Optional context key for the thread */
   contextKey?: string;
+  /** Whether the collapsible should be open by default (default: false) */
   defaultOpen?: boolean;
 }
 
-const MessageThreadCollapsible = React.forwardRef<
+/**
+ * A collapsible chat thread component with keyboard shortcuts and thread management
+ * @component
+ * @example
+ * ```tsx
+ * <MessageThreadCollapsible
+ *   contextKey="my-thread"
+ *   defaultOpen={false}
+ *   className="custom-styles"
+ * />
+ * ```
+ */
+export const MessageThreadCollapsible = React.forwardRef<
   HTMLDivElement,
   MessageThreadCollapsibleProps
 >(({ className, contextKey, defaultOpen = false, ...props }, ref) => {
@@ -140,5 +154,3 @@ const MessageThreadCollapsible = React.forwardRef<
   );
 });
 MessageThreadCollapsible.displayName = "MessageThreadCollapsible";
-
-export { MessageThreadCollapsible };

--- a/cli/src/registry/message-thread-full/message-thread-full.tsx
+++ b/cli/src/registry/message-thread-full/message-thread-full.tsx
@@ -10,16 +10,28 @@ import * as React from "react";
 import { useEffect, useRef } from "react";
 
 /**
- * Represents a full message thread component
- * @property {string} className - Optional className for custom styling
+ * Props for the MessageThreadFull component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
  */
-
 export interface MessageThreadFullProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  /** Optional context key for the thread */
   contextKey?: string;
 }
 
-const MessageThreadFull = React.forwardRef<
+/**
+ * A full-screen chat thread component with message history, input, and suggestions
+ * @component
+ * @example
+ * ```tsx
+ * <MessageThreadFull
+ *   contextKey="my-thread"
+ *   className="custom-styles"
+ * />
+ * ```
+ */
+export const MessageThreadFull = React.forwardRef<
   HTMLDivElement,
   MessageThreadFullProps
 >(({ className, contextKey, ...props }, ref) => {
@@ -70,5 +82,3 @@ const MessageThreadFull = React.forwardRef<
   );
 });
 MessageThreadFull.displayName = "MessageThreadFull";
-
-export { MessageThreadFull };

--- a/cli/src/registry/message-thread-panel/message-thread-panel.tsx
+++ b/cli/src/registry/message-thread-panel/message-thread-panel.tsx
@@ -12,7 +12,6 @@ import { useEffect, useRef } from "react";
 /**
  * Props for the MessageThreadPanel component
  * @interface
- * @extends React.HTMLAttributes<HTMLDivElement>
  */
 export interface MessageThreadPanelProps
   extends React.HTMLAttributes<HTMLDivElement> {

--- a/cli/src/registry/message-thread-panel/message-thread-panel.tsx
+++ b/cli/src/registry/message-thread-panel/message-thread-panel.tsx
@@ -1,24 +1,41 @@
 "use client";
 
-import * as React from "react";
-import { useEffect, useRef } from "react";
-import { cn } from "@/lib/utils";
-import { ThreadContent } from "@/components/ui/thread-content";
 import { MessageInput } from "@/components/ui/message-input";
 import { MessageSuggestions } from "@/components/ui/message-suggestions";
+import { ThreadContent } from "@/components/ui/thread-content";
 import { ThreadHistory } from "@/components/ui/thread-history";
+import { cn } from "@/lib/utils";
 import { useTambo } from "@tambo-ai/react";
+import * as React from "react";
+import { useEffect, useRef } from "react";
 
 /**
- * Represents a message thread panel component
- * @property {string} className - Optional className for custom styling
- * @property {string} contextKey - Optional context key for the Tambo thread
- * @property {React.ReactNode} children - Optional content to render in the left panel of the grid
+ * A resizable panel component that displays a chat thread with message history, input, and suggestions
+ * @component
+ * @example
+ * ```tsx
+ * <MessageThreadPanel
+ *   contextKey="my-thread"
+ *   className="custom-styles"
+ * >
+ *   <SidebarContent />
+ * </MessageThreadPanel>
+ * ```
  */
 
+/**
+ * Props for the MessageThreadPanel component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
+ */
 export interface MessageThreadPanelProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Optional key to identify the context of the thread
+   * Used to maintain separate thread histories for different contexts
+   */
   contextKey?: string;
+  /** Optional content to render in the left panel of the grid */
   children?: React.ReactNode;
 }
 

--- a/cli/src/registry/message-thread-panel/message-thread-panel.tsx
+++ b/cli/src/registry/message-thread-panel/message-thread-panel.tsx
@@ -10,20 +10,6 @@ import * as React from "react";
 import { useEffect, useRef } from "react";
 
 /**
- * A resizable panel component that displays a chat thread with message history, input, and suggestions
- * @component
- * @example
- * ```tsx
- * <MessageThreadPanel
- *   contextKey="my-thread"
- *   className="custom-styles"
- * >
- *   <SidebarContent />
- * </MessageThreadPanel>
- * ```
- */
-
-/**
  * Props for the MessageThreadPanel component
  * @interface
  * @extends React.HTMLAttributes<HTMLDivElement>
@@ -39,7 +25,20 @@ export interface MessageThreadPanelProps
   children?: React.ReactNode;
 }
 
-const MessageThreadPanel = React.forwardRef<
+/**
+ * A resizable panel component that displays a chat thread with message history, input, and suggestions
+ * @component
+ * @example
+ * ```tsx
+ * <MessageThreadPanel
+ *   contextKey="my-thread"
+ *   className="custom-styles"
+ * >
+ *   <SidebarContent />
+ * </MessageThreadPanel>
+ * ```
+ */
+export const MessageThreadPanel = React.forwardRef<
   HTMLDivElement,
   MessageThreadPanelProps
 >(({ className, contextKey, ...props }, ref) => {
@@ -120,5 +119,3 @@ const MessageThreadPanel = React.forwardRef<
   );
 });
 MessageThreadPanel.displayName = "MessageThreadPanel";
-
-export { MessageThreadPanel };

--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -1,18 +1,33 @@
 "use client";
 
-import * as React from "react";
-import ReactMarkdown from "react-markdown";
+import { createMarkdownComponents } from "@/components/ui/markdownComponents";
+import { cn } from "@/lib/utils";
 import type { TamboThreadMessage } from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "@/lib/utils";
-import { createMarkdownComponents } from "@/components/ui/markdownComponents";
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
 
 /**
- * Represents a message component
- * @property {string} className - Optional className for custom styling
- * @property {VariantProps<typeof messageVariants>["variant"]} variant - Optional variant for custom styling
+ * A component that renders a chat message with support for markdown content and custom styling
+ * @component
+ * @example
+ * ```tsx
+ * <Message
+ *   role="user"
+ *   content="Hello, how are you?"
+ *   message={threadMessage}
+ *   variant="solid"
+ * />
+ * ```
  */
 
+/**
+ * CSS variants for the message container
+ * @typedef {Object} MessageVariants
+ * @property {string} default - Default styling
+ * @property {string} solid - Solid styling with shadow effects
+ * @property {string} bordered - Bordered styling
+ */
 const messageVariants = cva("flex", {
   variants: {
     variant: {
@@ -36,10 +51,10 @@ const messageVariants = cva("flex", {
 });
 
 /**
- * Represents a bubble component
- * @property {string} role - Role of the bubble (user or assistant)
- * @property {string} className - Optional className for custom styling
- * @property {VariantProps<typeof bubbleVariants>["role"]} role - Role of the bubble (user or assistant)
+ * CSS variants for the message bubble
+ * @typedef {Object} BubbleVariants
+ * @property {string} user - Styling for user messages
+ * @property {string} assistant - Styling for assistant messages
  */
 const bubbleVariants = cva(
   "relative inline-block rounded-lg px-3 py-2 text-[15px] leading-relaxed transition-all duration-200 font-medium max-w-full [&_p]:my-1 [&_ul]:-my-5 [&_ol]:-my-5",
@@ -56,12 +71,33 @@ const bubbleVariants = cva(
   },
 );
 
+/**
+ * Props for the Message component
+ * @interface
+ */
 export interface MessageProps {
+  /** The role of the message sender - either 'user' or 'assistant' */
   role: "user" | "assistant";
+  /**
+   * The content of the message. Can be either a string or an array of content objects
+   * @example
+   * // String content
+   * "Hello, how are you?"
+   *
+   * // Array of content objects
+   * [
+   *   { type: "text", text: "Hello" },
+   *   { type: "text", text: "How are you?" }
+   * ]
+   */
   content: string | { type: string; text?: string }[];
+  /** The Tambo thread message object containing additional message data */
   message: TamboThreadMessage;
+  /** Optional styling variant for the message container */
   variant?: VariantProps<typeof messageVariants>["variant"];
+  /** Optional CSS class name for additional styling */
   className?: string;
+  /** Optional flag to indicate if the message is in a loading state */
   isLoading?: boolean;
 }
 

--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -8,20 +8,6 @@ import * as React from "react";
 import ReactMarkdown from "react-markdown";
 
 /**
- * A component that renders a chat message with support for markdown content and custom styling
- * @component
- * @example
- * ```tsx
- * <Message
- *   role="user"
- *   content="Hello, how are you?"
- *   message={threadMessage}
- *   variant="solid"
- * />
- * ```
- */
-
-/**
  * CSS variants for the message container
  * @typedef {Object} MessageVariants
  * @property {string} default - Default styling
@@ -101,7 +87,20 @@ export interface MessageProps {
   isLoading?: boolean;
 }
 
-const Message = React.forwardRef<HTMLDivElement, MessageProps>(
+/**
+ * A component that renders a chat message with support for markdown content and custom styling
+ * @component
+ * @example
+ * ```tsx
+ * <Message
+ *   role="user"
+ *   content="Hello, how are you?"
+ *   message={threadMessage}
+ *   variant="solid"
+ * />
+ * ```
+ */
+export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
   (
     { className, role, content, variant, message, isLoading, ...props },
     ref,
@@ -166,4 +165,4 @@ const Message = React.forwardRef<HTMLDivElement, MessageProps>(
 );
 Message.displayName = "Message";
 
-export { Message, messageVariants };
+export { messageVariants };

--- a/cli/src/registry/thread-content/thread-content.tsx
+++ b/cli/src/registry/thread-content/thread-content.tsx
@@ -44,64 +44,63 @@ export interface ThreadContentProps
  * />
  * ```
  */
-const ThreadContent = React.forwardRef<HTMLDivElement, ThreadContentProps>(
-  ({ className, variant, ...props }, ref) => {
-    const { thread, generationStage } = useTambo();
-    const messages = thread?.messages ?? [];
-    const isGenerating = generationStage === "STREAMING_RESPONSE";
+export const ThreadContent = React.forwardRef<
+  HTMLDivElement,
+  ThreadContentProps
+>(({ className, variant, ...props }, ref) => {
+  const { thread, generationStage } = useTambo();
+  const messages = thread?.messages ?? [];
+  const isGenerating = generationStage === "STREAMING_RESPONSE";
 
-    return (
-      <div
-        ref={ref}
-        className={cn(threadContentVariants({ variant }), className)}
-        {...props}
-      >
-        {messages.map((message, index) => {
-          const showLoading = isGenerating && index === messages.length - 1;
-          const messageContent = Array.isArray(message.content)
-            ? (message.content[0]?.text ?? "Empty message")
-            : typeof message.content === "string"
-              ? message.content
-              : "Empty message";
+  return (
+    <div
+      ref={ref}
+      className={cn(threadContentVariants({ variant }), className)}
+      {...props}
+    >
+      {messages.map((message, index) => {
+        const showLoading = isGenerating && index === messages.length - 1;
+        const messageContent = Array.isArray(message.content)
+          ? (message.content[0]?.text ?? "Empty message")
+          : typeof message.content === "string"
+            ? message.content
+            : "Empty message";
 
-          return (
+        return (
+          <div
+            key={
+              message.id ??
+              `${message.role}-${message.createdAt ?? Date.now()}-${message.content?.toString().substring(0, 10)}`
+            }
+            className={cn(
+              "animate-in fade-in-0 slide-in-from-bottom-2",
+              "duration-200 ease-in-out",
+            )}
+            style={{ animationDelay: `${index * 40}ms` }}
+          >
             <div
-              key={
-                message.id ??
-                `${message.role}-${message.createdAt ?? Date.now()}-${message.content?.toString().substring(0, 10)}`
-              }
               className={cn(
-                "animate-in fade-in-0 slide-in-from-bottom-2",
-                "duration-200 ease-in-out",
+                "flex flex-col gap-1.5",
+                message.role === "user" ? "ml-auto mr-0" : "ml-0 mr-auto",
+                "max-w-[85%]",
               )}
-              style={{ animationDelay: `${index * 40}ms` }}
             >
-              <div
-                className={cn(
-                  "flex flex-col gap-1.5",
-                  message.role === "user" ? "ml-auto mr-0" : "ml-0 mr-auto",
-                  "max-w-[85%]",
-                )}
-              >
-                <Message
-                  role={
-                    message.role === "hydra" || message.role === "assistant"
-                      ? "assistant"
-                      : "user"
-                  }
-                  content={messageContent}
-                  variant={variant}
-                  message={message}
-                  isLoading={showLoading}
-                />
-              </div>
+              <Message
+                role={
+                  message.role === "hydra" || message.role === "assistant"
+                    ? "assistant"
+                    : "user"
+                }
+                content={messageContent}
+                variant={variant}
+                message={message}
+                isLoading={showLoading}
+              />
             </div>
-          );
-        })}
-      </div>
-    );
-  },
-);
+          </div>
+        );
+      })}
+    </div>
+  );
+});
 ThreadContent.displayName = "ThreadContent";
-
-export { ThreadContent, threadContentVariants };

--- a/cli/src/registry/thread-content/thread-content.tsx
+++ b/cli/src/registry/thread-content/thread-content.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { cn } from "@/lib/utils";
-import * as React from "react";
 import { Message } from "@/components/ui/message";
+import { cn } from "@/lib/utils";
 import { useTambo } from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 const threadContentVariants = cva("flex flex-col gap-4", {
   variants: {
@@ -23,16 +23,27 @@ const threadContentVariants = cva("flex flex-col gap-4", {
 });
 
 /**
- * Represents a thread content component
- * @property {string} className - Optional className for custom styling
- * @property {VariantProps<typeof threadContentVariants>["variant"]} variant - Optional variant for custom styling
+ * Props for the ThreadContent component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
  */
-
 export interface ThreadContentProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  /** Optional styling variant for the thread content container */
   variant?: VariantProps<typeof threadContentVariants>["variant"];
 }
 
+/**
+ * A component that displays a chat thread's messages with animations and loading states
+ * @component
+ * @example
+ * ```tsx
+ * <ThreadContent
+ *   variant="solid"
+ *   className="custom-styles"
+ * />
+ * ```
+ */
 const ThreadContent = React.forwardRef<HTMLDivElement, ThreadContentProps>(
   ({ className, variant, ...props }, ref) => {
     const { thread, generationStage } = useTambo();

--- a/cli/src/registry/thread-history/thread-history.tsx
+++ b/cli/src/registry/thread-history/thread-history.tsx
@@ -8,23 +8,34 @@ import * as React from "react";
 import { useCallback } from "react";
 
 /**
- * Represents the history of threads
- * @property {string} className - Optional className for custom styling
- * @property {string} contextKey - The context key for the thread
- * @property {function} onThreadChange - The function to call when the thread changes
+ * Props for the ThreadHistory component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
  */
 export interface ThreadHistoryProps
   extends React.HTMLAttributes<HTMLDivElement> {
+  /** Optional context key for filtering threads */
   contextKey?: string;
+  /** Optional callback function called when the current thread changes */
   onThreadChange?: () => void;
 }
 
-export function ThreadHistory({
-  className,
-  contextKey,
-  onThreadChange,
-  ...props
-}: ThreadHistoryProps) {
+/**
+ * A component that displays a dropdown menu for managing chat threads with keyboard shortcuts
+ * @component
+ * @example
+ * ```tsx
+ * <ThreadHistory
+ *   contextKey="my-thread"
+ *   onThreadChange={() => console.log('Thread changed')}
+ *   className="custom-styles"
+ * />
+ * ```
+ */
+export const ThreadHistory = React.forwardRef<
+  HTMLDivElement,
+  ThreadHistoryProps
+>(({ className, contextKey, onThreadChange, ...props }, ref) => {
   const {
     data: threads,
     isLoading,
@@ -82,7 +93,7 @@ export function ThreadHistory({
   };
 
   return (
-    <div className={cn("relative", className)} {...props}>
+    <div className={cn("relative", className)} ref={ref} {...props}>
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
           <div
@@ -164,4 +175,4 @@ export function ThreadHistory({
       </DropdownMenu.Root>
     </div>
   );
-}
+});

--- a/cli/src/registry/thread-list/thread-list.tsx
+++ b/cli/src/registry/thread-list/thread-list.tsx
@@ -32,8 +32,6 @@ type Thread = Omit<TamboThread, "messages">;
 /**
  * Props for the ThreadList component
  * @interface
- * @extends React.HTMLAttributes<HTMLDivElement>
- * @extends VariantProps<typeof threadListVariants>
  */
 export interface ThreadListProps
   extends React.HTMLAttributes<HTMLDivElement>,

--- a/cli/src/registry/thread-list/thread-list.tsx
+++ b/cli/src/registry/thread-list/thread-list.tsx
@@ -63,7 +63,7 @@ export interface ThreadListProps
  * />
  * ```
  */
-const ThreadList = React.forwardRef<HTMLDivElement, ThreadListProps>(
+export const ThreadList = React.forwardRef<HTMLDivElement, ThreadListProps>(
   (
     {
       className,
@@ -125,4 +125,4 @@ const ThreadList = React.forwardRef<HTMLDivElement, ThreadListProps>(
 );
 ThreadList.displayName = "ThreadList";
 
-export { ThreadList, threadListVariants };
+export { threadListVariants };

--- a/cli/src/registry/thread-list/thread-list.tsx
+++ b/cli/src/registry/thread-list/thread-list.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import * as React from "react";
-import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 import type { TamboThread } from "@tambo-ai/react";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 const threadListVariants = cva("flex flex-col w-full", {
   variants: {
@@ -27,23 +27,42 @@ const threadListVariants = cva("flex flex-col w-full", {
   },
 });
 
-/**
- * Represents a thread list component
- * @property {string} className - Optional className for custom styling
- * @property {VariantProps<typeof threadListVariants>["variant"]} variant - Optional variant for custom styling
- */
-
 type Thread = Omit<TamboThread, "messages">;
 
+/**
+ * Props for the ThreadList component
+ * @interface
+ * @extends React.HTMLAttributes<HTMLDivElement>
+ * @extends VariantProps<typeof threadListVariants>
+ */
 export interface ThreadListProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof threadListVariants> {
+  /** Array of thread objects to display */
   threads: Thread[];
+  /** ID of the currently selected thread */
   selectedThreadId?: string | null;
+  /** Callback function called when a thread is selected */
   onThreadSelect?: (threadId: string) => void;
+  /** Whether the list is in a loading state */
   isLoading?: boolean;
 }
 
+/**
+ * A component that displays a list of chat threads with selection functionality
+ * @component
+ * @example
+ * ```tsx
+ * <ThreadList
+ *   threads={threads}
+ *   selectedThreadId="thread-123"
+ *   onThreadSelect={(id) => console.log('Selected thread:', id)}
+ *   variant="solid"
+ *   size="compact"
+ *   className="custom-styles"
+ * />
+ * ```
+ */
 const ThreadList = React.forwardRef<HTMLDivElement, ThreadListProps>(
   (
     {


### PR DESCRIPTION
including examples, etc

- **docs for form**
- **first cut at adding jsdocs, etc**
- **more cleanup**
- **no need for @extends**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved component usage examples and property descriptions across interactive elements such as chat, forms, graphs, and thread management.
  - Expanded guidance on component behaviors, default settings, and configuration options for a clearer user experience.
  - Enhanced documentation for interfaces and components, including new properties and clearer explanations.

- **Refactor**
  - Consolidated naming conventions and export strategies for better consistency and maintainability without altering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->