### PR TITLE
style(showcase): enhance code block styling

### DIFF
--- a/showcase/src/components/cli.tsx
+++ b/showcase/src/components/cli.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import hljs from "highlight.js";
-import "highlight.js/styles/vs2015.css";
+import "@/styles/code-blocks.css";
 import { Check, Copy } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
@@ -15,7 +15,7 @@ interface CLIProps {
 
 export function CLI({
   command,
-  background = "#1E1E1E",
+  background = "hsl(var(--background))",
   path,
   isCode = false,
   language = "typescript",
@@ -45,7 +45,7 @@ export function CLI({
 
   return (
     <div
-      className="p-3 md:p-4 font-mono text-xs md:text-sm rounded-lg w-full overflow-hidden"
+      className="p-3 md:p-4 font-mono text-xs md:text-sm rounded-lg w-full overflow-hidden text-foreground"
       style={{ background }}
     >
       {command && (

--- a/showcase/src/components/ui/markdown-components.tsx
+++ b/showcase/src/components/ui/markdown-components.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import type { Components } from "react-markdown";
 import { Copy, Check, ExternalLink } from "lucide-react";
 import hljs from "highlight.js";
-import "highlight.js/styles/github.css";
+import "@/styles/code-blocks.css";
 import DOMPurify from "dompurify";
 
 /**
@@ -117,9 +117,9 @@ export const createMarkdownComponents = (): Components => ({
               "[&::-webkit-scrollbar:horizontal]:h-[4px]",
             )}
           >
-            <pre className="p-4 whitespace-pre">
+            <pre className="p-4 whitespace-pre font-mono">
               <code
-                className={className}
+                className={cn("hljs", className)}
                 dangerouslySetInnerHTML={{
                   __html: DOMPurify.sanitize(highlighted ?? content),
                 }}
@@ -132,7 +132,10 @@ export const createMarkdownComponents = (): Components => ({
 
     return (
       <code
-        className={cn("bg-muted px-1.5 py-0.5 rounded text-sm", className)}
+        className={cn(
+          "bg-muted px-1.5 py-0.5 rounded text-sm font-mono",
+          className,
+        )}
         {...props}
       >
         {children}

--- a/showcase/src/components/ui/syntax-highlighter.tsx
+++ b/showcase/src/components/ui/syntax-highlighter.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import DOMPurify from "dompurify";
 import hljs from "highlight.js";
-import "highlight.js/styles/github.css";
+import "@/styles/code-blocks.css";
 import { Check, Copy } from "lucide-react";
 import React, { useEffect, useState } from "react";
 
@@ -74,15 +74,16 @@ export const SyntaxHighlighter = ({
           "[&::-webkit-scrollbar:horizontal]:h-[4px]",
         )}
       >
-        <pre className="p-4 whitespace-pre">
+        <pre className="p-4 whitespace-pre font-mono">
           {highlightedCode ? (
             <code
+              className="hljs"
               dangerouslySetInnerHTML={{
                 __html: highlightedCode,
               }}
             />
           ) : (
-            <code>{code}</code>
+            <code className="hljs">{code}</code>
           )}
         </pre>
       </div>

--- a/showcase/src/styles/code-blocks.css
+++ b/showcase/src/styles/code-blocks.css
@@ -1,0 +1,43 @@
+@layer showcase-theme {
+  .hljs {
+    background: transparent;
+    color: hsl(var(--foreground));
+  }
+  .hljs-comment,
+  .hljs-quote {
+    color: hsl(var(--muted-foreground));
+    font-style: italic;
+  }
+  .hljs-keyword,
+  .hljs-selector-tag,
+  .hljs-literal,
+  .hljs-section,
+  .hljs-link,
+  .hljs-function .hljs-keyword {
+    color: hsl(var(--primary));
+    font-weight: 600;
+  }
+  .hljs-string,
+  .hljs-title,
+  .hljs-name,
+  .hljs-type,
+  .hljs-attr,
+  .hljs-symbol,
+  .hljs-bullet,
+  .hljs-subst {
+    color: hsl(var(--secondary));
+  }
+  .hljs-number,
+  .hljs-deletion,
+  .hljs-addition,
+  .hljs-variable,
+  .hljs-template-variable {
+    color: hsl(var(--accent-foreground));
+  }
+  .hljs-emphasis {
+    font-style: italic;
+  }
+  .hljs-strong {
+    font-weight: 700;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable code block theme using showcase color variables
- apply new styling to syntax highlighter, markdown renderer, and CLI component
- ensure code blocks use monospace font and theme-aware colors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689eb27fee7c83329f06fb3cb88a72ad