### PR TITLE
fix: Show toolcall message in thread

### DIFF
--- a/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
@@ -296,7 +296,7 @@ describe("TamboThreadProvider", () => {
       });
     });
 
-    expect(result.current.generationStage).toBe(GenerationStage.IDLE);
+    expect(result.current.generationStage).toBe(GenerationStage.COMPLETE);
   });
 
   it("should handle tool calls during message processing", async () => {

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -222,13 +222,15 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         }
         const prevMessages = prevMap[threadId]?.messages || [];
         const updatedMessages = [...prevMessages, chatMessage];
-        return {
+
+        const updatedThreadMap = {
           ...prevMap,
           [threadId]: {
             ...prevMap[threadId],
             messages: updatedMessages,
           },
         };
+        return updatedThreadMap;
       });
 
       if (sendToServer) {
@@ -320,19 +322,21 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         console.warn("Switching to placeholder thread, may be a bug.");
         return;
       }
-
       setCurrentThreadId(threadId);
-      if (!threadMap[threadId]) {
-        setThreadMap((prevMap) => {
-          return {
-            ...prevMap,
-            [threadId]: {
-              ...prevMap[PLACEHOLDER_THREAD.id],
-              id: threadId,
-            },
-          };
-        });
-      }
+      setThreadMap((prevMap) => {
+        if (prevMap[threadId]) {
+          return prevMap;
+        }
+        // If this is a new thread, add placeholder thread messages to the thread
+        const updatedThreadMap = {
+          ...prevMap,
+          [threadId]: {
+            ...prevMap[PLACEHOLDER_THREAD.id],
+            id: threadId,
+          },
+        };
+        return updatedThreadMap;
+      });
       if (fetch) {
         await fetchThread(threadId);
       }
@@ -407,7 +411,6 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
             toolCallResponseStream,
             toolCallResponseParams,
             threadId,
-            finalMessage?.id,
           );
         } else {
           if (

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -406,7 +406,6 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
             chunk.responseMessageDto.threadId,
           );
 
-          // Pass the current message's ID to be removed when the new stream starts, since we now know it is a tool call request message
           return await handleAdvanceStream(
             toolCallResponseStream,
             toolCallResponseParams,


### PR DESCRIPTION
Now that toolcall requests can include a displaymessage, this PR updates the response handling flow so that it isn't overwritten by the following message from tambo.