### PR TITLE
feat(interactables):   Add automatic context injection for interactable components that sends their current state to the AI by default.

### DIFF
--- a/docs/content/docs/concepts/additional-context/index.mdx
+++ b/docs/content/docs/concepts/additional-context/index.mdx
@@ -113,7 +113,9 @@ All three methods can be used together—context from helpers and manual context
 | Custom Helpers   | You have app-wide context that should always be included | User profile, app settings, feature flags              |
 | Manual Context   | Context is specific to a particular interaction          | Search filters, form data, temporary state             |
 
-## Available Prebuilt Context Helpers
+## Available Prebuilt Context Helpers (On by Default)
+
+These helpers are automatically enabled when using the corresponding provider. You can disable them by overriding them with a function that returns null.
 
 ### currentTimeContextHelper
 
@@ -139,6 +141,31 @@ Example result:
   "title": "Analytics Dashboard"
 }
 ```
+
+### currentInteractablesContextHelper
+
+**Automatically enabled** when using `TamboInteractableProvider`. Provides information about all interactable components currently on the page that the AI can read and modify.
+
+We found this to be the most effective way to provide the AI with information about the current page and the components on the page. It's easy to disable or customize as needed.
+
+Example result:
+
+```json
+{
+  "description": "These are the interactable components currently visible on the page...",
+  "components": [
+    {
+      "id": "Note-abc123",
+      "componentName": "Note",
+      "description": "A simple note",
+      "props": { "title": "My Note", "content": "Hello world" },
+      "propsSchema": "Available - use component-specific update tools"
+    }
+  ]
+}
+```
+
+See [Interactable Components](/concepts/components/interactable-components) for details on customizing or disabling this helper.
 
 **Notes:**
 

--- a/docs/content/docs/concepts/components/interactable-components.mdx
+++ b/docs/content/docs/concepts/components/interactable-components.mdx
@@ -117,3 +117,167 @@ function App() {
 ```
 
 This creates a truly conversational interface where users can modify your UI through natural language, making your applications more accessible and user-friendly.
+
+## Automatic Context Awareness
+
+When you use `TamboInteractableProvider`, your interactable components are automatically included in the AI's context. This means:
+
+- The AI knows what components are currently on the page
+- Users can ask "What's on this page?" and get a comprehensive answer
+- The AI can see the current state (props) of all interactable components
+- Component changes are reflected in real-time
+
+**No additional setup required** - this context is provided automatically and can be customized or disabled if needed.
+
+### Example Interactions
+
+With interactable components on the page, users can ask:
+
+- "What components are available?"
+- "Change the note title to 'Important Reminder'"
+- "Show me the current state of all my components"
+- "Make the counter red and set it to 100"
+
+## Customizing Automatic Context
+
+The automatic context can be disabled, enabled selectively, or customized to show only specific information.
+
+### Disable Globally
+
+To disable interactables context across your entire app:
+
+```tsx
+<TamboProvider
+  apiKey={apiKey}
+  contextHelpers={{
+    // Disable interactables context globally
+    interactables: () => null,
+  }}
+>
+  <TamboInteractableProvider>
+    {/* Interactables context is disabled, but components still work */}
+    <InteractableNote title="Hidden from AI" />
+  </TamboInteractableProvider>
+</TamboProvider>
+```
+
+### Enable Locally (Override Global Disable)
+
+If you've disabled it globally but want to enable it for a specific page or section:
+
+```tsx
+function SpecificPage() {
+  const { addContextHelper } = useTamboContextHelpers();
+  const snapshot = useCurrentInteractablesSnapshot();
+
+  React.useEffect(() => {
+    // Re-enable interactables context for this page only
+    const helper = () => {
+      if (snapshot.length === 0) return null;
+
+      return {
+        description: "Interactable components on this page that you can modify",
+        components: snapshot.map((component) => ({
+          id: component.id,
+          componentName: component.name,
+          description: component.description,
+          props: component.props,
+          propsSchema: component.propsSchema ? "Available" : "Not specified",
+        })),
+      };
+    };
+
+    addContextHelper("interactables", helper);
+  }, [addContextHelper, snapshot]);
+
+  return (
+    <TamboInteractableProvider>
+      {/* Context is now enabled for this page */}
+      <InteractableNote title="Visible to AI" />
+    </TamboInteractableProvider>
+  );
+}
+```
+
+### Custom Context (IDs Only Example)
+
+Sometimes you might want to share summary information and have the AI request the full context when needed.
+
+This is an example of how to only IDs and names with every message:
+
+```tsx
+import {
+  useCurrentInteractablesSnapshot,
+  useTamboContextHelpers,
+} from "@tambo-ai/react";
+
+function IdsOnlyInteractables() {
+  const { addContextHelper } = useTamboContextHelpers();
+  const snapshot = useCurrentInteractablesSnapshot();
+
+  React.useEffect(() => {
+    const idsOnlyHelper = () => {
+      if (snapshot.length === 0) return null;
+
+      return {
+        description: "Available interactable component ids.",
+        components: snapshot.map((component) => ({
+          id: component.id,
+          componentName: component.name,
+          // Deliberately omit props.
+        })),
+      };
+    };
+
+    // Override the default helper with our ids only version
+    addContextHelper("interactables", idsOnlyHelper);
+  }, [addContextHelper, snapshot]);
+
+  return null; // This component just sets up the context helper
+}
+
+// Usage
+<TamboInteractableProvider>
+  <PrivacyFriendlyInteractables />
+  <InteractableNote title="Not visible unless requested." />
+  <InteractableCounter count={42} />
+</TamboInteractableProvider>;
+```
+
+### Filter by Component Type
+
+Maybe you only want to show certain types of components.
+
+Here is an example of how you could filter by component type:
+
+```tsx
+function FilteredInteractablesContext() {
+  const { addContextHelper } = useTamboContextHelpers();
+  const snapshot = useCurrentInteractablesSnapshot();
+
+  React.useEffect(() => {
+    const filteredHelper = () => {
+      // Only show Notes and Counters, hide other component types
+      const allowedTypes = ["Note", "Counter"];
+      const filteredComponents = snapshot.filter((component) =>
+        allowedTypes.includes(component.name),
+      );
+
+      if (filteredComponents.length === 0) return null;
+
+      return {
+        description: "Available interactable components (filtered)",
+        components: filteredComponents.map((component) => ({
+          id: component.id,
+          componentName: component.name,
+          props: component.props,
+        })),
+      };
+    };
+
+    addContextHelper("interactables", filteredHelper);
+  }, [addContextHelper, snapshot]);
+
+  return null;
+}
+```

