### PR TITLE
fix: add TAMBO_SERVER_URL to globalEnv in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
-  "globalEnv": ["NODE_ENV"],
+  "globalEnv": ["NODE_ENV", "TAMBO_SERVER_URL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Fixes #532

Resolves ESLint warning: `TAMBO_SERVER_URL is not listed as a dependency in turbo.json`

## Changes
- Added `TAMBO_SERVER_URL` to the `globalEnv` array in turbo.json
- This resolves the `turbo/no-undeclared-env-vars` ESLint warning

Generated with [Claude Code](https://claude.ai/code)