### PR TITLE
feat: Add cancellation UI

### DIFF
--- a/cli/src/registry/message-input/message-input.tsx
+++ b/cli/src/registry/message-input/message-input.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import { useTamboThread, useTamboThreadInput } from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { ArrowUp } from "lucide-react";
+import { ArrowUp, Square } from "lucide-react";
 import * as React from "react";
 
 /**
@@ -294,23 +294,32 @@ const MessageInputSubmitButton = React.forwardRef<
   MessageInputSubmitButtonProps
 >(({ className, children, ...props }, ref) => {
   const { isPending } = useMessageInputContext();
+  const { cancel } = useTamboThread();
+
+  const handleCancel = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    cancel();
+  };
+
+  const buttonClasses = cn(
+    "w-10 h-10 bg-black/80 text-white rounded-lg hover:bg-black/70 disabled:opacity-50 flex items-center justify-center cursor-pointer",
+    className,
+  );
 
   return (
     <button
       ref={ref}
-      type="submit"
-      disabled={isPending}
-      className={cn(
-        "w-10 h-10 bg-black/80 text-white rounded-lg hover:bg-black/70 disabled:opacity-50 flex items-center justify-center cursor-pointer",
-        className,
-      )}
-      aria-label="Send message"
-      data-slot="message-input-submit"
+      type={isPending ? "button" : "submit"}
+      onClick={isPending ? handleCancel : undefined}
+      className={buttonClasses}
+      aria-label={isPending ? "Cancel message" : "Send message"}
+      data-slot={isPending ? "message-input-cancel" : "message-input-submit"}
       {...props}
     >
       {children ??
         (isPending ? (
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
+          <Square className="w-4 h-4" fill="currentColor" />
         ) : (
           <ArrowUp className="w-5 h-5" />
         ))}

--- a/cli/src/registry/message-input/message-input.tsx
+++ b/cli/src/registry/message-input/message-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useTamboThreadInput } from "@tambo-ai/react";
+import { useTamboThread, useTamboThreadInput } from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { ArrowUp } from "lucide-react";
 import * as React from "react";
@@ -227,8 +227,10 @@ const MessageInputTextarea = ({
   placeholder = "What do you want to do?",
   ...props
 }: MessageInputTextareaProps) => {
-  const { value, setValue, isPending, textareaRef, handleSubmit } =
+  const { value, setValue, textareaRef, handleSubmit } =
     useMessageInputContext();
+  const { isIdle } = useTamboThread();
+  const isPending = !isIdle;
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setValue(e.target.value);
@@ -392,10 +394,10 @@ MessageInputToolbar.displayName = "MessageInput.Toolbar";
 
 // --- Exports ---
 export {
-  messageInputVariants,
   MessageInput,
-  MessageInputTextarea,
-  MessageInputSubmitButton,
-  MessageInputToolbar,
   MessageInputError,
+  MessageInputSubmitButton,
+  MessageInputTextarea,
+  MessageInputToolbar,
+  messageInputVariants,
 };

--- a/cli/src/registry/message-suggestions/message-generation-stage.tsx
+++ b/cli/src/registry/message-suggestions/message-generation-stage.tsx
@@ -21,7 +21,7 @@ export function MessageGenerationStage({
   showLabel = true,
   ...props
 }: GenerationStageProps) {
-  const { thread } = useTambo();
+  const { thread, isIdle } = useTambo();
   const stage = thread?.generationStage;
 
   // Only render if we have a generation stage
@@ -43,6 +43,10 @@ export function MessageGenerationStage({
 
   const label =
     stageLabels[stage] || `${stage.charAt(0).toUpperCase() + stage.slice(1)}`;
+
+  if (isIdle) {
+    return null;
+  }
 
   return (
     <div

--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -259,9 +259,7 @@ const MessageContent = React.forwardRef<HTMLDivElement, MessageContentProps>(
               safeContent
             )}
             {message.isCancelled && (
-              <span className="text-muted-foreground text-xs">
-                message cancelled
-              </span>
+              <span className="text-muted-foreground text-xs">cancelled</span>
             )}
           </div>
         )}

--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -364,7 +364,11 @@ const MessageRenderedComponentArea = React.forwardRef<
     };
   }, []);
 
-  if (!message.renderedComponent || role !== "assistant") {
+  if (
+    !message.renderedComponent ||
+    role !== "assistant" ||
+    message.isCancelled
+  ) {
     return null;
   }
 

--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -258,6 +258,11 @@ const MessageContent = React.forwardRef<HTMLDivElement, MessageContentProps>(
             ) : (
               safeContent
             )}
+            {message.isCancelled && (
+              <span className="text-muted-foreground text-xs">
+                message cancelled
+              </span>
+            )}
           </div>
         )}
         {toolStatusMessage && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -23708,7 +23708,7 @@
       "version": "0.32.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.1",
-        "@tambo-ai/typescript-sdk": "^0.55.0",
+        "@tambo-ai/typescript-sdk": "^0.56.0",
         "@tanstack/react-query": "^5.81.2",
         "partial-json": "^0.1.7",
         "react-fast-compare": "^3.2.2",
@@ -23756,9 +23756,9 @@
       }
     },
     "react-sdk/node_modules/@tambo-ai/typescript-sdk": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.55.0.tgz",
-      "integrity": "sha512-BIW1FYMxlgGSz/WwK7pgIVKrjjeYBs98JFCy4g9RxjkDaeMWUBd4R6E0abb3bIJZoRu3NyL6sy+dyGWr316C9g==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.56.0.tgz",
+      "integrity": "sha512-D4HRMBnJhnAUvzJbqyA61TpEIyALSB9HuPR3Bb5VGrnfXnmpZ6ypr32CgOslY5qJ59IulbIXTaDs84Ax9VDywQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "abort-controller": "^3.0.0",

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.1",
-    "@tambo-ai/typescript-sdk": "^0.55.0",
+    "@tambo-ai/typescript-sdk": "^0.56.0",
     "@tanstack/react-query": "^5.81.2",
     "partial-json": "^0.1.7",
     "react-fast-compare": "^3.2.2",

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -175,7 +175,7 @@ export const TamboThreadProvider: React.FC<
   const { componentList, toolRegistry, componentToolAssociations } =
     useTamboRegistry();
   const [inputValue, setInputValue] = useState("");
-  const [ignoreResponse, setIgnoreResopnse] = useState(false);
+  const [ignoreResponse, setIgnoreResponse] = useState(false);
   const ignoreResponseRef = useRef(ignoreResponse);
   const [currentThreadId, setCurrentThreadId] = useState<string>(
     PLACEHOLDER_THREAD.id,
@@ -465,7 +465,7 @@ export const TamboThreadProvider: React.FC<
       if (isIdle) {
         return;
       }
-      setIgnoreResopnse(true);
+      setIgnoreResponse(true);
       setThreadMap((prevMap) => {
         if (!prevMap[threadId]) {
           return prevMap;
@@ -490,7 +490,7 @@ export const TamboThreadProvider: React.FC<
       threadId: string,
     ): Promise<TamboThreadMessage> => {
       if (ignoreResponseRef.current) {
-        setIgnoreResopnse(false);
+        setIgnoreResponse(false);
         return {
           threadId: threadId,
           content: [{ type: "text", text: "" }],
@@ -516,7 +516,7 @@ export const TamboThreadProvider: React.FC<
             toolRegistry,
           );
           if (ignoreResponseRef.current) {
-            setIgnoreResopnse(false);
+            setIgnoreResponse(false);
             {
               return {
                 threadId: threadId,
@@ -647,7 +647,7 @@ export const TamboThreadProvider: React.FC<
         contextKey?: string;
       } = {},
     ): Promise<TamboThreadMessage> => {
-      setIgnoreResopnse(false);
+      setIgnoreResponse(false);
       const {
         threadId = currentThreadId ?? PLACEHOLDER_THREAD.id,
         streamResponse = streaming,


### PR DESCRIPTION
Updates UI registry to handle message cancellation state.

- shows 'cancelled' text under a cancelled message
- doesn't show component in a cancelled message
- shows 'stop' button in place of send button while generating
