### PR TITLE
fix: only run npm install twice

### DIFF
--- a/cli/src/commands/add/index.ts
+++ b/cli/src/commands/add/index.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import inquirer from "inquirer";
 import path from "path";
 import { getInstallationPath } from "../init.js";
-import { installSingleComponent } from "./component.js";
+import { installComponents } from "./component.js";
 import { resolveComponentDependencies } from "./dependencies.js";
 import { setupTailwindandGlobals } from "./tailwind.js";
 import type { InstallComponentOptions } from "./types.js";
@@ -84,9 +84,7 @@ export async function handleAddComponent(
     }
 
     // 6. Install components in order (dependencies first)
-    for (const component of newComponents) {
-      await installSingleComponent(component, { ...options, installPath });
-    }
+    await installComponents(newComponents, { ...options, installPath });
 
     // 7. Setup Tailwind and globals.css after all components are installed
     await setupTailwindandGlobals(process.cwd());

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import fs from "fs";
 import inquirer from "inquirer";
 import path from "path";
-import { installSingleComponent } from "./add/component.js";
+import { installComponents } from "./add/component.js";
 import { componentExists } from "./add/utils.js";
 import { getInstallationPath } from "./init.js";
 
@@ -86,7 +86,7 @@ export async function handleUpdateComponent(
     }
 
     // Perform the update by reinstalling the component
-    await installSingleComponent(componentName, {
+    await installComponents([componentName], {
       ...options,
       forceUpdate: true,
       installPath: location.installPath,


### PR DESCRIPTION
Improves the full-send experience without a giant page of NPM installs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Now supports installing multiple components in a single operation for a more efficient workflow.
	- Enhanced dependency management that groups and installs required packages collectively.
	- Streamlined add and update processes for a more cohesive installation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->