### PR TITLE
feat: expose isUpdating from useTamboSessionToken

### DIFF
--- a/react-sdk/src/providers/hooks/__tests__/use-tambo-session-token.test.tsx
+++ b/react-sdk/src/providers/hooks/__tests__/use-tambo-session-token.test.tsx
@@ -1,4 +1,5 @@
 import TamboAI from "@tambo-ai/typescript-sdk";
+import { QueryClient } from "@tanstack/react-query";
 import { act, renderHook } from "@testing-library/react";
 import { DeepPartial } from "ts-essentials";
 import { useTamboSessionToken } from "../use-tambo-session-token";
@@ -25,62 +26,77 @@ describe("useTamboSessionToken", () => {
     beta: mockBeta,
     bearer: "",
   } satisfies PartialTamboAI as unknown as TamboAI;
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
     jest.useFakeTimers();
     (mockTamboAI as any).bearer = "";
+    queryClient.clear();
   });
 
-  afterEach(() => {
-    jest.runOnlyPendingTimers();
+  afterEach(async () => {
+    await act(async () => {
+      await jest.runOnlyPendingTimersAsync();
+    });
     jest.useRealTimers();
+    jest.resetAllMocks();
   });
 
   it("should return null initially when no userToken is provided", () => {
     const { result } = renderHook(() =>
-      useTamboSessionToken(mockTamboAI, undefined),
+      useTamboSessionToken(mockTamboAI, queryClient, undefined),
     );
 
-    expect(result.current).toEqual({
-      tamboSessionToken: null,
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: undefined,
+      isFetching: false,
     });
     expect(mockAuthApi.getToken).not.toHaveBeenCalled();
   });
 
   it("should fetch and return session token when userToken is provided", async () => {
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue(mockTokenResponse);
+    mockAuthApi.getToken.mockResolvedValue(mockTokenResponse);
 
     const { result } = renderHook(() =>
-      useTamboSessionToken(mockTamboAI, "user-token"),
+      useTamboSessionToken(mockTamboAI, queryClient, "user-token"),
+    );
+    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await jest.runOnlyPendingTimersAsync();
+    });
+
+    expect(result.current).toMatchObject({
+      data: mockTokenResponse,
+      isFetching: false,
+    });
+    expect(mockTamboAI.bearer).toBe(mockTokenResponse.access_token);
+    // Verify the hook was called with correct parameters
+    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(2);
+    expect(mockAuthApi.getToken).toHaveBeenCalledWith(expect.any(Object));
+  });
+
+  it("should call getToken with correct token exchange parameters", async () => {
+    mockAuthApi.getToken.mockResolvedValue(mockTokenResponse);
+
+    renderHook(() =>
+      useTamboSessionToken(mockTamboAI, queryClient, "user-token"),
     );
 
     await act(async () => {
       await jest.runOnlyPendingTimersAsync();
     });
 
-    expect(result.current).toEqual({
-      tamboSessionToken: "test-access-token",
-      isUpdating: false,
-    });
-    expect(mockTamboAI.bearer).toBe("test-access-token");
-    // Verify the hook was called with correct parameters
-    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(1);
-    expect(mockAuthApi.getToken).toHaveBeenCalledWith(expect.any(Object));
-  });
-
-  it("should call getToken with correct token exchange parameters", async () => {
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue(mockTokenResponse);
-
-    renderHook(() => useTamboSessionToken(mockTamboAI, "user-token"));
-
-    await act(async () => {
-      await jest.runOnlyPendingTimersAsync();
-    });
-
-    const callArgs = jest.mocked(mockAuthApi.getToken).mock.calls[0][0];
+    const callArgs = mockAuthApi.getToken.mock.calls[0][0];
     const tokenRequestString = new TextDecoder().decode(callArgs);
     const tokenRequest = new URLSearchParams(tokenRequestString);
 
@@ -94,19 +110,18 @@ describe("useTamboSessionToken", () => {
   });
 
   it("should set bearer token on client", async () => {
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue(mockTokenResponse);
+    mockAuthApi.getToken.mockResolvedValue(mockTokenResponse);
 
     const { result } = renderHook(() =>
-      useTamboSessionToken(mockTamboAI, "user-token"),
+      useTamboSessionToken(mockTamboAI, queryClient, "user-token"),
     );
 
     await act(async () => {
       await jest.runOnlyPendingTimersAsync();
     });
 
-    expect(result.current).toEqual({
-      tamboSessionToken: "test-access-token",
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: mockTokenResponse,
     });
     expect(mockTamboAI.bearer).toBe("test-access-token");
   });
@@ -118,42 +133,48 @@ describe("useTamboSessionToken", () => {
       token_type: "Bearer",
     };
 
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue(customTokenResponse);
+    mockAuthApi.getToken.mockResolvedValue(customTokenResponse);
 
     const { result } = renderHook(() =>
-      useTamboSessionToken(mockTamboAI, "user-token"),
+      useTamboSessionToken(mockTamboAI, queryClient, "user-token"),
     );
+    expect(result.current).toMatchObject({
+      data: undefined,
+      isFetching: true,
+    });
 
     await act(async () => {
       await jest.runOnlyPendingTimersAsync();
     });
 
-    expect(result.current).toEqual({
-      tamboSessionToken: "custom-access-token",
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: customTokenResponse,
+      isFetching: false,
     });
     expect(mockTamboAI.bearer).toBe("custom-access-token");
   });
 
   it("should not fetch token when userToken changes to undefined", async () => {
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue(mockTokenResponse);
+    mockAuthApi.getToken.mockResolvedValue(mockTokenResponse);
 
     const { result, rerender } = renderHook(
-      ({ userToken }) => useTamboSessionToken(mockTamboAI, userToken),
+      ({ userToken }) =>
+        useTamboSessionToken(mockTamboAI, queryClient, userToken),
       {
         initialProps: { userToken: "user-token" as string | undefined },
       },
     );
+    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await jest.runOnlyPendingTimersAsync();
     });
 
-    expect(result.current).toEqual({
-      tamboSessionToken: "test-access-token",
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: mockTokenResponse,
+      isFetching: false,
     });
-    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(1);
+    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(2);
 
     // Clear mock and change userToken to undefined
     jest.clearAllMocks();
@@ -166,27 +187,29 @@ describe("useTamboSessionToken", () => {
   });
 
   it("should refetch token when userToken changes", async () => {
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue(mockTokenResponse);
+    mockAuthApi.getToken.mockResolvedValue(mockTokenResponse);
 
     const { result, rerender } = renderHook(
-      ({ userToken }) => useTamboSessionToken(mockTamboAI, userToken),
+      ({ userToken }) =>
+        useTamboSessionToken(mockTamboAI, queryClient, userToken),
       {
         initialProps: { userToken: "user-token-1" },
       },
     );
+    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await jest.runOnlyPendingTimersAsync();
     });
 
-    expect(result.current).toEqual({
-      tamboSessionToken: "test-access-token",
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: mockTokenResponse,
+      isFetching: false,
     });
-    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(1);
+    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(2);
 
     // Mock response for new token
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue({
+    mockAuthApi.getToken.mockResolvedValue({
       ...mockTokenResponse,
       access_token: "new-access-token",
     });
@@ -200,18 +223,19 @@ describe("useTamboSessionToken", () => {
       await jest.runOnlyPendingTimersAsync();
     });
 
-    expect(result.current).toEqual({
-      tamboSessionToken: "new-access-token",
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: { access_token: "new-access-token" },
+      isFetching: false,
     });
-    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(2);
+    expect(mockAuthApi.getToken).toHaveBeenCalledTimes(4);
   });
 
   it("should reset token when userToken becomes null", async () => {
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue(mockTokenResponse);
+    mockAuthApi.getToken.mockResolvedValue(mockTokenResponse);
 
     const { result, rerender } = renderHook(
-      ({ userToken }) => useTamboSessionToken(mockTamboAI, userToken),
+      ({ userToken }) =>
+        useTamboSessionToken(mockTamboAI, queryClient, userToken),
       {
         initialProps: { userToken: "user-token" as string | undefined },
       },
@@ -221,20 +245,21 @@ describe("useTamboSessionToken", () => {
       await jest.runOnlyPendingTimersAsync();
     });
 
-    expect(result.current).toEqual({
-      tamboSessionToken: "test-access-token",
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: mockTokenResponse,
+      isFetching: false,
     });
 
     // Change userToken to undefined
-    act(() => {
-      rerender({ userToken: undefined });
+    rerender({ userToken: undefined });
+    await act(async () => {
+      await jest.runAllTimersAsync();
     });
 
-    // Token should remain the same (hook doesn't reset it to null when userToken is undefined)
-    expect(result.current).toEqual({
-      tamboSessionToken: "test-access-token",
-      isUpdating: false,
+    // Token should reset to null (hook doesn't reset it to null when userToken is undefined)
+    expect(result.current).toMatchObject({
+      data: undefined,
+      isFetching: false,
     });
   });
 
@@ -244,15 +269,15 @@ describe("useTamboSessionToken", () => {
       resolvePromise = resolve;
     });
 
-    jest.mocked(mockAuthApi.getToken).mockReturnValue(promise);
+    mockAuthApi.getToken.mockReturnValue(promise);
 
     const { result, unmount } = renderHook(() =>
-      useTamboSessionToken(mockTamboAI, "user-token"),
+      useTamboSessionToken(mockTamboAI, queryClient, "user-token"),
     );
 
-    expect(result.current).toEqual({
-      tamboSessionToken: null,
-      isUpdating: true,
+    expect(result.current).toMatchObject({
+      data: undefined,
+      isFetching: true,
     });
 
     // Unmount before the promise resolves
@@ -264,39 +289,39 @@ describe("useTamboSessionToken", () => {
     });
 
     // Token should still be null since component was unmounted
-    expect(result.current).toEqual({
-      tamboSessionToken: null,
-      isUpdating: true,
+    expect(result.current).toMatchObject({
+      data: undefined,
+      isFetching: true,
     });
   });
 
   it("should set isUpdating to true while fetching token", () => {
-    jest.mocked(mockAuthApi.getToken).mockImplementation(async () => {
+    mockAuthApi.getToken.mockImplementation(async () => {
       return await new Promise(() => {}); // Never resolves
     });
 
     const { result } = renderHook(() =>
-      useTamboSessionToken(mockTamboAI, "user-token"),
+      useTamboSessionToken(mockTamboAI, queryClient, "user-token"),
     );
 
     // Should be updating immediately when userToken is provided
-    expect(result.current).toEqual({
-      tamboSessionToken: null,
-      isUpdating: true,
+    expect(result.current).toMatchObject({
+      data: undefined,
+      isFetching: true,
     });
   });
 
   it("should set isUpdating to false after token fetch completes", async () => {
-    jest.mocked(mockAuthApi.getToken).mockResolvedValue(mockTokenResponse);
+    mockAuthApi.getToken.mockResolvedValue(mockTokenResponse);
 
     const { result } = renderHook(() =>
-      useTamboSessionToken(mockTamboAI, "user-token"),
+      useTamboSessionToken(mockTamboAI, queryClient, "user-token"),
     );
 
     // Should be updating initially
-    expect(result.current).toEqual({
-      tamboSessionToken: null,
-      isUpdating: true,
+    expect(result.current).toMatchObject({
+      data: undefined,
+      isFetching: true,
     });
 
     await act(async () => {
@@ -304,35 +329,34 @@ describe("useTamboSessionToken", () => {
     });
 
     // Should not be updating after completion
-    expect(result.current).toEqual({
-      tamboSessionToken: "test-access-token",
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: mockTokenResponse,
+      isFetching: false,
     });
   });
 
   it("should set isUpdating to false after token fetch fails", async () => {
-    jest
-      .mocked(mockAuthApi.getToken)
-      .mockRejectedValue(new Error("Token fetch failed"));
+    mockAuthApi.getToken.mockRejectedValue(new Error("Token fetch failed"));
 
     const { result } = renderHook(() =>
-      useTamboSessionToken(mockTamboAI, "user-token"),
+      useTamboSessionToken(mockTamboAI, queryClient, "user-token"),
     );
 
     // Should be updating initially
-    expect(result.current).toEqual({
-      tamboSessionToken: null,
-      isUpdating: true,
+    expect(result.current).toMatchObject({
+      data: undefined,
+      isFetching: true,
     });
 
     await act(async () => {
-      await jest.runOnlyPendingTimersAsync();
+      await jest.runAllTimersAsync();
     });
 
     // Should not be updating after failure
-    expect(result.current).toEqual({
-      tamboSessionToken: null,
-      isUpdating: false,
+    expect(result.current).toMatchObject({
+      data: undefined,
+      error: expect.any(Error),
+      isFetching: false,
     });
   });
 });

--- a/react-sdk/src/providers/hooks/use-tambo-session-token.tsx
+++ b/react-sdk/src/providers/hooks/use-tambo-session-token.tsx
@@ -94,7 +94,6 @@ export function useTamboSessionToken(
       if (expireTimer) {
         clearTimeout(expireTimer);
       }
-      setIsUpdating(false);
     };
   }, [client, isExpired, userToken]);
 

--- a/react-sdk/src/providers/hooks/use-tambo-session-token.tsx
+++ b/react-sdk/src/providers/hooks/use-tambo-session-token.tsx
@@ -1,6 +1,7 @@
 "use client";
 import TamboAI from "@tambo-ai/typescript-sdk";
-import { useEffect, useState } from "react";
+import { QueryClient, useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 
 /**
  * This internal hook is used to get the Tambo session token and keep it
@@ -11,91 +12,46 @@ import { useEffect, useState } from "react";
  *
  * This hook is used by the TamboClientProvider.
  * @param client - The Tambo client.
+ * @param queryClient - The query client.
  * @param userToken - The user token.
  * @returns The Tambo session token.
  */
 export function useTamboSessionToken(
   client: TamboAI,
+  queryClient: QueryClient,
   userToken: string | undefined,
 ) {
-  const [tamboSessionToken, setTamboSessionToken] = useState<string | null>(
-    null,
-  );
-  // we need to set this to true when the token is expired, this is effectively
-  // like a dirty bit, which will trigger a new useEffect()
-  const [isExpired, setIsExpired] = useState(true);
-  const [isUpdating, setIsUpdating] = useState(false);
-  useEffect(() => {
-    let expireTimer: NodeJS.Timeout | null = null;
-
-    async function updateToken(
-      subjectToken: string,
-      abortController: AbortController,
-    ) {
-      if (abortController.signal.aborted || !userToken) {
-        return;
-      }
-
-      setIsUpdating(true);
-      const tokenRequest = {
-        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-        subject_token: subjectToken,
-        subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
-      };
-      const tokenRequestFormEncoded = new URLSearchParams(
-        tokenRequest,
-      ).toString();
-      const tokenAsArrayBuffer = new TextEncoder().encode(
-        tokenRequestFormEncoded,
-      );
-
-      try {
-        const tamboToken = await client.beta.auth.getToken(
-          tokenAsArrayBuffer as any,
+  const result = useQuery(
+    {
+      queryKey: ["tambo-session-token", userToken],
+      queryFn: async () => {
+        const tokenRequest = {
+          grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+          // will only be undefined if the userToken is not provided, in which case the query will be disabled.
+          subject_token: userToken!,
+          subject_token_type: "urn:ietf:params:oauth:token-type:access_token",
+        };
+        const tokenRequestFormEncoded = new URLSearchParams(
+          tokenRequest,
+        ).toString();
+        const tokenAsArrayBuffer = new TextEncoder().encode(
+          tokenRequestFormEncoded,
         );
-
-        if (abortController.signal.aborted) {
-          return;
+        return await client.beta.auth.getToken(tokenAsArrayBuffer as any);
+      },
+      enabled: !!userToken,
+      refetchInterval: (result) => {
+        if (result.state.data?.expires_in) {
+          return result.state.data.expires_in * 1000;
         }
-        setTamboSessionToken(tamboToken.access_token);
-        client.bearer = tamboToken.access_token;
-        setIsExpired(false);
-
-        // we need to set a timer to refresh the token when it expires
-        const refreshTime = Math.max(tamboToken.expires_in - 60, 0);
-
-        // careful with the assignment here: since this is an async function, this
-        // code is executed outside the of the scope of the useEffect() hook, so
-        // we need to use a let variable to store the timer
-        expireTimer = setTimeout(() => {
-          setIsExpired(true);
-        }, refreshTime * 1000);
-      } catch (error) {
-        if (!abortController.signal.aborted) {
-          console.error("Failed to get token:", error);
-        }
-      } finally {
-        if (!abortController.signal.aborted) {
-          setIsUpdating(false);
-        }
-      }
-    }
-
-    const abortController = new AbortController();
-    if (userToken && isExpired) {
-      updateToken(userToken, abortController);
-    } else if (!userToken) {
-      setIsUpdating(false);
-    }
-
-    return () => {
-      // This fires when the component unmounts or the userToken changes
-      abortController.abort();
-      if (expireTimer) {
-        clearTimeout(expireTimer);
-      }
-    };
-  }, [client, isExpired, userToken]);
-
-  return { tamboSessionToken, isUpdating };
+        return false;
+      },
+    },
+    queryClient,
+  );
+  const accessToken = result.data?.access_token ?? null;
+  useEffect(() => {
+    client.bearer = accessToken;
+  }, [accessToken, client]);
+  return result;
 }

--- a/react-sdk/src/providers/tambo-client-provider.tsx
+++ b/react-sdk/src/providers/tambo-client-provider.tsx
@@ -72,14 +72,18 @@ export const TamboClientProvider: React.FC<
   const [queryClient] = useState(() => new QueryClient());
 
   // Keep the session token updated and get the updating state
-  const { isUpdating } = useTamboSessionToken(client, userToken);
+  const { isFetching: isUpdatingToken } = useTamboSessionToken(
+    client,
+    queryClient,
+    userToken,
+  );
 
   return (
     <TamboClientContext.Provider
       value={{
         client,
         queryClient,
-        isUpdatingToken: isUpdating,
+        isUpdatingToken,
       }}
     >
       {children}

--- a/react-sdk/src/providers/tambo-client-provider.tsx
+++ b/react-sdk/src/providers/tambo-client-provider.tsx
@@ -34,6 +34,8 @@ export interface TamboClientContextProps {
   client: TamboAI;
   /** The tambo-specific query client */
   queryClient: QueryClient;
+  /** Whether the session token is currently being updated */
+  isUpdatingToken: boolean;
 }
 
 export const TamboClientContext = createContext<
@@ -69,11 +71,17 @@ export const TamboClientProvider: React.FC<
   const [client] = useState(() => new TamboAI(tamboConfig));
   const [queryClient] = useState(() => new QueryClient());
 
-  // Keep the session token updated
-  useTamboSessionToken(client, userToken);
+  // Keep the session token updated and get the updating state
+  const { isUpdating } = useTamboSessionToken(client, userToken);
 
   return (
-    <TamboClientContext.Provider value={{ client, queryClient }}>
+    <TamboClientContext.Provider
+      value={{
+        client,
+        queryClient,
+        isUpdatingToken: isUpdating,
+      }}
+    >
       {children}
     </TamboClientContext.Provider>
   );
@@ -106,4 +114,18 @@ export const useTamboQueryClient = () => {
     );
   }
   return context.queryClient;
+};
+
+/**
+ * Hook to check if the session token is currently being updated
+ * @returns true if the token is being refreshed, false otherwise
+ */
+export const useIsTamboTokenUpdating = () => {
+  const context = React.useContext(TamboClientContext);
+  if (context === undefined) {
+    throw new Error(
+      "useIsTamboTokenUpdating must be used within a TamboClientProvider",
+    );
+  }
+  return context.isUpdatingToken;
 };

--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -5,6 +5,7 @@ import {
   TamboClientContextProps,
   TamboClientProvider,
   TamboClientProviderProps,
+  useIsTamboTokenUpdating,
   useTamboClient,
   useTamboQueryClient,
 } from "./tambo-client-provider";
@@ -51,6 +52,7 @@ import {
  * @param props.tools - The tools to register
  * @param props.streaming - Whether to stream the response by default. Defaults to true.
  * @param props.contextHelpers - Configuration for which context helpers are enabled/disabled
+ * @param props.userToken - The user token to use to identify the user in the Tambo API
  * @param props.contextKey - Optional context key to be used in the thread input provider.
  * @param props.userToken - Optional user token to be used in the TamboClientProvider for requests to the Tambo API.
  * @returns The TamboProvider component
@@ -128,6 +130,7 @@ export const TamboCompositeProvider: React.FC<PropsWithChildren> = ({
   const threads = useTamboThread();
   const client = useTamboClient();
   const queryClient = useTamboQueryClient();
+  const isUpdatingToken = useIsTamboTokenUpdating();
   const componentRegistry = useTamboComponent();
   const interactableComponents = useTamboInteractable();
   const contextHelpers = useTamboContextHelpers();
@@ -137,6 +140,7 @@ export const TamboCompositeProvider: React.FC<PropsWithChildren> = ({
       value={{
         client,
         queryClient,
+        isUpdatingToken,
         ...componentRegistry,
         ...threads,
         ...interactableComponents,

--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -52,9 +52,8 @@ import {
  * @param props.tools - The tools to register
  * @param props.streaming - Whether to stream the response by default. Defaults to true.
  * @param props.contextHelpers - Configuration for which context helpers are enabled/disabled
- * @param props.userToken - The user token to use to identify the user in the Tambo API
- * @param props.contextKey - Optional context key to be used in the thread input provider.
- * @param props.userToken - Optional user token to be used in the TamboClientProvider for requests to the Tambo API.
+ * @param props.userToken - The JWT id token to use to identify the user in the Tambo API. (preferred over contextKey)
+ * @param props.contextKey - Optional context key to be used in the thread input provider
  * @returns The TamboProvider component
  */
 export const TamboProvider: React.FC<

--- a/react-sdk/src/providers/tambo-stubs.tsx
+++ b/react-sdk/src/providers/tambo-stubs.tsx
@@ -53,11 +53,20 @@ const TamboStubClientProvider: React.FC<
   PropsWithChildren<{
     client: TamboAI;
     queryClient: QueryClient;
+    isUpdatingToken: boolean;
     threads?: Partial<TamboAI.Beta.Threads.ThreadsOffsetAndLimit>;
     projectId?: string;
     contextKey?: string;
   }>
-> = ({ children, client, queryClient, threads, projectId, contextKey }) => {
+> = ({
+  children,
+  client,
+  queryClient,
+  threads,
+  projectId,
+  contextKey,
+  isUpdatingToken,
+}) => {
   // Prepopulate the query cache with threads data if provided
   useEffect(() => {
     if (threads) {
@@ -70,7 +79,9 @@ const TamboStubClientProvider: React.FC<
   }, [threads, projectId, contextKey, queryClient]);
 
   return (
-    <TamboClientContext.Provider value={{ client, queryClient }}>
+    <TamboClientContext.Provider
+      value={{ client, queryClient, isUpdatingToken }}
+    >
       {children}
     </TamboClientContext.Provider>
   );
@@ -344,6 +355,7 @@ export const TamboStubProvider: React.FC<
       threads={threads}
       projectId={resolvedProjectId}
       contextKey={contextKey}
+      isUpdatingToken={false}
     >
       <TamboStubRegistryProvider
         componentList={componentList}

--- a/react-sdk/src/providers/tambo-thread-input-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-input-provider.tsx
@@ -58,7 +58,9 @@ export interface TamboThreadInputProviderProps {
  * Provider that manages shared thread input state across all components
  * This ensures that useTamboThreadInput, useTamboSuggestions, and components
  * all share the same input state
- * @param contextKey - Optional context key.
+ * @param props - The props for the TamboThreadInputProvider
+ * @param props.contextKey - Optional context key.
+ * @param props.children - The children to render.
  * @returns The thread input context
  */
 export const TamboThreadInputProvider: React.FC<


### PR DESCRIPTION
exposes an `isUpdating` field from `useTamboSessionToken`, and exposes the resulting value from client provider.