### PR TITLE
feat: handle toolcall failures

### DIFF
--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { createMarkdownComponents } from "@/components/ui/markdownComponents";
+import { checkHasContent, getSafeContent } from "@/lib/thread-hooks";
 import { cn } from "@/lib/utils";
 import type { TamboThreadMessage } from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ExternalLink, Check, Loader2 } from "lucide-react";
+import { Check, ExternalLink, Loader2, X } from "lucide-react";
 import * as React from "react";
 import ReactMarkdown from "react-markdown";
-import { getSafeContent, checkHasContent } from "@/lib/thread-hooks";
 
 /**
  * CSS variants for the message container
@@ -213,6 +213,7 @@ const MessageContent = React.forwardRef<HTMLDivElement, MessageContentProps>(
 
     const showLoading = isLoading && !hasContent;
     const toolStatusMessage = getToolStatusMessage(message, isLoading);
+    const hasToolError = message.actionType === "tool_call" && message.error;
 
     return (
       <div
@@ -253,7 +254,9 @@ const MessageContent = React.forwardRef<HTMLDivElement, MessageContentProps>(
         )}
         {toolStatusMessage && (
           <div className="flex items-center gap-2 text-xs opacity-50 mt-2">
-            {isLoading ? (
+            {hasToolError ? (
+              <X className="w-3 h-3 text-bold text-red-500" />
+            ) : isLoading ? (
               <Loader2 className="w-3 h-3 text-muted-foreground text-bold animate-spin" />
             ) : (
               <Check className="w-3 h-3 text-bold text-green-500" />
@@ -350,9 +353,9 @@ MessageRenderedComponentArea.displayName = "Message.RenderedComponentArea";
 
 // --- Exports ---
 export {
-  messageVariants,
+  LoadingIndicator,
   Message,
   MessageContent,
   MessageRenderedComponentArea,
-  LoadingIndicator,
+  messageVariants,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     },
     "cli": {
       "name": "tambo",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@tambo-ai/react": "*",
         "chalk": "^5.3.0",
@@ -65,7 +65,7 @@
       }
     },
     "create-tambo-app": {
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "create-tambo-app": "dist/index.js"
       },
@@ -6102,9 +6102,9 @@
       "link": true
     },
     "node_modules/@tambo-ai/typescript-sdk": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.47.0.tgz",
-      "integrity": "sha512-CzO43TMlTSyWg2fKhmWMOUulJatWsq//flfTyN8cw2DJRNAy32fqgsAP6yGaHgJyNsGO3Oe9dJrm46L12KllKw==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.49.0.tgz",
+      "integrity": "sha512-53stX6cYQIZRdwnMHuyJ2893QeYyX8UIRlXbCudy47UA8EfLBsiqTe65Rj2FFHEN9sBPZUQ19P9BMfKBs+GC6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -21170,10 +21170,10 @@
     },
     "react-sdk": {
       "name": "@tambo-ai/react",
-      "version": "0.23.1",
+      "version": "0.24.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.2",
-        "@tambo-ai/typescript-sdk": "^0.47.0",
+        "@tambo-ai/typescript-sdk": "^0.49.0",
         "@tanstack/react-query": "^5.75.2",
         "partial-json": "^0.1.7",
         "react-fast-compare": "^3.2.2",
@@ -21222,7 +21222,7 @@
     },
     "showcase": {
       "name": "@tambo-ai/showcase",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-slot": "^1.2.2",

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.2",
-    "@tambo-ai/typescript-sdk": "^0.48.0",
+    "@tambo-ai/typescript-sdk": "^0.49.0",
     "@tanstack/react-query": "^5.75.2",
     "partial-json": "^0.1.7",
     "react-fast-compare": "^3.2.2",

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -384,9 +384,9 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
             toolRegistry,
           );
           const toolCallResponseString =
-            typeof toolCallResponse === "string"
-              ? toolCallResponse
-              : JSON.stringify(toolCallResponse);
+            typeof toolCallResponse.result === "string"
+              ? toolCallResponse.result
+              : JSON.stringify(toolCallResponse.result);
           const toolCallResponseParams: TamboAI.Beta.Threads.ThreadAdvanceParams =
             {
               ...params,
@@ -396,6 +396,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
                 actionType: "tool_response",
                 component: chunk.responseMessageDto.component,
                 tool_call_id: chunk.responseMessageDto.tool_call_id,
+                error: toolCallResponse.error,
               },
             };
           updateThreadStatus(
@@ -555,9 +556,9 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           toolRegistry,
         );
         const toolResponseString =
-          typeof toolCallResponse === "string"
-            ? toolCallResponse
-            : JSON.stringify(toolCallResponse);
+          typeof toolCallResponse.result === "string"
+            ? toolCallResponse.result
+            : JSON.stringify(toolCallResponse.result);
         const toolCallResponseParams: TamboAI.Beta.Threads.ThreadAdvanceParams =
           {
             ...params,
@@ -568,6 +569,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
               actionType: "tool_response",
               component: advanceResponse.responseMessageDto.component,
               tool_call_id: advanceResponse.responseMessageDto.tool_call_id,
+              error: toolCallResponse.error,
             },
           };
         updateThreadStatus(threadId, GenerationStage.HYDRATING_COMPONENT);

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -402,8 +402,10 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
 
           if (toolCallResponse.error) {
             //update toolcall message with error
-            const toolCallMessage = chunk.responseMessageDto;
-            toolCallMessage.error = toolCallResponse.error;
+            const toolCallMessage = {
+              ...chunk.responseMessageDto,
+              error: toolCallResponse.error,
+            };
             updateThreadMessage(
               chunk.responseMessageDto.id,
               toolCallMessage,
@@ -585,8 +587,10 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           };
         if (toolCallResponse.error) {
           //update toolcall message with error
-          const toolCallMessage = advanceResponse.responseMessageDto;
-          toolCallMessage.error = toolCallResponse.error;
+          const toolCallMessage = {
+            ...advanceResponse.responseMessageDto,
+            error: toolCallResponse.error,
+          };
           updateThreadMessage(toolCallMessage.id, toolCallMessage, false);
         }
         updateThreadStatus(threadId, GenerationStage.HYDRATING_COMPONENT);

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -399,6 +399,17 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
                 error: toolCallResponse.error,
               },
             };
+
+          if (toolCallResponse.error) {
+            //update toolcall message with error
+            const toolCallMessage = chunk.responseMessageDto;
+            toolCallMessage.error = toolCallResponse.error;
+            updateThreadMessage(
+              chunk.responseMessageDto.id,
+              toolCallMessage,
+              false,
+            );
+          }
           updateThreadStatus(
             chunk.responseMessageDto.threadId,
             GenerationStage.STREAMING_RESPONSE,
@@ -572,6 +583,12 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
               error: toolCallResponse.error,
             },
           };
+        if (toolCallResponse.error) {
+          //update toolcall message with error
+          const toolCallMessage = advanceResponse.responseMessageDto;
+          toolCallMessage.error = toolCallResponse.error;
+          updateThreadMessage(toolCallMessage.id, toolCallMessage, false);
+        }
         updateThreadStatus(threadId, GenerationStage.HYDRATING_COMPONENT);
         advanceResponse = await client.beta.threads.advanceById(
           advanceResponse.responseMessageDto.threadId,

--- a/react-sdk/src/util/tool-caller.ts
+++ b/react-sdk/src/util/tool-caller.ts
@@ -12,19 +12,27 @@ import { mapTamboToolToContextTool } from "./registry";
  * @returns The result of the tool call
  */
 export const handleToolCall = async (
-  message: TamboAI.Beta.ThreadMessage,
+  message: TamboAI.Beta.Threads.ThreadMessage,
   toolRegistry: TamboToolRegistry,
-) => {
+): Promise<{
+  result: string;
+  error?: string;
+}> => {
   if (!message?.toolCallRequest?.toolName) {
     throw new Error("Tool name is required");
   }
 
   try {
     const tool = findTool(message.toolCallRequest.toolName, toolRegistry);
-    return await runToolChoice(message.toolCallRequest, tool);
+    return {
+      result: await runToolChoice(message.toolCallRequest, tool),
+    };
   } catch (error) {
     console.error("Error in calling tool: ", error);
-    return `When attempting to call tool ${message.toolCallRequest.toolName} the following error occurred: ${error}. Explain to the user that the tool call failed and try again if needed.`;
+    return {
+      result: `When attempting to call tool ${message.toolCallRequest.toolName} the following error occurred: ${error}. Explain to the user that the tool call failed and try again if needed.`,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
   }
 };
 

--- a/react-sdk/src/util/tool-caller.ts
+++ b/react-sdk/src/util/tool-caller.ts
@@ -19,10 +19,13 @@ export const handleToolCall = async (
     throw new Error("Tool name is required");
   }
 
-  const tool = findTool(message.toolCallRequest.toolName, toolRegistry);
-  const toolResult = await runToolChoice(message.toolCallRequest, tool);
-
-  return toolResult;
+  try {
+    const tool = findTool(message.toolCallRequest.toolName, toolRegistry);
+    return await runToolChoice(message.toolCallRequest, tool);
+  } catch (error) {
+    console.error("Error in calling tool: ", error);
+    return `When attempting to call tool ${message.toolCallRequest.toolName} the following error occurred: ${error}. Explain to the user that the tool call failed and try again if needed.`;
+  }
 };
 
 const findTool = (toolName: string, toolRegistry: TamboToolRegistry) => {


### PR DESCRIPTION
Updates react sdk to catch toolcall failures and send a description of the error back to tambo as the tool response, while also attaching the error to the message so we can handle displaying the failure.

Updates the Message registry component to show x if a toolcall fails instead of the checkmark