--- a/react-sdk/src/context-helpers/current-interactables-context-helper.ts
+++ b/react-sdk/src/context-helpers/current-interactables-context-helper.ts
@@ -1,0 +1,62 @@
+import { ContextHelperFn } from "./types";
+
+/**
+ * Prebuilt context helper that provides information about all interactable components currently on the page.
+ * This gives the AI awareness of what components it can interact with and their current state.
+ * @returns an object with description and components, or null to skip including this context.
+ * To disable this helper, override it with a function that returns null:
+ * @example
+ * ```tsx
+ * // To disable the default interactables context
+ * const { addContextHelper } = useTamboContextHelpers();
+ * addContextHelper("interactables", () => null);
+ *
+ * // To customize the context
+ * addContextHelper("interactables", () => ({
+ *   description: "Custom description",
+ *   components: getCustomComponentsSubset()
+ * }));
+ * ```
+ */
+export const currentInteractablesContextHelper: ContextHelperFn = () => {
+  // This will be provided by the interactable provider when it registers this helper
+  // Since we're provider-only now, this function gets replaced at runtime
+  return null;
+};
+
+/**
+ * Creates an interactables context helper with access to the current components.
+ * This is used internally by TamboInteractableProvider.
+ * @param getComponents Function to get current interactable components
+ * @returns Context helper function
+ */
+export const createInteractablesContextHelper = (
+  getComponents: () => any[],
+): ContextHelperFn => {
+  return () => {
+    try {
+      const components = getComponents();
+
+      if (!Array.isArray(components) || components.length === 0) {
+        return null; // No interactable components on the page
+      }
+
+      return {
+        description:
+          "These are the interactable components currently visible on the page that you can read and modify. Each component has an id, componentName, current props, and optional schema. You can use tools to update these components on behalf of the user.",
+        components: components.map((component) => ({
+          id: component.id,
+          componentName: component.name,
+          description: component.description,
+          props: component.props,
+          propsSchema: component.propsSchema
+            ? "Available - use component-specific update tools"
+            : "Not specified",
+        })),
+      };
+    } catch (e) {
+      console.error("currentInteractablesContextHelper failed:", e);
+      return null;
+    }
+  };
+};

--- a/react-sdk/src/context-helpers/index.ts
+++ b/react-sdk/src/context-helpers/index.ts
@@ -1,3 +1,4 @@
 export * from "./current-page-context-helper";
 export * from "./current-time-context-helper";
