### PR TITLE
Add streaming JSON props hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     },
     "cli": {
       "name": "tambo",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@tambo-ai/react": "*",
         "chalk": "^5.3.0",
@@ -66,7 +66,7 @@
       }
     },
     "create-tambo-app": {
-      "version": "0.1.1",
+      "version": "0.1.4",
       "bin": {
         "create-tambo-app": "dist/index.js"
       },

--- a/react-sdk/src/hooks/__tests__/use-streaming-json-props.test.tsx
+++ b/react-sdk/src/hooks/__tests__/use-streaming-json-props.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { useStreamingProps } from "../use-streaming-json-props";
+
+describe("useStreamingProps", () => {
+  it("handles all keys streamed then done", () => {
+    const { result } = renderHook(() =>
+      useStreamingProps<{ name: string; email: string }>(["name", "email"]),
+    );
+
+    act(() => {
+      result.current.handleChunk({ key: "name", value: "Alice" });
+      result.current.handleChunk({ key: "email", value: "alice@example.com" });
+      result.current.handleDone();
+    });
+
+    expect(result.current.props).toEqual({
+      name: "Alice",
+      email: "alice@example.com",
+    });
+    expect(result.current.meta.name.state).toBe("complete");
+    expect(result.current.meta.email.state).toBe("complete");
+    expect(result.current.isStreamDone).toBe(true);
+  });
+
+  it("marks missing keys as skipped on done", () => {
+    const { result } = renderHook(() =>
+      useStreamingProps<{
+        firstName: string;
+        lastName: string;
+        age: string;
+      }>(["firstName", "lastName", "age"]),
+    );
+
+    act(() => {
+      result.current.handleChunk({ key: "firstName", value: "John" });
+      result.current.handleDone();
+    });
+
+    expect(result.current.props).toEqual({ firstName: "John" });
+    expect(result.current.meta.firstName.state).toBe("complete");
+    expect(result.current.meta.lastName.state).toBe("skipped");
+    expect(result.current.meta.age.state).toBe("skipped");
+  });
+
+  it("leaves streaming state without done", () => {
+    const { result } = renderHook(() =>
+      useStreamingProps<{ summary: string }>(["summary"]),
+    );
+
+    act(() => {
+      result.current.handleChunk({ key: "summary", value: "Hello" });
+    });
+
+    expect(result.current.meta.summary.state).toBe("streaming");
+    expect(result.current.isStreamDone).toBe(false);
+  });
+
+  it("ignores unknown keys", () => {
+    const { result } = renderHook(() =>
+      useStreamingProps<{ foo: string }>(["foo"]),
+    );
+
+    act(() => {
+      result.current.handleChunk({ key: "bar", value: "baz" });
+      result.current.handleDone();
+    });
+
+    expect(result.current.props).toEqual({});
+    expect(result.current.meta.foo.state).toBe("skipped");
+  });
+});

--- a/react-sdk/src/hooks/index.ts
+++ b/react-sdk/src/hooks/index.ts
@@ -6,6 +6,7 @@ export {
   useTamboMessageContext,
 } from "./use-current-message";
 export { useTamboStreamingProps } from "./use-streaming-props";
+export { useStreamingProps } from "./use-streaming-json-props";
 export * from "./use-suggestions";
 export { useTamboThreadList } from "./use-tambo-threads";
 export { useTamboThreadInput } from "./use-thread-input";

--- a/react-sdk/src/hooks/use-streaming-json-props.ts
+++ b/react-sdk/src/hooks/use-streaming-json-props.ts
@@ -1,0 +1,124 @@
+import { useCallback, useRef, useState } from "react";
+
+export type KeyState = "notStarted" | "streaming" | "complete" | "skipped";
+
+export interface KeyMeta {
+  state: KeyState;
+  streamStartedAt?: number;
+  streamCompletedAt?: number;
+}
+
+export interface StreamChunk {
+  key: string;
+  value: string;
+}
+
+export interface UseStreamingPropsResult<T extends Record<string, any>> {
+  props: Partial<T>;
+  meta: Record<keyof T | string, KeyMeta>;
+  isStreamDone: boolean;
+  handleChunk: (chunk: StreamChunk) => void;
+  handleDone: () => void;
+}
+
+/**
+ * Hook to track a JSON streaming response on a per-key basis.
+ * @param expectedKeys - list of keys expected in the final props object
+ * @returns current props, metadata for each key, and helper functions
+ */
+export function useStreamingProps<T extends Record<string, any>>(
+  expectedKeys: (keyof T | string)[],
+): UseStreamingPropsResult<T> {
+  const [props, setProps] = useState<Partial<T>>({});
+  const [meta, setMeta] = useState<Record<string, KeyMeta>>(() => {
+    const initial: Record<string, KeyMeta> = {};
+    for (const key of expectedKeys) {
+      initial[String(key)] = { state: "notStarted" };
+    }
+    return initial;
+  });
+  const [isStreamDone, setIsStreamDone] = useState(false);
+
+  const currentKeyRef = useRef<string | null>(null);
+
+  const handleChunk = useCallback(
+    ({ key, value }: StreamChunk) => {
+      if (!expectedKeys.includes(key)) {
+        // Ignore unknown keys
+        return;
+      }
+
+      setProps((prev) => ({
+        ...prev,
+        [key]: ((prev as Record<string, string>)[key] || "") + value,
+      }));
+
+      setMeta((prev) => {
+        const now = Date.now();
+        const updated = { ...prev };
+        const prevCurrent = currentKeyRef.current;
+
+        if (prevCurrent && prevCurrent !== key) {
+          const prevMeta = updated[prevCurrent];
+          if (prevMeta && prevMeta.state === "streaming") {
+            updated[prevCurrent] = {
+              ...prevMeta,
+              state: "complete",
+              streamCompletedAt: now,
+            };
+          }
+        }
+
+        const thisMeta = updated[key];
+        if (thisMeta.state === "notStarted") {
+          updated[key] = { state: "streaming", streamStartedAt: now };
+        } else if (thisMeta.state === "complete") {
+          updated[key] = {
+            ...thisMeta,
+            state: "streaming",
+            streamCompletedAt: undefined,
+          };
+        }
+
+        currentKeyRef.current = key;
+        return updated;
+      });
+    },
+    [expectedKeys],
+  );
+
+  const handleDone = useCallback(() => {
+    setMeta((prev) => {
+      const now = Date.now();
+      const updated: Record<string, KeyMeta> = { ...prev };
+
+      for (const key of expectedKeys.map(String)) {
+        const info = updated[key];
+        if (!info) continue;
+        if (info.state === "streaming") {
+          updated[key] = {
+            ...info,
+            state: "complete",
+            streamCompletedAt: now,
+          };
+        } else if (info.state === "notStarted") {
+          updated[key] = { state: "skipped" };
+        }
+      }
+
+      return updated;
+    });
+    setIsStreamDone(true);
+    currentKeyRef.current = null;
+  }, [expectedKeys]);
+
+  return {
+    props,
+    meta: meta as Record<keyof T | string, KeyMeta>,
+    isStreamDone,
+    handleChunk,
+    handleDone,
+  };
+}
+
+export default useStreamingProps;


### PR DESCRIPTION
## Summary
- add `useStreamingProps` hook to track SSE-style JSON key states
- expose key-level meta info and streaming status
- test hook with various stream scenarios
- rename hook per review feedback

## Testing
- `npm test --silent -- --runInBand` *(fails: `npm` not found)*