### PR TITLE
fix: update exports for tambo stream provider

### DIFF
--- a/react-sdk/src/index.ts
+++ b/react-sdk/src/index.ts
@@ -1,4 +1,5 @@
 /** Exports for the library. Only publically available exports are re-exported here. Anything not exported here is not supported and may change or break at any time. */
+
 export { useTamboComponentState } from "./hooks/use-component-state";
 export {
   TamboMessageProvider,
@@ -18,11 +19,13 @@ export { useTamboThreadInput } from "./hooks/use-thread-input";
 export {
   TamboClientProvider,
   TamboComponentProvider,
+  TamboPropStreamProvider,
   TamboProvider,
   TamboStubProvider,
   TamboThreadProvider,
   useTambo,
   useTamboClient,
+  useTamboStream,
   useTamboThread,
   type TamboComponent,
   type TamboRegistryContext,

--- a/react-sdk/src/providers/index.ts
+++ b/react-sdk/src/providers/index.ts
@@ -4,7 +4,10 @@ export {
   TamboComponentProvider,
   useTamboComponent,
 } from "./tambo-component-provider";
-export { TamboPropStreamProvider } from "./tambo-prop-stream-provider";
+export {
+  TamboPropStreamProvider,
+  useTamboStream,
+} from "./tambo-prop-stream-provider";
 export { TamboContext, TamboProvider, useTambo } from "./tambo-provider";
 export {
   TamboRegistryProvider,

--- a/react-sdk/src/providers/index.ts
+++ b/react-sdk/src/providers/index.ts
@@ -8,6 +8,12 @@ export {
   TamboPropStreamProvider,
   useTamboStream,
 } from "./tambo-prop-stream-provider";
+export type {
+  TamboPropStreamProviderProps,
+  LoadingProps,
+  EmptyProps,
+  CompleteProps,
+} from "./tambo-prop-stream-provider";
 export { TamboContext, TamboProvider, useTambo } from "./tambo-provider";
 export {
   TamboRegistryProvider,

--- a/react-sdk/src/providers/tambo-prop-stream-provider.tsx
+++ b/react-sdk/src/providers/tambo-prop-stream-provider.tsx
@@ -63,7 +63,7 @@ export interface CompleteProps {
 /**
  * Loading component that renders children when the stream is in a loading state
  * @param props - The props for the Loading component
- * @param props.key - The key to identify this loading state
+ * @param props.streamKey - The key to identify this loading state
  * @param props.children - The children to render when loading
  * @param props.className - Optional className for styling
  * @returns The Loading component
@@ -94,7 +94,7 @@ const Loading: React.FC<LoadingProps> = ({
 /**
  * Empty component that renders children when the stream has no data
  * @param props - The props for the Empty component
- * @param props.key - The key to identify this empty state
+ * @param props.streamKey - The key to identify this empty state
  * @param props.children - The children to render when empty
  * @param props.className - Optional className for styling
  * @returns The Empty component
@@ -139,7 +139,7 @@ const Empty: React.FC<EmptyProps> = ({
 /**
  * Complete component that renders children when the stream has data
  * @param props - The props for the Complete component
- * @param props.key - The key to identify this complete state
+ * @param props.streamKey - The key to identify this complete state
  * @param props.children - The children to render when complete
  * @param props.className - Optional className for styling
  * @returns The Complete component


### PR DESCRIPTION
This PR fixes missing exports for the TamboPropStreamProvider and useTamboStream hook, and adds TypeScript exports for compound component prop types.

## Changes
- Added exports for TamboPropStreamProvider and useTamboStream hook to make the stream provider publicly available
- Fixed JSDoc documentation to correctly reference streamKey parameter instead of key 
- Added TypeScript type exports for TamboPropStreamProviderProps, LoadingProps, EmptyProps, and CompleteProps to enable better type safety for consumers

## Breaking Changes
None - this is purely additive and fixes missing exports