### PR TITLE
feat(context-helpers): remove global context helper registry

### DIFF
--- a/react-sdk/src/context-helpers/__tests__/context-helpers-provider.test.tsx
+++ b/react-sdk/src/context-helpers/__tests__/context-helpers-provider.test.tsx
@@ -12,9 +12,8 @@
  *  - The provider aggregates helpers passed in its props and returns AdditionalContext[].
  */
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import React, { PropsWithChildren } from "react";
-import { setHelpers } from "../../context-helpers/registry";
 import {
   TamboContextHelpersProvider,
   useTamboContextHelpers,
@@ -46,7 +45,6 @@ function wrapper(helpers?: Record<string, ContextHelperFn>) {
 describe("Context Helpers API", () => {
   // Ensure the global registry doesn't leak state between tests
   beforeEach(() => {
-    setHelpers({});
     jest.clearAllMocks();
   });
 
@@ -133,7 +131,10 @@ describe("Context Helpers API", () => {
     expect(await result.current.getAdditionalContext()).toHaveLength(0);
 
     // Add
-    result.current.addContextHelper("dyn", () => ({ x: 10 }));
+    act(() => {
+      result.current.addContextHelper("dyn", () => ({ x: 10 }));
+    });
+
     let contexts = await result.current.getAdditionalContext();
     expect(contexts).toHaveLength(1);
     expect(contexts[0]).toEqual<AdditionalContext>({
@@ -142,7 +143,9 @@ describe("Context Helpers API", () => {
     });
 
     // Update
-    result.current.addContextHelper("dyn", () => ({ x: 20 }));
+    act(() => {
+      result.current.addContextHelper("dyn", () => ({ x: 20 }));
+    });
     contexts = await result.current.getAdditionalContext();
     expect(contexts).toHaveLength(1);
     expect(contexts[0]).toEqual<AdditionalContext>({
@@ -151,7 +154,9 @@ describe("Context Helpers API", () => {
     });
 
     // Remove
-    result.current.removeContextHelper("dyn");
+    act(() => {
+      result.current.removeContextHelper("dyn");
+    });
     contexts = await result.current.getAdditionalContext();
     expect(contexts).toHaveLength(0);
   });

--- a/react-sdk/src/context-helpers/registry.ts
+++ b/react-sdk/src/context-helpers/registry.ts
@@ -9,48 +9,13 @@ export type HelperFn = () =>
   | undefined
   | Promise<any | null | undefined>;
 
-let helpers: Record<string, HelperFn> = {};
-
-/**
- * Get the current helpers map (by reference).
- * @returns The current helpers map.
- */
-export function getHelpers(): Record<string, HelperFn> {
-  return helpers;
-}
-
-/**
- * Replace the entire helpers map (used for hydration/reset in tests).
- * @param next - The new helpers map.
- */
-export function setHelpers(next: Record<string, HelperFn>) {
-  helpers = next;
-}
-
-/**
- * Add or replace a helper.
- * @param name - The name of the helper.
- * @param fn - The helper function.
- */
-export function addHelper(name: string, fn: HelperFn) {
-  helpers[name] = fn;
-}
-
-/**
- * Remove a helper by name.
- * @param name - The name of the helper.
- */
-export function removeHelper(name: string) {
-  delete helpers[name];
-}
-
 /**
  * Resolve all helpers to AdditionalContext entries, skipping null/undefined and errors.
  * @returns The resolved additional context.
  */
-export async function resolveAdditionalContext(): Promise<
-  { name: string; context: any }[]
-> {
+export async function resolveAdditionalContext(
+  helpers: Record<string, HelperFn>,
+): Promise<{ name: string; context: any }[]> {
   const entries = Object.entries(helpers);
   if (entries.length === 0) return [];
 

--- a/react-sdk/src/providers/__tests__/tambo-context-helpers-provider.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-context-helpers-provider.test.tsx
@@ -34,43 +34,6 @@ describe("TamboContextHelpersProvider", () => {
 
   describe("useTamboContextHelpers", () => {
     /**
-     * NOTE: The hook is registry-backed and safe outside provider. It should not throw.
-     * This replaces the previous behavior that threw without a provider.
-     */
-    it("should be safe outside provider (registry-backed no provider)", async () => {
-      const consoleSpy = jest
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      const { result } = renderHook(() => useTamboContextHelpers());
-
-      // Should return callable functions
-      expect(typeof result.current.getAdditionalContext).toBe("function");
-      expect(typeof result.current.getContextHelpers).toBe("function");
-      expect(typeof result.current.addContextHelper).toBe("function");
-      expect(typeof result.current.removeContextHelper).toBe("function");
-
-      // Starts empty
-      expect(await result.current.getAdditionalContext()).toHaveLength(0);
-
-      // Add a helper and verify
-      act(() => {
-        result.current.addContextHelper("outsideHelper", () => ({ ok: true }));
-      });
-
-      const contexts = await result.current.getAdditionalContext();
-      expect(contexts).toContainEqual({
-        name: "outsideHelper",
-        context: { ok: true },
-      });
-
-      // Cleanup
-      act(() => {
-        result.current.removeContextHelper("outsideHelper");
-      });
-      consoleSpy.mockRestore();
-    });
-
-    /**
      * Verifies that the hook returns the expected API functions when used within a provider.
      */
     it("should provide context helpers functions (inside provider)", () => {

--- a/react-sdk/src/providers/__tests__/tambo-context-helpers-provider.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-context-helpers-provider.test.tsx
@@ -4,7 +4,6 @@ import {
   currentPageContextHelper,
   currentTimeContextHelper,
 } from "../../context-helpers";
-import { setHelpers } from "../../context-helpers/registry";
 import {
   TamboContextHelpersProvider,
   useTamboContextHelpers,
@@ -25,7 +24,6 @@ import {
 describe("TamboContextHelpersProvider", () => {
   // Ensure registry is clean for each test to avoid cross-test contamination
   beforeEach(() => {
-    setHelpers({});
     jest.clearAllMocks();
   });
 
@@ -170,7 +168,6 @@ describe("TamboContextHelpersProvider", () => {
  */
 describe("Custom Context Helpers via contextHelpers config", () => {
   beforeEach(() => {
-    setHelpers({});
     jest.clearAllMocks();
   });
 


### PR DESCRIPTION
doing global registration is an anti-pattern in react, and may break some apps, especially those that have multiple react roots
