### PR TITLE
Migrate from react-markdown to streamdown for AI Streaming

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -66,8 +66,10 @@
     "meow": "^13.2.0",
     "open": "^10.2.0",
     "ora": "^8.1.0",
+    "react-markdown": "^10.1.0",
     "sanitize-html": "^2.17.0",
     "semver": "^7.7.2",
+    "streamdown": "^1.1.3",
     "ts-morph": "^26.0.0"
   },
   "devDependencies": {

--- a/cli/src/registry/message-input/config.json
+++ b/cli/src/registry/message-input/config.json
@@ -9,7 +9,7 @@
     "radix-ui",
     "react-dom",
     "framer-motion",
-    "react-markdown"
+    "streamdown"
   ],
   "devDependencies": [],
   "requires": [],

--- a/cli/src/registry/message-input/mcp-config-modal.tsx
+++ b/cli/src/registry/message-input/mcp-config-modal.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@radix-ui/react-dropdown-menu";
 import { createMarkdownComponents } from "@/components/ui/markdown-components";
-import Markdown from "react-markdown";
+import { Streamdown } from "streamdown";
 import { cn } from "@/lib/utils";
 
 /**
@@ -219,9 +219,9 @@ function MyApp() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.3 }}
               >
-                <Markdown components={createMarkdownComponents()}>
+                <Streamdown components={createMarkdownComponents()}>
                   {instructions}
-                </Markdown>
+                </Streamdown>
               </motion.div>
             )}
           </div>

--- a/cli/src/registry/message/config.json
+++ b/cli/src/registry/message/config.json
@@ -4,7 +4,7 @@
   "componentName": "Message",
   "dependencies": [
     "class-variance-authority",
-    "react-markdown",
+    "streamdown",
     "lucide-react",
     "highlight.js",
     "@tambo-ai/react",

--- a/cli/src/registry/message/markdown-components.tsx
+++ b/cli/src/registry/message/markdown-components.tsx
@@ -9,7 +9,7 @@ import "highlight.js/styles/github.css";
 import DOMPurify from "dompurify";
 
 /**
- * Markdown Components for React-Markdown
+ * Markdown Components for Streamdown
  *
  * This module provides customized components for rendering markdown content with syntax highlighting.
  * It uses highlight.js for code syntax highlighting and supports streaming content updates.
@@ -17,11 +17,11 @@ import DOMPurify from "dompurify";
  * @example
  * ```tsx
  * import { createMarkdownComponents } from './markdown-components';
- * import ReactMarkdown from 'react-markdown';
+ * import { Streamdown } from 'streamdown';
  *
  * const MarkdownRenderer = ({ content }) => {
- *   const components = createMarkdownComponents('light');
- *   return <ReactMarkdown components={components}>{content}</ReactMarkdown>;
+ *   const components = createMarkdownComponents();
+ *   return <Streamdown components={components}>{content}</Streamdown>;
  * };
  * ```
  */
