### PR TITLE
fix: Don't throw error if TamboProvider used outside browser

### DIFF
--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -40,7 +40,7 @@ export const TamboProvider: React.FC<
 > = ({ children, tamboUrl, apiKey, components, environment }) => {
   // explode if we're not in a browser
   if (typeof window === "undefined") {
-    throw new Error("TamboProvider must be used within a browser");
+    console.error("TamboProvider must be used within a browser");
   }
 
   return (

--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -38,7 +38,7 @@ import {
 export const TamboProvider: React.FC<
   PropsWithChildren<TamboClientProviderProps & TamboRegistryProviderProps>
 > = ({ children, tamboUrl, apiKey, components, environment }) => {
-  // explode if we're not in a browser
+  // Should only be used in browser
   if (typeof window === "undefined") {
     console.error("TamboProvider must be used within a browser");
   }


### PR DESCRIPTION
Changes the error throw to an error log since in NextJS the provider is rendered once on server-side.