### PR TITLE
fix: convert ThreadOptionsDropdown from forwardRef to regular function component

### DIFF
--- a/cli/src/registry/thread-dropdown/thread-dropdown.tsx
+++ b/cli/src/registry/thread-dropdown/thread-dropdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { DropdownMenu } from "radix-ui";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { useTamboThread, useTamboThreadList } from "@tambo-ai/react";
 import { ChevronDownIcon, PlusIcon } from "lucide-react";
 import * as React from "react";

--- a/cli/src/registry/thread-history/thread-history.tsx
+++ b/cli/src/registry/thread-history/thread-history.tsx
@@ -561,14 +561,15 @@ ThreadHistoryList.displayName = "ThreadHistory.List";
 /**
  * Dropdown menu component for thread actions
  */
-const ThreadOptionsDropdown = React.forwardRef<
-  HTMLDivElement,
-  {
-    thread: TamboThread;
-    onRename: (thread: TamboThread) => void;
-    onGenerateName: (thread: TamboThread) => void;
-  } & React.HTMLAttributes<HTMLDivElement>
->(({ thread, onRename, onGenerateName }) => {
+const ThreadOptionsDropdown = ({
+  thread,
+  onRename,
+  onGenerateName,
+}: {
+  thread: TamboThread;
+  onRename: (thread: TamboThread) => void;
+  onGenerateName: (thread: TamboThread) => void;
+}) => {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
@@ -609,8 +610,7 @@ const ThreadOptionsDropdown = React.forwardRef<
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
   );
-});
-ThreadOptionsDropdown.displayName = "ThreadHistory.Dropdown";
+};
 
 export {
   ThreadHistory,

--- a/showcase/src/components/ui/thread-dropdown.tsx
+++ b/showcase/src/components/ui/thread-dropdown.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import { useTamboThread, useTamboThreadList } from "@tambo-ai/react";
 import { ChevronDownIcon, PlusIcon } from "lucide-react";
-import { DropdownMenu } from "radix-ui";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as React from "react";
 import { useCallback } from "react";
 

--- a/showcase/src/components/ui/thread-history.tsx
+++ b/showcase/src/components/ui/thread-history.tsx
@@ -561,14 +561,15 @@ ThreadHistoryList.displayName = "ThreadHistory.List";
 /**
  * Dropdown menu component for thread actions
  */
-const ThreadOptionsDropdown = React.forwardRef<
-  HTMLDivElement,
-  {
-    thread: TamboThread;
-    onRename: (thread: TamboThread) => void;
-    onGenerateName: (thread: TamboThread) => void;
-  } & React.HTMLAttributes<HTMLDivElement>
->(({ thread, onRename, onGenerateName }) => {
+const ThreadOptionsDropdown = ({
+  thread,
+  onRename,
+  onGenerateName,
+}: {
+  thread: TamboThread;
+  onRename: (thread: TamboThread) => void;
+  onGenerateName: (thread: TamboThread) => void;
+}) => {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
@@ -609,8 +610,7 @@ const ThreadOptionsDropdown = React.forwardRef<
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
   );
-});
-ThreadOptionsDropdown.displayName = "ThreadHistory.Dropdown";
+};
 
 export {
   ThreadHistory,


### PR DESCRIPTION
The ThreadOptionsDropdown component was using React.forwardRef but missing the required ref parameter, causing a TypeScript error. Since the component doesn't actually need to forward refs or use additional HTML attributes, converted it to a regular functional component.

Fixes #559

Generated with [Claude Code](https://claude.ai/code)