@@ -86,9 +86,8 @@ const CodeHeader = ({
 };
 
 /**
- * Creates a set of components for use with react-markdown
- * @param theme - The theme to use ('light' or 'dark')
- * @returns Components object for react-markdown
+ * Creates a set of components for use with streamdown
+ * @returns Components object for streamdown
  */
 export const createMarkdownComponents = (): Components => ({
   code: function Code({ className, children, ...props }) {

--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -10,7 +10,7 @@ import stringify from "json-stringify-pretty-compact";
 import { Check, ChevronDown, ExternalLink, Loader2, X } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
+import { Streamdown } from "streamdown";
 import { createMarkdownComponents } from "@/components/ui/markdown-components";
 
 /**
@@ -225,9 +225,9 @@ const MessageContent = React.forwardRef<HTMLDivElement, MessageContentProps>(
             ) : React.isValidElement(contentToRender) ? (
               contentToRender
             ) : markdown ? (
-              <ReactMarkdown components={createMarkdownComponents()}>
+              <Streamdown components={createMarkdownComponents()}>
                 {typeof safeContent === "string" ? safeContent : ""}
-              </ReactMarkdown>
+              </Streamdown>
             ) : (
               safeContent
             )}

--- a/cli/src/types/utils.d.ts
+++ b/cli/src/types/utils.d.ts
@@ -5,7 +5,7 @@
  *
  * This file provides type definitions for:
  * - Internal utility functions (@/lib/utils) - created during component installation, declared here to avoid creating lib folder in CLI
- * - React Markdown components
+ * - Streamdown components
  * - Highlight.js
  * - Dompurify
  * - Json-stringify-pretty-compact
@@ -20,18 +20,17 @@ declare module "@/lib/utils" {
   export function cn(...inputs: ClassValue[]): string;
 }
 
-declare module "react-markdown" {
+declare module "streamdown" {
   import type * as React from "react";
-  interface ReactMarkdownProps {
+  interface StreamdownProps {
     children: string;
     className?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     components?: Record<string, React.ComponentType<any>>;
   }
-  const ReactMarkdown: React.ComponentType<ReactMarkdownProps>;
+  export const Streamdown: React.ComponentType<StreamdownProps>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export type Components = Record<string, React.ComponentType<any>>;
-  export default ReactMarkdown;
 }
 
 declare module "highlight.js" {

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,8 @@
     "radix-ui": "^1.4.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "streamdown": "^1.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/docs/src/components/tambo/markdown-components.tsx
+++ b/docs/src/components/tambo/markdown-components.tsx
@@ -9,7 +9,7 @@ import "highlight.js/styles/github.css";
 import DOMPurify from "dompurify";
 
 /**
- * Markdown Components for React-Markdown
+ * Markdown Components for Streamdown
  *
  * This module provides customized components for rendering markdown content with syntax highlighting.
  * It uses highlight.js for code syntax highlighting and supports streaming content updates.
@@ -17,11 +17,11 @@ import DOMPurify from "dompurify";
  * @example
  * ```tsx
  * import { createMarkdownComponents } from './markdown-components';
- * import ReactMarkdown from 'react-markdown';
+ * import { Streamdown } from 'streamdown';
  *
  * const MarkdownRenderer = ({ content }) => {
- *   const components = createMarkdownComponents('light');
- *   return <ReactMarkdown components={components}>{content}</ReactMarkdown>;
+ *   const components = createMarkdownComponents();
+ *   return <Streamdown components={components}>{content}</Streamdown>;
  * };
  * ```
  */
@@ -86,9 +86,8 @@ const CodeHeader = ({
 };
 
 /**
- * Creates a set of components for use with react-markdown
- * @param theme - The theme to use ('light' or 'dark')
- * @returns Components object for react-markdown
+ * Creates a set of components for use with streamdown
+ * @returns Components object for streamdown
  */
 export const createMarkdownComponents = (): Components => ({
   code: function Code({ className, children, ...props }) {

--- a/docs/src/components/tambo/mcp-config-modal.tsx
+++ b/docs/src/components/tambo/mcp-config-modal.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@radix-ui/react-dropdown-menu";
 import { createMarkdownComponents } from "@/components/tambo/markdown-components";
-import Markdown from "react-markdown";
+import { Streamdown } from "streamdown";
 import { cn } from "@/lib/utils";
 
 /**
@@ -219,9 +219,9 @@ function MyApp() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.3 }}
               >
-                <Markdown components={createMarkdownComponents()}>
+                <Streamdown components={createMarkdownComponents()}>
                   {instructions}
-                </Markdown>
+                </Streamdown>
               </motion.div>
             )}
           </div>

--- a/docs/src/components/tambo/message.tsx
+++ b/docs/src/components/tambo/message.tsx
@@ -10,7 +10,7 @@ import stringify from "json-stringify-pretty-compact";
 import { Check, ChevronDown, ExternalLink, Loader2, X } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
+import { Streamdown } from "streamdown";
 import { createMarkdownComponents } from "@/components/tambo/markdown-components";
 
 /**
@@ -225,9 +225,9 @@ const MessageContent = React.forwardRef<HTMLDivElement, MessageContentProps>(
             ) : React.isValidElement(contentToRender) ? (
               contentToRender
             ) : markdown ? (
-              <ReactMarkdown components={createMarkdownComponents()}>
+              <Streamdown components={createMarkdownComponents()}>
                 {typeof safeContent === "string" ? safeContent : ""}
-              </ReactMarkdown>
+              </Streamdown>
             ) : (
               safeContent
             )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,8 +45,10 @@
         "meow": "^13.2.0",
         "open": "^10.2.0",
         "ora": "^8.1.0",
+        "react-markdown": "^10.1.0",
         "sanitize-html": "^2.17.0",
         "semver": "^7.7.2",
+        "streamdown": "^1.1.3",
         "ts-morph": "^26.0.0"
       },
       "bin": {
@@ -140,7 +142,8 @@
         "radix-ui": "^1.4.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "streamdown": "^1.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.12",
@@ -8781,6 +8784,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/leaflet": {
       "version": "1.9.20",
       "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.20.tgz",
@@ -14657,6 +14666,16 @@
         "uglify-js": "^3.1.4"
       }
     },
+    "node_modules/harden-react-markdown": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/harden-react-markdown/-/harden-react-markdown-1.0.5.tgz",
+      "integrity": "sha512-uN+PdsmySN4gdczqM0DXzltS4dELSO4U/p/QVLiiypyZMBR1CaewgQTI7ZxArFazBoCk7lGRVvYsyxos0VHGNg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-markdown": ">=9.0.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -14744,6 +14763,101 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-to-estree": {
@@ -14837,6 +14951,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -14844,6 +14974,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -18934,9 +19081,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.1.tgz",
-      "integrity": "sha512-ij/2lXfCRT71L6u0M29tJPhP0bM5shLL3u5BePhFwPELj2blMJ6GDtD7PfJhRLhJ/c2UwrK17ySVcDzy2YHjHQ==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.2.0.tgz",
+      "integrity": "sha512-LbbTuye+0dWRz2TS9KJ7wsnD4KAtpj0MVkWc90XvBa6AslXsT0hTBVH5k32pcSyHH1fst9XEFJunXHktVy0zlg==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -19101,6 +19248,25 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -19516,6 +19682,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -21000,7 +21185,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -21013,7 +21197,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -22250,6 +22433,25 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-recma": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
@@ -22292,6 +22494,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -23262,6 +23480,38 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamdown": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/streamdown/-/streamdown-1.1.3.tgz",
+      "integrity": "sha512-8Zw8n6NmMX1GSAHmWqCjap6/w42jQiJ7H3C3axXJKHcATSWCusg5VJfFz6bwSlaWEzw1OFWoZY+nyo1v8IddFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "harden-react-markdown": "^1.0.4",
+        "katex": "^0.16.22",
+        "lucide-react": "^0.541.0",
+        "marked": "^16.1.2",
+        "mermaid": "^11.0.0",
+        "react-markdown": "^10.1.0",
+        "rehype-katex": "^7.0.1",
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
+        "shiki": "^3.9.2",
+        "tailwind-merge": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/streamdown/node_modules/lucide-react": {
+      "version": "0.541.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.541.0.tgz",
+      "integrity": "sha512-s0Vircsu5WaGv2KoJZ5+SoxiAJ3UXV5KqEM3eIFDHaHkcLIFdIWgXtZ412+Gh02UsdS7Was+jvEpBvPCWQISlg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/string-argv": {
@@ -24733,6 +24983,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
@@ -24766,6 +25030,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -25025,6 +25303,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
@@ -25131,6 +25423,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -25831,6 +26133,7 @@
         "react-leaflet": "^4.2.1",
         "react-markdown": "^10.1.0",
         "recharts": "^3.1.2",
+        "streamdown": "^1.0.0",
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
     "react-markdown": "^10.1.0",
+    "streamdown": "^1.0.0",
     "recharts": "^3.1.2",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/showcase/src/components/ui/markdown-components.tsx
+++ b/showcase/src/components/ui/markdown-components.tsx
@@ -9,7 +9,7 @@ import "highlight.js/styles/github.css";
 import DOMPurify from "dompurify";
 
 /**
- * Markdown Components for React-Markdown
+ * Markdown Components for Streamdown
  *
  * This module provides customized components for rendering markdown content with syntax highlighting.
  * It uses highlight.js for code syntax highlighting and supports streaming content updates.
@@ -17,11 +17,11 @@ import DOMPurify from "dompurify";
  * @example
  * ```tsx
  * import { createMarkdownComponents } from './markdown-components';
- * import ReactMarkdown from 'react-markdown';
+ * import { Streamdown } from 'streamdown';
  *
  * const MarkdownRenderer = ({ content }) => {
- *   const components = createMarkdownComponents('light');
- *   return <ReactMarkdown components={components}>{content}</ReactMarkdown>;
+ *   const components = createMarkdownComponents();
+ *   return <Streamdown components={components}>{content}</Streamdown>;
  * };
  * ```
  */
@@ -86,9 +86,8 @@ const CodeHeader = ({
 };
 
 /**
- * Creates a set of components for use with react-markdown
- * @param theme - The theme to use ('light' or 'dark')
- * @returns Components object for react-markdown
+ * Creates a set of components for use with streamdown
+ * @returns Components object for streamdown
  */
 export const createMarkdownComponents = (): Components => ({
   code: function Code({ className, children, ...props }) {

--- a/showcase/src/components/ui/mcp-config-modal.tsx
+++ b/showcase/src/components/ui/mcp-config-modal.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@radix-ui/react-dropdown-menu";
 import { createMarkdownComponents } from "@/components/ui/markdown-components";
-import Markdown from "react-markdown";
+import { Streamdown } from "streamdown";
 import { cn } from "@/lib/utils";
 
 /**
@@ -219,9 +219,9 @@ function MyApp() {
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.3 }}
               >
-                <Markdown components={createMarkdownComponents()}>
+                <Streamdown components={createMarkdownComponents()}>
                   {instructions}
-                </Markdown>
+                </Streamdown>
               </motion.div>
             )}
           </div>

--- a/showcase/src/components/ui/message.tsx
+++ b/showcase/src/components/ui/message.tsx
@@ -11,7 +11,7 @@ import stringify from "json-stringify-pretty-compact";
 import { Check, ChevronDown, ExternalLink, Loader2, X } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
-import ReactMarkdown from "react-markdown";
+import { Streamdown } from "streamdown";
 
 /**
  * CSS variants for the message container
@@ -226,9 +226,9 @@ const MessageContent = React.forwardRef<HTMLDivElement, MessageContentProps>(
             ) : React.isValidElement(contentToRender) ? (
               contentToRender
             ) : markdown ? (
-              <ReactMarkdown components={createMarkdownComponents()}>
+              <Streamdown components={createMarkdownComponents()}>
                 {typeof safeContent === "string" ? safeContent : ""}
-              </ReactMarkdown>
+              </Streamdown>
             ) : (
               safeContent
             )}
@@ -369,14 +369,14 @@ const ToolcallInfo = React.forwardRef<HTMLDivElement, ToolcallInfoProps>(
                   ) : React.isValidElement(associatedToolResponse.content) ? (
                     associatedToolResponse.content
                   ) : markdown ? (
-                    <ReactMarkdown components={createMarkdownComponents()}>
+                    <Streamdown components={createMarkdownComponents()}>
                       {typeof getSafeContent(associatedToolResponse.content) ===
                       "string"
                         ? (getSafeContent(
                             associatedToolResponse.content,
                           ) as string)
                         : ""}
-                    </ReactMarkdown>
+                    </Streamdown>
                   ) : (
                     getSafeContent(associatedToolResponse.content)
                   )}


### PR DESCRIPTION
## What's Changed
- Replaced react-markdown with streamdown across CLI, showcase, and docs packages
- Updated all message components and MCP modals to use streaming markdown rendering
- Added react-markdown as direct dependency for TypeScript resolution
## Why do we still have react-markdown?
Streamdown is a drop-in replacement that intentionally doesn't re-export the components type to avoid duplication and ensure compatibility with the existing react-markdown ecosystem.

ps: this feat was suggested by @michaelmagan in [tambo's discord server](https://discord.gg/hpT8n7XdyN) - [message link](https://discord.com/channels/1251581895414911016/1251581896920530985/1408131952451518537)