### PR TITLE
feat: add forceToolChoice param

### DIFF
--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.2",
-    "@tambo-ai/typescript-sdk": "^0.47.0",
+    "@tambo-ai/typescript-sdk": "^0.48.0",
     "@tanstack/react-query": "^5.75.2",
     "partial-json": "^0.1.7",
     "react-fast-compare": "^3.2.2",

--- a/react-sdk/src/hooks/use-thread-input.ts
+++ b/react-sdk/src/hooks/use-thread-input.ts
@@ -42,13 +42,14 @@ interface UseThreadInputInternal {
   submit: (options?: {
     contextKey?: string;
     streamResponse?: boolean;
+    forceToolChoice?: string;
   }) => Promise<void>;
 }
 export type UseThreadInput = UseThreadInputInternal &
   UseMutationResult<
     void,
     Error,
-    { contextKey?: string; streamResponse?: boolean }
+    { contextKey?: string; streamResponse?: boolean; forceToolChoice?: string }
   >;
 
 /**
@@ -63,7 +64,12 @@ export function useTamboThreadInput(contextKey?: string): UseThreadInput {
     async ({
       contextKey: submitContextKey,
       streamResponse,
-    }: { contextKey?: string; streamResponse?: boolean } = {}) => {
+      forceToolChoice,
+    }: {
+      contextKey?: string;
+      streamResponse?: boolean;
+      forceToolChoice?: string;
+    } = {}) => {
       const validation = validateInput(inputValue);
       if (!validation.isValid) {
         throw new ThreadInputError(
@@ -76,6 +82,7 @@ export function useTamboThreadInput(contextKey?: string): UseThreadInput {
         threadId: thread.id,
         contextKey: submitContextKey ?? contextKey ?? undefined,
         streamResponse: streamResponse,
+        forceToolChoice: forceToolChoice,
       });
       setInputValue("");
     },

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -55,6 +55,7 @@ export interface TamboThreadContextProps {
       threadId?: string;
       streamResponse?: boolean;
       contextKey?: string;
+      forceToolChoice?: string;
     },
   ) => Promise<TamboThreadMessage>;
   /** The generation stage of the current thread - updated as the thread progresses */
@@ -485,9 +486,14 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         threadId?: string;
         streamResponse?: boolean;
         contextKey?: string;
+        forceToolChoice?: string;
       } = { threadId: PLACEHOLDER_THREAD.id },
     ): Promise<TamboThreadMessage> => {
-      const { threadId = currentThread.id, streamResponse } = options;
+      const {
+        threadId = currentThread.id,
+        streamResponse,
+        forceToolChoice,
+      } = options;
       updateThreadStatus(threadId, GenerationStage.CHOOSING_COMPONENT);
 
       addThreadMessage(
@@ -512,7 +518,9 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         toolRegistry,
         componentToolAssociations,
       );
-      const params: TamboAI.Beta.Threads.ThreadAdvanceParams = {
+      const params: TamboAI.Beta.Threads.ThreadAdvanceParams & {
+        forceToolChoice?: string;
+      } = {
         messageToAppend: {
           content: [{ type: "text", text: message }],
           role: "user",
@@ -522,6 +530,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         clientTools: unassociatedTools.map((tool) =>
           mapTamboToolToContextTool(tool),
         ),
+        forceToolChoice: forceToolChoice,
       };
 
       if (streamResponse) {

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -518,9 +518,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         toolRegistry,
         componentToolAssociations,
       );
-      const params: TamboAI.Beta.Threads.ThreadAdvanceParams & {
-        forceToolChoice?: string;
-      } = {
+      const params: TamboAI.Beta.Threads.ThreadAdvanceParams = {
         messageToAppend: {
           content: [{ type: "text", text: message }],
           role: "user",


### PR DESCRIPTION
Updates `submit` and `sendThreadMessage` to take a 'forceToolChoice` param where a tool name can be passed as a way to force it to be called before normal processing.

This is a way to tell tambo "Before processing the user message, call this tool to get extra information"