### PR TITLE
fix: update local thread with toolcallrequest messages

### DIFF
--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -402,21 +402,13 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
 
           updateThreadMessage(
             chunk.responseMessageDto.id,
-            chunk.responseMessageDto,
-            false,
-          );
-          if (toolCallResponse.error) {
-            //update toolcall message with error
-            const toolCallMessage = {
+            {
               ...chunk.responseMessageDto,
               error: toolCallResponse.error,
-            };
-            updateThreadMessage(
-              chunk.responseMessageDto.id,
-              toolCallMessage,
-              false,
-            );
-          }
+            },
+            false,
+          );
+
           updateThreadStatus(
             chunk.responseMessageDto.threadId,
             GenerationStage.STREAMING_RESPONSE,

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -400,6 +400,11 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
               },
             };
 
+          updateThreadMessage(
+            chunk.responseMessageDto.id,
+            chunk.responseMessageDto,
+            false,
+          );
           if (toolCallResponse.error) {
             //update toolcall message with error
             const toolCallMessage = {


### PR DESCRIPTION
Previously we were not updating the local thread with toolcallrequest messages, so we sometimes didn't see the 'toolcall processing' UI when a tool was running. Sometimes the actionType field, which we determine whether to show the tool ui based on, was returned before the toolcallrequest, so it would still make it through.

Changes to update the local thread message on each received chunk, even for toolcallrequest messages.