### PR TITLE
feat: add method for changing a thread's name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     },
     "cli": {
       "name": "tambo",
-      "version": "0.10.1",
+      "version": "0.12.0",
       "dependencies": {
         "@tambo-ai/react": "*",
         "chalk": "^5.3.0",
@@ -6107,6 +6107,19 @@
     "node_modules/@tambo-ai/typescript-config": {
       "resolved": "packages/typescript-config",
       "link": true
+    },
+    "node_modules/@tambo-ai/typescript-sdk": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.51.0.tgz",
+      "integrity": "sha512-2W+nxd1JBLq2DeMN2oSw1+3o03KDZuKQNN0Efkdcky0I9MIV39FVMmv8gZL44URQH0q7fe02jpqsqQXhnlS4XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.77.2",
@@ -20885,10 +20898,10 @@
     },
     "react-sdk": {
       "name": "@tambo-ai/react",
-      "version": "0.26.3",
+      "version": "0.26.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
-        "@tambo-ai/typescript-sdk": "^0.50.0",
+        "@tambo-ai/typescript-sdk": "^0.51.0",
         "@tanstack/react-query": "^5.77.2",
         "partial-json": "^0.1.7",
         "react-fast-compare": "^3.2.2",
@@ -20935,22 +20948,9 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "react-sdk/node_modules/@tambo-ai/typescript-sdk": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.50.0.tgz",
-      "integrity": "sha512-xD2pkB2VuYrHns6ZffhbKOGyjLi7sjt592OuPPGIU6qQf1ZhMhJdfvwVUpga5vpOUJg621jCWERzqLdGpIbbRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
     "showcase": {
       "name": "@tambo-ai/showcase",
-      "version": "0.7.0",
+      "version": "0.8.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "@tambo-ai/typescript-sdk": "^0.50.0",
+    "@tambo-ai/typescript-sdk": "^0.51.0",
     "@tanstack/react-query": "^5.77.2",
     "partial-json": "^0.1.7",
     "react-fast-compare": "^3.2.2",

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -345,7 +345,7 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         });
       }
     },
-    [currentThreadId],
+    [currentThreadId, client.beta.projects, client.beta.threads],
   );
 
   const switchCurrentThread = useCallback(

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -345,11 +345,13 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         return { ...prevMap, [threadId]: { ...prevMap[threadId], name } };
       });
 
-      const currentProject = await client.beta.projects.getCurrent();
-      await client.beta.threads.update(threadId, {
-        name,
-        projectId: currentProject.id,
-      });
+      if (threadId !== PLACEHOLDER_THREAD.id) {
+        const currentProject = await client.beta.projects.getCurrent();
+        await client.beta.threads.update(threadId, {
+          name,
+          projectId: currentProject.id,
+        });
+      }
     },
     [currentThreadId],
   );

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -33,6 +33,10 @@ export interface TamboThreadContextProps {
   switchCurrentThread: (threadId: string, fetch?: boolean) => void;
   /** Start a new thread */
   startNewThread: () => void;
+  /** Update a thread's name */
+  updateThreadName: (name: string, threadId?: string) => void;
+  /** Triggers a name autogeneration for a thread */
+  generateThreadName: (threadId?: string) => void;
   /** Add a message to the current thread */
   addThreadMessage: (
     message: TamboThreadMessage,
@@ -95,6 +99,18 @@ export const TamboThreadContext = createContext<TamboThreadContextProps>({
    */
   startNewThread: () => {
     throw new Error("startNewThread not implemented");
+  },
+  /**
+   *
+   */
+  updateThreadName: () => {
+    throw new Error("updateThreadName not implemented");
+  },
+  /**
+   *
+   */
+  generateThreadName: () => {
+    throw new Error("generateThreadName not implemented");
   },
   /**
    *
@@ -317,6 +333,20 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
       };
     });
   }, []);
+
+  const updateThreadName = useCallback(
+    (_name: string, threadId?: string) => {
+      threadId ??= currentThreadId;
+    },
+    [currentThreadId],
+  );
+
+  const generateThreadName = useCallback(
+    (threadId?: string) => {
+      threadId ??= currentThreadId;
+    },
+    [currentThreadId],
+  );
 
   const switchCurrentThread = useCallback(
     async (threadId: string, fetch = true) => {
@@ -630,6 +660,8 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         thread: currentThread,
         switchCurrentThread,
         startNewThread,
+        updateThreadName,
+        generateThreadName,
         addThreadMessage,
         updateThreadMessage,
         inputValue,

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -35,8 +35,6 @@ export interface TamboThreadContextProps {
   startNewThread: () => void;
   /** Update a thread's name */
   updateThreadName: (name: string, threadId?: string) => void;
-  /** Triggers a name autogeneration for a thread */
-  generateThreadName: (threadId?: string) => void;
   /** Add a message to the current thread */
   addThreadMessage: (
     message: TamboThreadMessage,
@@ -105,12 +103,6 @@ export const TamboThreadContext = createContext<TamboThreadContextProps>({
    */
   updateThreadName: () => {
     throw new Error("updateThreadName not implemented");
-  },
-  /**
-   *
-   */
-  generateThreadName: () => {
-    throw new Error("generateThreadName not implemented");
   },
   /**
    *
@@ -352,14 +344,6 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
           projectId: currentProject.id,
         });
       }
-    },
-    [currentThreadId],
-  );
-
-  const generateThreadName = useCallback(
-    (threadId?: string) => {
-      threadId ??= currentThreadId;
-      throw new Error("not implemented");
     },
     [currentThreadId],
   );
@@ -677,7 +661,6 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
         switchCurrentThread,
         startNewThread,
         updateThreadName,
-        generateThreadName,
         addThreadMessage,
         updateThreadMessage,
         inputValue,

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -359,9 +359,8 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
   const generateThreadName = useCallback(
     (threadId?: string) => {
       threadId ??= currentThreadId;
+      throw new Error("not implemented");
     },
-
-    // const thread = await client.beta.threads.
     [currentThreadId],
   );
 

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -335,8 +335,21 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
   }, []);
 
   const updateThreadName = useCallback(
-    (_name: string, threadId?: string) => {
+    async (name: string, threadId?: string) => {
       threadId ??= currentThreadId;
+
+      setThreadMap((prevMap) => {
+        if (!prevMap[threadId]) {
+          return prevMap;
+        }
+        return { ...prevMap, [threadId]: { ...prevMap[threadId], name } };
+      });
+
+      const currentProject = await client.beta.projects.getCurrent();
+      await client.beta.threads.update(threadId, {
+        name,
+        projectId: currentProject.id,
+      });
     },
     [currentThreadId],
   );
@@ -345,6 +358,8 @@ export const TamboThreadProvider: React.FC<PropsWithChildren> = ({
     (threadId?: string) => {
       threadId ??= currentThreadId;
     },
+
+    // const thread = await client.beta.threads.
     [currentThreadId],
   );
 


### PR DESCRIPTION
exposes   `updateThreadName: (name: string, threadId?: string) => void;` from useTamboThread

If no threadId is provided, uses the currentThread's id.