+export * from "./current-interactables-context-helper";
 export * from "./types";

--- a/react-sdk/src/index.ts
+++ b/react-sdk/src/index.ts
@@ -74,7 +74,10 @@ export {
   type InteractableConfig,
   type WithTamboInteractableProps,
 } from "./providers/hoc/with-tambo-interactable";
-export { useTamboInteractable } from "./providers/tambo-interactable-provider";
+export {
+  useTamboInteractable,
+  useCurrentInteractablesSnapshot,
+} from "./providers/tambo-interactable-provider";
 
 // Context helpers exports
 export {

--- a/react-sdk/src/providers/__tests__/tambo-interactables-additional-context-edge-cases.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-interactables-additional-context-edge-cases.test.tsx
@@ -1,0 +1,482 @@
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { z } from "zod";
+import {
+  useTamboContextHelpers,
+  TamboContextHelpersProvider,
+} from "../tambo-context-helpers-provider";
+import { TamboInteractableProvider } from "../tambo-interactable-provider";
+import { TamboStubProvider } from "../tambo-stubs";
+import { withTamboInteractable } from "../hoc/with-tambo-interactable";
+
+function wrapperWithProviders(children: React.ReactNode) {
+  const thread = {
+    id: "t-1",
+    projectId: "p-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    messages: [],
+    metadata: {},
+  } as any;
+
+  return (
+    <TamboStubProvider
+      thread={thread}
+      registerTool={() => {}}
+      registerTools={() => {}}
+      registerComponent={() => {}}
+      addToolAssociation={() => {}}
+    >
+      <TamboContextHelpersProvider>{children}</TamboContextHelpersProvider>
+    </TamboStubProvider>
+  );
+}
+
+describe("Interactables AdditionalContext - Edge Cases & Advanced Scenarios", () => {
+  test("handles components without propsSchema gracefully", async () => {
+    const SimpleComponent: React.FC<{ text: string }> = ({ text }) => (
+      <div>{text}</div>
+    );
+
+    const InteractableSimpleComponent = withTamboInteractable(SimpleComponent, {
+      componentName: "SimpleComponent",
+      description: "A component without schema",
+      // No propsSchema provided
+    });
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            capturedContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <InteractableSimpleComponent text="test" />
+          <TestComponent />
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(entry).toBeDefined();
+      const component = entry!.context.components[0];
+      expect(component.propsSchema).toBe("Not specified");
+    });
+  });
+
+  test("handles component unmounting and remounting correctly", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        const interval = setInterval(() => {
+          getAdditionalContext().then((contexts) => {
+            if (mounted) {
+              capturedContexts = contexts;
+            }
+          });
+        }, 50);
+        return () => {
+          mounted = false;
+          clearInterval(interval);
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const Host = () => {
+      const [showNote, setShowNote] = React.useState(true);
+
+      React.useEffect(() => {
+        // Toggle the note on/off to test unmounting
+        const timeout = setTimeout(() => setShowNote(false), 100);
+        const timeout2 = setTimeout(() => setShowNote(true), 200);
+        return () => {
+          clearTimeout(timeout);
+          clearTimeout(timeout2);
+        };
+      }, []);
+
+      return (
+        <TamboInteractableProvider>
+          {showNote && <InteractableNote title="dynamic note" />}
+          <TestComponent />
+        </TamboInteractableProvider>
+      );
+    };
+
+    const { getByTestId } = render(wrapperWithProviders(<Host />));
+
+    await waitFor(
+      () => {
+        expect(getByTestId("ready")).toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+
+    // Eventually should show the note again
+    await waitFor(
+      () => {
+        const entry = capturedContexts.find(
+          (c: any) => c.name === "interactables",
+        );
+        expect(entry?.context?.components).toHaveLength(1);
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  test("context helper updates when props change from parent", async () => {
+    const Counter: React.FC<{ count: number; label?: string }> = ({
+      count,
+      label = "Count",
+    }) => (
+      <div>
+        {label}: {count}
+      </div>
+    );
+
+    const InteractableCounter = withTamboInteractable(Counter, {
+      componentName: "Counter",
+      description: "A counter component",
+      propsSchema: z.object({
+        count: z.number(),
+        label: z.string().optional(),
+      }),
+    });
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        const interval = setInterval(() => {
+          getAdditionalContext().then((contexts) => {
+            if (mounted) {
+              capturedContexts = contexts;
+            }
+          });
+        }, 50);
+        return () => {
+          mounted = false;
+          clearInterval(interval);
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const Host = () => {
+      const [count, setCount] = React.useState(0);
+      const [label, setLabel] = React.useState("Items");
+
+      React.useEffect(() => {
+        const timeout1 = setTimeout(() => setCount(5), 100);
+        const timeout2 = setTimeout(() => setLabel("Updated Items"), 200);
+        return () => {
+          clearTimeout(timeout1);
+          clearTimeout(timeout2);
+        };
+      }, []);
+
+      return (
+        <TamboInteractableProvider>
+          <InteractableCounter count={count} label={label} />
+          <TestComponent />
+        </TamboInteractableProvider>
+      );
+    };
+
+    const { getByTestId } = render(wrapperWithProviders(<Host />));
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+    });
+
+    // Wait for updates to propagate
+    await waitFor(
+      () => {
+        const entry = capturedContexts.find(
+          (c: any) => c.name === "interactables",
+        );
+        if (entry?.context?.components?.[0]) {
+          const props = entry.context.components[0].props;
+          expect(props.count).toBe(5);
+          expect(props.label).toBe("Updated Items");
+        }
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  test("multiple providers with nested context helpers work correctly", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    let outerContexts: any[] = [];
+    let innerContexts: any[] = [];
+
+    const OuterTestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            outerContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="outer-ready">outer ready</div>;
+    };
+
+    const InnerTestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            innerContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="inner-ready">inner ready</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <InteractableNote title="outer note" />
+          <OuterTestComponent />
+          <TamboContextHelpersProvider
+            contextHelpers={{
+              customContext: () => ({ custom: "inner" }),
+            }}
+          >
+            <TamboInteractableProvider>
+              <InteractableNote title="inner note" />
+              <InnerTestComponent />
+            </TamboInteractableProvider>
+          </TamboContextHelpersProvider>
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("outer-ready")).toBeInTheDocument();
+      expect(getByTestId("inner-ready")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      // Outer context should have outer note
+      const outerEntry = outerContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(outerEntry?.context?.components).toHaveLength(1);
+      expect(outerEntry?.context?.components[0]?.props?.title).toBe(
+        "outer note",
+      );
+
+      // Inner context should have inner note and custom context
+      const innerEntry = innerContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(innerEntry?.context?.components).toHaveLength(1);
+      expect(innerEntry?.context?.components[0]?.props?.title).toBe(
+        "inner note",
+      );
+
+      const customEntry = innerContexts.find(
+        (c: any) => c.name === "customContext",
+      );
+      expect(customEntry?.context).toEqual({ custom: "inner" });
+    });
+  });
+
+  test("provider cleanup removes helper when last provider unmounts", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        const interval = setInterval(() => {
+          getAdditionalContext().then((contexts) => {
+            if (mounted) {
+              capturedContexts = contexts;
+            }
+          });
+        }, 50);
+        return () => {
+          mounted = false;
+          clearInterval(interval);
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const Host = () => {
+      const [showProvider, setShowProvider] = React.useState(true);
+
+      React.useEffect(() => {
+        const timeout = setTimeout(() => setShowProvider(false), 200);
+        return () => clearTimeout(timeout);
+      }, []);
+
+      return (
+        <>
+          {showProvider && (
+            <TamboInteractableProvider>
+              <InteractableNote title="will disappear" />
+            </TamboInteractableProvider>
+          )}
+          <TestComponent />
+        </>
+      );
+    };
+
+    const { getByTestId } = render(wrapperWithProviders(<Host />));
+
+    // Initially should have the context
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(entry).toBeDefined();
+    });
+
+    // After provider unmounts, context should be gone
+    await waitFor(
+      () => {
+        const entry = capturedContexts.find(
+          (c: any) => c.name === "interactables",
+        );
+        expect(entry).toBeUndefined();
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  test("helper error handling doesn't crash the system", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    // Mock console.error to capture error logs
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext, addContextHelper } =
+        useTamboContextHelpers();
+
+      React.useEffect(() => {
+        // Add a helper that throws an error
+        addContextHelper("errorHelper", () => {
+          throw new Error("Test error in helper");
+        });
+      }, [addContextHelper]);
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext()
+          .then((contexts) => {
+            if (mounted) {
+              capturedContexts = contexts;
+            }
+          })
+          .catch(() => {
+            // Should not reach here - errors should be handled gracefully
+          });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <InteractableNote title="test" />
+          <TestComponent />
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      // Should still have the interactables context despite the error
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(entry).toBeDefined();
+
+      // Error helper should not be present (filtered out)
+      const errorEntry = capturedContexts.find(
+        (c: any) => c.name === "errorHelper",
+      );
+      expect(errorEntry).toBeUndefined();
+    });
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/react-sdk/src/providers/__tests__/tambo-interactables-additional-context.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-interactables-additional-context.test.tsx
@@ -1,0 +1,430 @@
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+import { z } from "zod";
+import {
+  useTamboContextHelpers,
+  TamboContextHelpersProvider,
+} from "../tambo-context-helpers-provider";
+import {
+  TamboInteractableProvider,
+  useCurrentInteractablesSnapshot,
+} from "../tambo-interactable-provider";
+import { TamboStubProvider } from "../tambo-stubs";
+import { withTamboInteractable } from "../hoc/with-tambo-interactable";
+
+function wrapperWithProviders(children: React.ReactNode) {
+  const thread = {
+    id: "t-1",
+    projectId: "p-1",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    messages: [],
+    metadata: {},
+  } as any;
+
+  return (
+    <TamboStubProvider
+      thread={thread}
+      registerTool={() => {}}
+      registerTools={() => {}}
+      registerComponent={() => {}}
+      addToolAssociation={() => {}}
+    >
+      <TamboContextHelpersProvider>{children}</TamboContextHelpersProvider>
+    </TamboStubProvider>
+  );
+}
+
+describe("Interactables AdditionalContext (provider-based)", () => {
+  test("registers default helper and returns payload with description and components", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            capturedContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <InteractableNote title="hello" />
+          <TestComponent />
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(entry).toBeDefined();
+      expect(entry?.context?.description).toMatch(/interactable components/i);
+      expect(Array.isArray(entry?.context?.components)).toBe(true);
+      const comp = entry!.context.components[0];
+      expect(comp.componentName).toBe("Note");
+      expect(comp.props).toEqual({ title: "hello" });
+    });
+  });
+
+  test("returns null when no interactable components are present", async () => {
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            capturedContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <div>No interactables here</div>
+          <TestComponent />
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(entry).toBeUndefined(); // Should be filtered out when helper returns null
+    });
+  });
+
+  test("context includes proper AI prompt with clear instructions", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A simple note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            capturedContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <InteractableNote title="test" />
+          <TestComponent />
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(entry?.context?.description).toContain("interactable components");
+      expect(entry?.context?.description).toContain("visible on the page");
+      expect(entry?.context?.description).toContain("you can read and modify");
+      expect(entry?.context?.description).toContain("tools to update");
+    });
+  });
+
+  test("includes component metadata in expected format", async () => {
+    const Note: React.FC<{ title: string; color?: string }> = ({
+      title,
+      color = "white",
+    }) => <div className={`note-${color}`}>{title}</div>;
+
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A colorful note component",
+      propsSchema: z.object({
+        title: z.string(),
+        color: z.string().optional(),
+      }),
+    });
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            capturedContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <InteractableNote title="test note" color="blue" />
+          <TestComponent />
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      const component = entry!.context.components[0];
+
+      expect(component).toMatchObject({
+        id: expect.any(String),
+        componentName: "Note",
+        description: "A colorful note component",
+        props: { title: "test note", color: "blue" },
+        propsSchema: "Available - use component-specific update tools",
+      });
+    });
+  });
+
+  test("snapshot hook returns immutable copies", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    const TestComponent = () => {
+      const snapshot = useCurrentInteractablesSnapshot();
+      const [testResult, setTestResult] = React.useState<string>("pending");
+
+      React.useEffect(() => {
+        if (snapshot.length > 0) {
+          const originalLength = snapshot.length;
+
+          // Try to mutate the returned array and props
+          snapshot.push({
+            id: "fake",
+            name: "Fake",
+            description: "",
+            component: () => null,
+            props: {},
+          } as any);
+          (snapshot[0].props as any).title = "MUTATED";
+
+          // The mutations should succeed on the returned copy, proving it's a separate object
+          if (
+            snapshot.length === originalLength + 1 &&
+            snapshot[0].props.title === "MUTATED"
+          ) {
+            setTestResult("mutation-successful-but-isolated");
+          } else {
+            setTestResult("mutation-failed");
+          }
+        }
+      }, [snapshot]);
+
+      return <div data-testid="test-result">{testResult}</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <InteractableNote title="immutable test" />
+          <TestComponent />
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      const result = getByTestId("test-result").textContent;
+      expect(result).toBe("mutation-successful-but-isolated");
+    });
+  });
+
+  test("multiple interactables from same provider appear in context", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+    const Counter: React.FC<{ count: number }> = ({ count }) => (
+      <div>{count}</div>
+    );
+
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    const InteractableCounter = withTamboInteractable(Counter, {
+      componentName: "Counter",
+      description: "A counter",
+      propsSchema: z.object({ count: z.number() }),
+    });
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            capturedContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const { getByTestId } = render(
+      wrapperWithProviders(
+        <TamboInteractableProvider>
+          <InteractableNote title="first" />
+          <InteractableCounter count={42} />
+          <TestComponent />
+        </TamboInteractableProvider>,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(entry?.context?.components).toHaveLength(2);
+
+      const components = entry!.context.components;
+      expect(components[0].componentName).toBe("Note");
+      expect(components[0].props).toEqual({ title: "first" });
+      expect(components[1].componentName).toBe("Counter");
+      expect(components[1].props).toEqual({ count: 42 });
+    });
+  });
+
+  test("can be disabled by returning null", async () => {
+    const Note: React.FC<{ title: string }> = ({ title }) => <div>{title}</div>;
+    const InteractableNote = withTamboInteractable(Note, {
+      componentName: "Note",
+      description: "A note",
+      propsSchema: z.object({ title: z.string() }),
+    });
+
+    // Create a context helpers provider with a disabled interactables helper
+    const DisabledContextHelpers = ({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) => (
+      <TamboContextHelpersProvider
+        contextHelpers={{
+          ["interactables"]: () => null,
+        }}
+      >
+        {children}
+      </TamboContextHelpersProvider>
+    );
+
+    let capturedContexts: any[] = [];
+    const TestComponent = () => {
+      const { getAdditionalContext } = useTamboContextHelpers();
+
+      React.useEffect(() => {
+        let mounted = true;
+        getAdditionalContext().then((contexts) => {
+          if (mounted) {
+            capturedContexts = contexts;
+          }
+        });
+        return () => {
+          mounted = false;
+        };
+      }, [getAdditionalContext]);
+
+      return <div data-testid="ready">ready</div>;
+    };
+
+    const thread = {
+      id: "t-1",
+      projectId: "p-1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+      metadata: {},
+    } as any;
+
+    const { getByTestId } = render(
+      <TamboStubProvider
+        thread={thread}
+        registerTool={() => {}}
+        registerTools={() => {}}
+        registerComponent={() => {}}
+        addToolAssociation={() => {}}
+      >
+        <DisabledContextHelpers>
+          <TamboInteractableProvider>
+            <InteractableNote title="should not appear" />
+            <TestComponent />
+          </TamboInteractableProvider>
+        </DisabledContextHelpers>
+      </TamboStubProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("ready")).toBeInTheDocument();
+      const entry = capturedContexts.find(
+        (c: any) => c.name === "interactables",
+      );
+      expect(entry).toBeUndefined(); // Should be filtered out when helper returns null
+    });
+  });
+});


