### PR TITLE
feat(cli): add 'create-tambo-app' command to CLI for app creation from template

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -39,7 +39,7 @@ const cli = meow(
     ${chalk.yellow("add")}                 Add a new component
     ${chalk.yellow("update")}              Update an existing component from the registry
     ${chalk.yellow("full-send")}           Full initialization with auth flow and component installation
-    ${chalk.yellow("create-tambo-app")}    Create a new tambo app from a template
+    ${chalk.yellow("create-app")}          Create a new tambo app from a template
 
   ${chalk.bold("Options")}
     ${chalk.yellow("--legacy-peer-deps")}  Install dependencies with --legacy-peer-deps flag
@@ -52,8 +52,8 @@ const cli = meow(
     $ ${chalk.cyan("tambo")} ${chalk.yellow("update <componentName>")}
     $ ${chalk.cyan("tambo")} ${chalk.yellow("add <componentName> --legacy-peer-deps")}
     $ ${chalk.cyan("tambo")} ${chalk.yellow("update <componentName> --legacy-peer-deps")}
-    $ ${chalk.cyan("tambo")} ${chalk.yellow("create-tambo-app <app-name>")}
-    $ ${chalk.cyan("tambo")} ${chalk.yellow("create-tambo-app .")}
+    $ ${chalk.cyan("tambo")} ${chalk.yellow("create-app <app-name>")}
+    $ ${chalk.cyan("tambo")} ${chalk.yellow("create-app .")}
   `,
   {
     flags: {
@@ -146,12 +146,12 @@ async function handleCommand(cmd: string, flags: Result<CLIFlags>["flags"]) {
     return;
   }
 
-  if (cmd === "create-tambo-app") {
+  if (cmd === "create-app") {
     const appName = cli.input[1];
     if (!appName) {
       console.error(chalk.red("App name is required"));
       console.log(
-        `Run ${chalk.cyan("tambo create-tambo-app <app-name>")} to create a new app`,
+        `Run ${chalk.cyan("tambo create-app <app-name>")} to create a new app`,
       );
       return;
     }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -11,6 +11,7 @@ import { handleAddComponent } from "./commands/add/index.js";
 import { getComponentList } from "./commands/add/utils.js";
 import { handleInit } from "./commands/init.js";
 import { handleUpdateComponent } from "./commands/update.js";
+import { handleCreateApp } from "./commands/create-app.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -38,6 +39,7 @@ const cli = meow(
     ${chalk.yellow("add")}                 Add a new component
     ${chalk.yellow("update")}              Update an existing component from the registry
     ${chalk.yellow("full-send")}           Full initialization with auth flow and component installation
+    ${chalk.yellow("create-tambo-app")}    Create a new tambo app from a template
 
   ${chalk.bold("Options")}
     ${chalk.yellow("--legacy-peer-deps")}  Install dependencies with --legacy-peer-deps flag
@@ -50,6 +52,8 @@ const cli = meow(
     $ ${chalk.cyan("tambo")} ${chalk.yellow("update <componentName>")}
     $ ${chalk.cyan("tambo")} ${chalk.yellow("add <componentName> --legacy-peer-deps")}
     $ ${chalk.cyan("tambo")} ${chalk.yellow("update <componentName> --legacy-peer-deps")}
+    $ ${chalk.cyan("tambo")} ${chalk.yellow("create-tambo-app <app-name>")}
+    $ ${chalk.cyan("tambo")} ${chalk.yellow("create-tambo-app .")}
   `,
   {
     flags: {
@@ -137,6 +141,21 @@ async function handleCommand(cmd: string, flags: Result<CLIFlags>["flags"]) {
       return;
     }
     await handleUpdateComponent(componentName, {
+      legacyPeerDeps: Boolean(flags.legacyPeerDeps),
+    });
+    return;
+  }
+
+  if (cmd === "create-tambo-app") {
+    const appName = cli.input[1];
+    if (!appName) {
+      console.error(chalk.red("App name is required"));
+      console.log(
+        `Run ${chalk.cyan("tambo create-tambo-app <app-name>")} to create a new app`,
+      );
+      return;
+    }
+    await handleCreateApp(appName, {
       legacyPeerDeps: Boolean(flags.legacyPeerDeps),
     });
     return;

--- a/cli/src/commands/create-app.ts
+++ b/cli/src/commands/create-app.ts
@@ -1,0 +1,138 @@
+import chalk from "chalk";
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import ora from "ora";
+
+interface CreateAppOptions {
+  legacyPeerDeps?: boolean;
+}
+
+function safeRemoveGitFolder(gitFolder: string): void {
+  try {
+    if (process.platform === 'win32') {
+      // Windows: First remove read-only attributes, then remove directory
+      try {
+        execSync(`attrib -r "${gitFolder}\\*.*" /s`, { stdio: 'ignore' });
+      } catch (_e) {
+        console.error(chalk.red('Failed to remove read-only attributes'));
+      }
+      try {
+        execSync(`rmdir /s /q "${gitFolder}"`, { stdio: 'ignore' });
+      } catch (_e) {
+        fs.rmSync(gitFolder, { recursive: true, force: true });
+      }
+    } else {
+      // Unix-like systems (Mac, Linux)
+      try {
+        execSync(`rm -rf "${gitFolder}"`, { stdio: 'ignore' });
+      } catch (_e) {
+        fs.rmSync(gitFolder, { recursive: true, force: true });
+      }
+    }
+  } catch (_error) {
+    // If all removal attempts fail, warn but continue
+    console.warn(chalk.yellow('\nWarning: Could not completely remove .git folder. You may want to remove it manually.'));
+  }
+}
+
+export async function handleCreateApp(
+  appName: string,
+  options: CreateAppOptions = {}
+): Promise<void> {
+  // Validate app name
+  if (appName !== "." && !/^[a-zA-Z0-9-_]+$/.test(appName)) {
+    throw new Error("App name can only contain letters, numbers, dashes, and underscores");
+  }
+
+  const targetDir = appName === "." ? process.cwd() : path.join(process.cwd(), appName);
+  
+  console.log(chalk.blue(`\nCreating a new Tambo app in ${chalk.cyan(targetDir)}`));
+
+  try {
+    // Check if directory is empty when using "."
+    if (appName === "." && fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+      throw new Error("Current directory is not empty. Please use an empty directory or specify a new app name.");
+    }
+
+    // Create directory if it doesn't exist and appName is not "."
+    if (appName !== ".") {
+      if (fs.existsSync(targetDir)) {
+        throw new Error(`Directory "${appName}" already exists. Please choose a different name or use an empty directory.`);
+      }
+      fs.mkdirSync(targetDir, { recursive: true });
+    }
+
+    // Clone the template repository
+    const cloneSpinner = ora({
+      text: 'Downloading template...',
+      spinner: 'dots'
+    }).start();
+    
+    try {
+      execSync(
+        `git clone --depth 1 https://github.com/tambo-ai/tambo-template.git ${
+          appName === "." ? "." : appName
+        }`,
+        { stdio: 'ignore' }
+      );
+      cloneSpinner.succeed('Template downloaded successfully');
+    } catch (_error) {
+      cloneSpinner.fail('Failed to download template');
+      throw new Error(
+        "Failed to clone template repository. Please check your internet connection and try again."
+      );
+    }
+
+    // Remove .git folder to start fresh
+    const gitFolder = path.join(targetDir, ".git");
+    if (fs.existsSync(gitFolder)) {
+      safeRemoveGitFolder(gitFolder);
+    }
+
+    // Change to target directory
+    process.chdir(targetDir);
+
+    // Install dependencies with spinner
+    const installSpinner = ora({
+      text: 'Installing dependencies...',
+      spinner: 'dots'
+    }).start();
+    
+    try {
+      execSync(
+        `npm install${options.legacyPeerDeps ? " --legacy-peer-deps" : ""}`,
+        { stdio: 'ignore' }
+      );
+      installSpinner.succeed('Dependencies installed successfully');
+    } catch (_error) {
+      installSpinner.fail('Failed to install dependencies');
+      throw new Error(
+        "Failed to install dependencies. Please try running 'npm install' manually."
+      );
+    }
+
+    console.log(chalk.green("\nSuccessfully created a new Tambo app"));
+    console.log("\nNext steps:");
+    console.log(`  1. ${chalk.cyan(`cd ${appName === "." ? "." : appName}`)}`);
+    console.log(`  2. ${chalk.cyan("npm run dev")}`);
+    console.log(`  3. ${chalk.cyan("npx tambo init")} to complete setup`);
+    console.log(`  4. ${chalk.cyan("npx tambo add <component-name>")} to add components`);
+    console.log(`  5. ${chalk.cyan("npx tambo update <component-name>")} to update components`);
+
+  } catch (error) {
+    console.error(
+      chalk.red("\nError creating app:"),
+      error instanceof Error ? error.message : String(error)
+    );
+    // Clean up on failure if we created a new directory
+    if (appName !== "." && fs.existsSync(targetDir)) {
+      try {
+        fs.rmSync(targetDir, { recursive: true, force: true });
+      } catch (_e) {
+        console.error(chalk.yellow(`\nFailed to clean up directory "${targetDir}". You may want to remove it manually.`));
+      }
+    }
+    process.exit(1);
+  }
+} 

--- a/cli/src/commands/create-app.ts
+++ b/cli/src/commands/create-app.ts
@@ -10,77 +10,94 @@ interface CreateAppOptions {
 
 function safeRemoveGitFolder(gitFolder: string): void {
   try {
-    if (process.platform === 'win32') {
+    if (process.platform === "win32") {
       // Windows: First remove read-only attributes, then remove directory
       try {
-        execSync(`attrib -r "${gitFolder}\\*.*" /s`, { stdio: 'ignore' });
+        execSync(`attrib -r "${gitFolder}\\*.*" /s`, { stdio: "ignore" });
       } catch (_e) {
-        console.error(chalk.red('Failed to remove read-only attributes'));
+        console.error(chalk.red("Failed to remove read-only attributes"));
       }
       try {
-        execSync(`rmdir /s /q "${gitFolder}"`, { stdio: 'ignore' });
+        execSync(`rmdir /s /q "${gitFolder}"`, { stdio: "ignore" });
       } catch (_e) {
         fs.rmSync(gitFolder, { recursive: true, force: true });
       }
     } else {
       // Unix-like systems (Mac, Linux)
       try {
-        execSync(`rm -rf "${gitFolder}"`, { stdio: 'ignore' });
+        execSync(`rm -rf "${gitFolder}"`, { stdio: "ignore" });
       } catch (_e) {
         fs.rmSync(gitFolder, { recursive: true, force: true });
       }
     }
   } catch (_error) {
     // If all removal attempts fail, warn but continue
-    console.warn(chalk.yellow('\nWarning: Could not completely remove .git folder. You may want to remove it manually.'));
+    console.warn(
+      chalk.yellow(
+        "\nWarning: Could not completely remove .git folder. You may want to remove it manually.",
+      ),
+    );
   }
 }
 
 export async function handleCreateApp(
   appName: string,
-  options: CreateAppOptions = {}
+  options: CreateAppOptions = {},
 ): Promise<void> {
   // Validate app name
   if (appName !== "." && !/^[a-zA-Z0-9-_]+$/.test(appName)) {
-    throw new Error("App name can only contain letters, numbers, dashes, and underscores");
+    throw new Error(
+      "App name can only contain letters, numbers, dashes, and underscores",
+    );
   }
 
-  const targetDir = appName === "." ? process.cwd() : path.join(process.cwd(), appName);
-  
-  console.log(chalk.blue(`\nCreating a new Tambo app in ${chalk.cyan(targetDir)}`));
+  const targetDir =
+    appName === "." ? process.cwd() : path.join(process.cwd(), appName);
+
+  console.log(
+    chalk.blue(`\nCreating a new Tambo app in ${chalk.cyan(targetDir)}`),
+  );
 
   try {
     // Check if directory is empty when using "."
-    if (appName === "." && fs.existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
-      throw new Error("Current directory is not empty. Please use an empty directory or specify a new app name.");
+    if (
+      appName === "." &&
+      fs.existsSync(targetDir) &&
+      fs.readdirSync(targetDir).length > 0
+    ) {
+      throw new Error(
+        "Current directory is not empty. Please use an empty directory or specify a new app name.",
+      );
     }
 
     // Create directory if it doesn't exist and appName is not "."
     if (appName !== ".") {
       if (fs.existsSync(targetDir)) {
-        throw new Error(`Directory "${appName}" already exists. Please choose a different name or use an empty directory.`);
+        throw new Error(
+          `Directory "${appName}" already exists. Please choose a different name or use an empty directory.`,
+        );
       }
       fs.mkdirSync(targetDir, { recursive: true });
     }
 
     // Clone the template repository
     const cloneSpinner = ora({
-      text: 'Downloading template...',
-      spinner: 'dots'
+      text: "Downloading template...",
+      spinner: "dots",
     }).start();
-    
+
     try {
       execSync(
         `git clone --depth 1 https://github.com/tambo-ai/tambo-template.git ${
           appName === "." ? "." : appName
         }`,
-        { stdio: 'ignore' }
+        { stdio: "ignore" },
       );
-      cloneSpinner.succeed('Template downloaded successfully');
+      cloneSpinner.succeed("Template downloaded successfully");
     } catch (_error) {
-      cloneSpinner.fail('Failed to download template');
+      cloneSpinner.fail("Failed to download template");
       throw new Error(
-        "Failed to clone template repository. Please check your internet connection and try again."
+        "Failed to clone template repository. Please check your internet connection and try again.",
       );
     }
 
@@ -95,20 +112,20 @@ export async function handleCreateApp(
 
     // Install dependencies with spinner
     const installSpinner = ora({
-      text: 'Installing dependencies...',
-      spinner: 'dots'
+      text: "Installing dependencies...",
+      spinner: "dots",
     }).start();
-    
+
     try {
       execSync(
         `npm install${options.legacyPeerDeps ? " --legacy-peer-deps" : ""}`,
-        { stdio: 'ignore' }
+        { stdio: "ignore" },
       );
-      installSpinner.succeed('Dependencies installed successfully');
+      installSpinner.succeed("Dependencies installed successfully");
     } catch (_error) {
-      installSpinner.fail('Failed to install dependencies');
+      installSpinner.fail("Failed to install dependencies");
       throw new Error(
-        "Failed to install dependencies. Please try running 'npm install' manually."
+        "Failed to install dependencies. Please try running 'npm install' manually.",
       );
     }
 
@@ -117,22 +134,29 @@ export async function handleCreateApp(
     console.log(`  1. ${chalk.cyan(`cd ${appName === "." ? "." : appName}`)}`);
     console.log(`  2. ${chalk.cyan("npm run dev")}`);
     console.log(`  3. ${chalk.cyan("npx tambo init")} to complete setup`);
-    console.log(`  4. ${chalk.cyan("npx tambo add <component-name>")} to add components`);
-    console.log(`  5. ${chalk.cyan("npx tambo update <component-name>")} to update components`);
-
+    console.log(
+      `  4. ${chalk.cyan("npx tambo add <component-name>")} to add components`,
+    );
+    console.log(
+      `  5. ${chalk.cyan("npx tambo update <component-name>")} to update components`,
+    );
   } catch (error) {
     console.error(
       chalk.red("\nError creating app:"),
-      error instanceof Error ? error.message : String(error)
+      error instanceof Error ? error.message : String(error),
     );
     // Clean up on failure if we created a new directory
     if (appName !== "." && fs.existsSync(targetDir)) {
       try {
         fs.rmSync(targetDir, { recursive: true, force: true });
       } catch (_e) {
-        console.error(chalk.yellow(`\nFailed to clean up directory "${targetDir}". You may want to remove it manually.`));
+        console.error(
+          chalk.yellow(
+            `\nFailed to clean up directory "${targetDir}". You may want to remove it manually.`,
+          ),
+        );
       }
     }
     process.exit(1);
   }
-} 
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the `create-app` command to quickly generate a new application from a template, automating setup processes such as downloading the template and installing dependencies.

- **Documentation**
	- Updated CLI usage instructions and examples to clearly guide users and provide error notifications when required parameters (like the app name) are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->