### PR TITLE
feat: send all defined tools, even if they are not associated with a component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5978,19 +5978,6 @@
       "resolved": "packages/typescript-config",
       "link": true
     },
-    "node_modules/@tambo-ai/typescript-sdk": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.43.0.tgz",
-      "integrity": "sha512-Q5PwXtb+IibYhcSMfc/44E70JQKBfbLCnN7k/7r0zxG20qg1mSfHJwPWr8IjzXUiuIldLtnvBcaAGYA7XNduDw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
     "node_modules/@tanstack/query-core": {
       "version": "5.74.4",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.4.tgz",
@@ -20419,7 +20406,7 @@
       "name": "@tambo-ai/react",
       "version": "0.20.4",
       "dependencies": {
-        "@tambo-ai/typescript-sdk": "^0.43.0",
+        "@tambo-ai/typescript-sdk": "^0.44.0",
         "@tanstack/react-query": "^5.74.4",
         "partial-json": "^0.1.7",
         "react-fast-compare": "^3.2.2",
@@ -20464,6 +20451,19 @@
         "@types/react-dom": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "react-sdk/node_modules/@tambo-ai/typescript-sdk": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.44.0.tgz",
+      "integrity": "sha512-Y0k1IPHvNlQY6Yyq69UHk9G/aZmxK/f8jNjDDy40gQhQGVPMqN2+o9OV0hTFquw/Fc0RCgWlskbKtrvMA/gFqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
       }
     },
     "showcase": {

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -62,7 +62,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@tambo-ai/typescript-sdk": "^0.43.0",
+    "@tambo-ai/typescript-sdk": "^0.44.0",
     "@tanstack/react-query": "^5.74.4",
     "partial-json": "^0.1.7",
     "react-fast-compare": "^3.2.2",

--- a/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
@@ -249,6 +249,7 @@ describe("TamboThreadProvider", () => {
       },
       availableComponents: serializeRegistry(mockRegistry),
       contextKey: undefined,
+      clientTools: [],
     });
     expect(result.current.generationStage).toBe(GenerationStage.COMPLETE);
   });

--- a/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
@@ -300,7 +300,7 @@ describe("TamboThreadProvider", () => {
     expect(result.current.generationStage).toBe(GenerationStage.COMPLETE);
   });
 
-  it("should handle tool calls during message processing", async () => {
+  it("should handle tool calls during message processing.", async () => {
     const mockToolCallResponse: TamboAI.Beta.Threads.ThreadAdvanceResponse = {
       responseMessageDto: {
         id: "tool-call-1",

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -19,6 +19,7 @@ import { renderComponentIntoMessage } from "../util/generate-component";
 import {
   getAvailableComponents,
   getClientContext,
+  getUnassociatedTools,
   mapTamboToolToContextTool,
 } from "../util/registry";
 import { handleToolCall } from "../util/tool-caller";
@@ -515,6 +516,10 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         toolRegistry,
         componentToolAssociations,
       );
+      const unassociatedTools = getUnassociatedTools(
+        toolRegistry,
+        componentToolAssociations,
+      );
       const params: TamboAI.Beta.Threads.ThreadAdvanceParams = {
         messageToAppend: {
           content: [{ type: "text", text: message }],
@@ -522,7 +527,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         },
         contextKey: options.contextKey,
         availableComponents: availableComponents,
-        clientTools: Object.values(toolRegistry).map((tool) =>
+        clientTools: unassociatedTools.map((tool) =>
           mapTamboToolToContextTool(tool),
         ),
       };

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -16,7 +16,11 @@ import {
 } from "../model/generate-component-response";
 import { TamboThread } from "../model/tambo-thread";
 import { renderComponentIntoMessage } from "../util/generate-component";
-import { getAvailableComponents, getClientContext } from "../util/registry";
+import {
+  getAvailableComponents,
+  getClientContext,
+  mapTamboToolToContextTool,
+} from "../util/registry";
 import { handleToolCall } from "../util/tool-caller";
 import { useTamboClient } from "./tambo-client-provider";
 import { useTamboRegistry } from "./tambo-registry-provider";
@@ -518,6 +522,9 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         },
         contextKey: options.contextKey,
         availableComponents: availableComponents,
+        clientTools: Object.values(toolRegistry).map((tool) =>
+          mapTamboToolToContextTool(tool),
+        ),
       };
 
       if (streamResponse) {

--- a/react-sdk/src/util/registry.ts
+++ b/react-sdk/src/util/registry.ts
@@ -48,6 +48,22 @@ export const getAvailableComponents = (
 };
 
 /**
+ * Get tools from tool registry that are not associated with any component
+ * @param toolRegistry - The tool registry
+ * @param toolAssociations - The tool associations
+ * @returns The tools that are not associated with any component
+ */
+export const getUnassociatedTools = (
+  toolRegistry: TamboToolRegistry,
+  toolAssociations: TamboToolAssociations,
+): TamboTool[] => {
+  return Object.values(toolRegistry).filter((tool) => {
+    // Check if the tool's name appears in any of the tool association arrays
+    return !Object.values(toolAssociations).flat().includes(tool.name);
+  });
+};
+
+/**
  * Helper function to convert component props from Zod schema to JSON Schema
  * @param component - The component to convert
  * @returns The converted props


### PR DESCRIPTION
Allows sending tools to tambo without associating them with components.

Enables client-side MCP usage

Currently still sends tools that are associated with a component within the component's definition, even though serverside the association is ignored and tools are all considered separately.