### PR DESCRIPTION
## Key Changes

  - **New context helper**: `currentInteractablesContextHelper` automatically registers when using `TamboInteractableProvider`
  - **Simplified architecture**: Adapted to provider-only system (no global registry dependencies)
  - **Complete API**: Includes disable, override, and customization options
  - **Comprehensive tests**: 13 tests covering core functionality and edge cases
  - **Integrated docs**: Added customization examples to existing interactable components page

  ## User Impact

  Users can now ask "what's on the page?" and get comprehensive answers about their interactable components without any additional setup. The context
  automatically includes component IDs, names, descriptions, current props, and schema information.


https://github.com/user-attachments/assets/9b84afac-1685-4cf8-9eb7-46dad34e775a



  ## Breaking Changes

  None - this is a purely additive feature that works automatically.

  ## Testing

  - ✅ All existing tests pass
  - ✅ 13 new tests covering functionality and edge cases
  - ✅ Linting and type checking pass

  ## Examples

  **Before**: AI has no awareness of page components
  **After**:
  ```tsx
  <TamboInteractableProvider>
    <InteractableNote title="My Note" />
    {/* AI automatically knows about this component */}
  </TamboInteractableProvider>

  Users can disable globally:
  <TamboProvider contextHelpers={{ interactables: () => null }}>

  Or customize for privacy:
  // Only send IDs and names, not props
  addContextHelper("interactables", () => ({
    components: snapshot.map(c => ({ id: c.id, name: c.name }))
  }));