### PR TITLE
feat: add method to auto-generate a thread's name based on its messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
     },
     "cli": {
       "name": "tambo",
-      "version": "0.12.0",
+      "version": "0.13.1",
       "dependencies": {
         "@tambo-ai/react": "*",
         "chalk": "^5.3.0",
@@ -6107,19 +6107,6 @@
     "node_modules/@tambo-ai/typescript-config": {
       "resolved": "packages/typescript-config",
       "link": true
-    },
-    "node_modules/@tambo-ai/typescript-sdk": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.51.0.tgz",
-      "integrity": "sha512-2W+nxd1JBLq2DeMN2oSw1+3o03KDZuKQNN0Efkdcky0I9MIV39FVMmv8gZL44URQH0q7fe02jpqsqQXhnlS4XQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.77.2",
@@ -20904,10 +20891,10 @@
     },
     "react-sdk": {
       "name": "@tambo-ai/react",
-      "version": "0.26.4",
+      "version": "0.28.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
-        "@tambo-ai/typescript-sdk": "^0.51.0",
+        "@tambo-ai/typescript-sdk": "^0.52.0",
         "@tanstack/react-query": "^5.77.2",
         "partial-json": "^0.1.7",
         "react-fast-compare": "^3.2.2",
@@ -20954,9 +20941,22 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "react-sdk/node_modules/@tambo-ai/typescript-sdk": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.52.0.tgz",
+      "integrity": "sha512-Pq/gy7JjKt1W4hLUwosEZp2KLayAfDZCWmDChxwPWlzJ5E1h2GI+h/MV72C4GbzCTIM9OSh2nkHGvFO3ayhFCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
     "showcase": {
       "name": "@tambo-ai/showcase",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "@tambo-ai/typescript-sdk": "^0.51.0",
+    "@tambo-ai/typescript-sdk": "^0.52.0",
     "@tanstack/react-query": "^5.77.2",
     "partial-json": "^0.1.7",
     "react-fast-compare": "^3.2.2",

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -376,6 +376,19 @@ export const TamboThreadProvider: React.FC<
 
       const threadWithGeneratedName =
         await client.beta.threads.generateName(threadId);
+
+      setThreadMap((prevMap) => {
+        if (!prevMap[threadId]) {
+          return prevMap;
+        }
+        return {
+          ...prevMap,
+          [threadId]: {
+            ...prevMap[threadId],
+            name: threadWithGeneratedName.name,
+          },
+        };
+      });
       return threadWithGeneratedName;
     },
     [client.beta.threads, currentThreadId, threadMap],


### PR DESCRIPTION
Updates `useTamboThread` to expose a method called `generateThreadName(threadId?: string)` which makes a request to Tambo's api to use an LLM to generate and set the thread's name based on the conversation.

If no threadId is provided, uses the 'current' thread.

Does nothing on a new (empty) threads. 