### PR TITLE
feat: Allow MCP urls passed into tambo provider

### DIFF
--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -32,11 +32,20 @@ import {
  * @param props.components - The components to register
  * @param props.environment - The environment to use for the Tambo API
  * @param props.tools - The tools to register
+ * @param props.mcpServers - MCP servers to fetch tools from
  * @returns The TamboProvider component
  */
 export const TamboProvider: React.FC<
   PropsWithChildren<TamboClientProviderProps & TamboRegistryProviderProps>
-> = ({ children, tamboUrl, apiKey, components, environment, tools }) => {
+> = ({
+  children,
+  tamboUrl,
+  apiKey,
+  components,
+  environment,
+  tools,
+  mcpServers,
+}) => {
   // Should only be used in browser
   if (typeof window === "undefined") {
     console.error("TamboProvider must be used within a browser");
@@ -48,7 +57,11 @@ export const TamboProvider: React.FC<
       apiKey={apiKey}
       environment={environment}
     >
-      <TamboRegistryProvider components={components} tools={tools}>
+      <TamboRegistryProvider
+        components={components}
+        tools={tools}
+        mcpServers={mcpServers}
+      >
         <TamboThreadProvider>
           <TamboComponentProvider>
             <TamboCompositeProvider>{children}</TamboCompositeProvider>

--- a/react-sdk/src/providers/tambo-registry-provider.tsx
+++ b/react-sdk/src/providers/tambo-registry-provider.tsx
@@ -290,7 +290,7 @@ function isZodSchema(obj: unknown): obj is ZodSchema {
 }
 
 /**
- * Fetches tools from MCP servers
+ * Fetches tools from each MCP server and maps them to Tambo tools
  * @param mcpServers - The MCP servers to fetch tools from.
  * @returns The tools fetched from the MCP servers mapped to Tambo tools
  */
@@ -299,10 +299,9 @@ async function fetchToolsFromMCPServers(
 ): Promise<TamboTool[]> {
   const tools = await Promise.all(
     mcpServers.map(async (mcpServer) => {
-      const mcpTools = await fetch(`${mcpServer}/tools`).then(async (res) =>
-        await res.json(),
-      );
-      return mapMcpToolsToTamboTools(mcpTools, mcpServer);
+      const mcpToolsResponse = await fetch(mcpServer);
+      const mcpToolsJson = await mcpToolsResponse.json();
+      return mapMcpToolsToTamboTools(mcpToolsJson.tools, mcpServer);
     }),
   );
   return tools.flat();

--- a/react-sdk/src/providers/tambo-registry-provider.tsx
+++ b/react-sdk/src/providers/tambo-registry-provider.tsx
@@ -314,7 +314,7 @@ async function fetchToolsFromMCPServers(
  * @returns The Tambo tools
  */
 function mapMcpToolsToTamboTools(
-  mcpTools: any[],
+  mcpTools: MCPTool[],
   mcpServerUrl: string,
 ): TamboTool[] {
   return mcpTools.map((tool: MCPTool) => ({


### PR DESCRIPTION
A list of mcp urls can be passed into the TamboProvider, and a request will be made to each to fetch tool definitions, which are then registered with Tambo.

When Tambo wants to use one of the tools, it makes a post request to the same route with the tool name and args.