### PR TITLE
fix: update local toolrequestmessage before running toolcall

### DIFF
--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -527,6 +527,14 @@ export const TamboThreadProvider: React.FC<
             GenerationStage.FETCHING_CONTEXT,
           );
 
+          updateThreadMessage(
+            chunk.responseMessageDto.id,
+            {
+              ...chunk.responseMessageDto,
+            },
+            false,
+          );
+
           const toolCallResponse = await handleToolCall(
             chunk.responseMessageDto,
             toolRegistry,


### PR DESCRIPTION
previously information about a toolcallrequest (like the actionType field) was not added to the local thread message before running the toolcall. So we were not seeing the 'tool processing' ui until after the tool completed.