### PR TITLE
fix: send toolcall counts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24283,10 +24283,10 @@
     },
     "react-sdk": {
       "name": "@tambo-ai/react",
-      "version": "0.37.1",
+      "version": "0.37.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.0",
-        "@tambo-ai/typescript-sdk": "^0.61.0",
+        "@tambo-ai/typescript-sdk": "^0.62.0",
         "@tanstack/react-query": "^5.81.5",
         "partial-json": "^0.1.7",
         "react-fast-compare": "^3.2.2",
@@ -24331,6 +24331,19 @@
         "@types/react-dom": "^18.0.0 || ^19.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "react-sdk/node_modules/@tambo-ai/typescript-sdk": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.62.0.tgz",
+      "integrity": "sha512-EplHDT4OYbepPtHskdLikkUsSpObmHRYZJ1btMYnrrFahbGwQgPFfNFb3d4M13whfV7LOANv4vowrwGYalvadA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
       }
     },
     "react-sdk/node_modules/@types/node": {

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.15.0",
-    "@tambo-ai/typescript-sdk": "^0.61.0",
+    "@tambo-ai/typescript-sdk": "^0.62.0",
     "@tanstack/react-query": "^5.81.5",
     "partial-json": "^0.1.7",
     "react-fast-compare": "^3.2.2",

--- a/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
@@ -258,6 +258,7 @@ describe("TamboThreadProvider", () => {
       availableComponents: serializeRegistry(mockRegistry),
       contextKey: undefined,
       clientTools: [],
+      toolCallCounts: {},
     });
     expect(result.current.generationStage).toBe(GenerationStage.COMPLETE);
   });
@@ -414,6 +415,7 @@ describe("TamboThreadProvider", () => {
           contextKey: undefined,
           clientTools: [],
           forceToolChoice: undefined,
+          toolCallCounts: {},
         },
         "test-thread-1",
       );
@@ -455,6 +457,7 @@ describe("TamboThreadProvider", () => {
         contextKey: undefined,
         clientTools: [],
         forceToolChoice: undefined,
+        toolCallCounts: {},
       });
 
       // Should not call advance or advanceStream
@@ -496,6 +499,7 @@ describe("TamboThreadProvider", () => {
         contextKey: undefined,
         clientTools: [],
         forceToolChoice: undefined,
+        toolCallCounts: {},
       });
 
       // Should not call advance or advanceStream
@@ -559,6 +563,7 @@ describe("TamboThreadProvider", () => {
           contextKey: undefined,
           clientTools: [],
           forceToolChoice: undefined,
+          toolCallCounts: {},
         },
         "test-thread-1",
       );
@@ -603,6 +608,7 @@ describe("TamboThreadProvider", () => {
         contextKey: undefined,
         clientTools: [],
         forceToolChoice: undefined,
+        toolCallCounts: {},
       });
 
       // Should not call advanceById or advanceStream
@@ -671,6 +677,7 @@ describe("TamboThreadProvider", () => {
           contextKey: undefined,
           clientTools: [],
           forceToolChoice: undefined,
+          toolCallCounts: {},
         },
         undefined, // threadId is undefined for placeholder thread
       );


### PR DESCRIPTION
updates react sdk to send toolcall counts during processing of a user message, so api can handle limiting based on project configuration