### PR TITLE
feat(docs): add custom top navigation bar

### DIFF
--- a/docs/src/app/(docs)/layout.tsx
+++ b/docs/src/app/(docs)/layout.tsx
@@ -9,6 +9,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       tree={source.pageTree}
       {...baseOptions}
       sidebar={{ collapsible: false }}
+      containerProps={{ className: "[--fd-nav-height:56px]" }}
     >
       {children as React.ReactNode}
     </DocsLayout>

--- a/docs/src/app/layout.config.tsx
+++ b/docs/src/app/layout.config.tsx
@@ -1,17 +1,12 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
-import Image from "next/image";
+import TopNav from "@/components/top-nav";
 
 export const baseOptions: BaseLayoutProps = {
   nav: {
-    title: (
-      <Image
-        src="/logo/lockup/Tambo-Lockup.svg"
-        alt="Tambo Lockup"
-        width={100}
-        height={26}
-        className="h-7 w-auto"
-      />
-    ),
+    component: <TopNav />,
+  },
+  searchToggle: {
+    enabled: false,
   },
   // see https://fumadocs.dev/docs/ui/navigation/links
   links: [],

--- a/docs/src/components/top-nav.tsx
+++ b/docs/src/components/top-nav.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import {
+  LargeSearchToggle,
+  SearchToggle,
+} from "fumadocs-ui/components/layout/search-toggle";
+import { buttonVariants } from "fumadocs-ui/components/ui/button";
+import { cn } from "fumadocs-ui/utils/cn";
+
+export default function TopNav() {
+  return (
+    <nav className="flex h-14 items-center border-b px-4">
+      <Link href="/" className="mr-4">
+        <Image
+          src="/logo/lockup/Tambo-Lockup.svg"
+          alt="Tambo Lockup"
+          width={100}
+          height={26}
+          className="h-7 w-auto"
+        />
+      </Link>
+      <div className="flex flex-1 items-center justify-end gap-4">
+        <LargeSearchToggle className="hidden w-full max-w-xs md:flex" />
+        <SearchToggle className="md:hidden" />
+        <Link
+          href="https://tambo.co/discord"
+          target="_blank"
+          rel="noreferrer"
+          className="text-sm"
+        >
+          Discord
+        </Link>
+        <Link
+          href="https://tambo.co/gh"
+          target="_blank"
+          rel="noreferrer"
+          className="text-sm"
+        >
+          GitHub
+        </Link>
+        <Link
+          href="https://tambo.co/"
+          target="_blank"
+          rel="noreferrer"
+          className={cn(buttonVariants({ color: "primary", size: "sm" }))}
+        >
+          Cloud
+        </Link>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add custom TopNav with logo, search, and links to Discord, GitHub, and Cloud
- disable default Fumadocs logo and search
- adjust docs layout for custom nav height

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eb1e6553c833286ffcf8f16753c23