### PR TITLE
Feature/initial messages

### DIFF
--- a/docs/examples/initial-messages-example.tsx
+++ b/docs/examples/initial-messages-example.tsx
@@ -1,0 +1,230 @@
+import {
+  TamboProvider,
+  TamboThreadMessage,
+  useTambo,
+} from "@tambo-ai/react-sdk";
+import React from "react";
+
+// Example initial messages for different use cases
+const CUSTOMER_SUPPORT_MESSAGES: TamboThreadMessage[] = [
+  {
+    id: "system-1",
+    role: "system",
+    content: [
+      {
+        type: "text",
+        text: "You are a customer support agent for TechCorp. Be helpful, professional, and always ask for the customer's order number if they have an issue.",
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+  {
+    id: "welcome-1",
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: "Hi! I'm here to help with any questions about your TechCorp products. What can I assist you with today?",
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+];
+
+const EDUCATIONAL_MESSAGES: TamboThreadMessage[] = [
+  {
+    id: "system-2",
+    role: "system",
+    content: [
+      {
+        type: "text",
+        text: "You are an educational assistant. Always encourage learning, ask clarifying questions, and provide step-by-step explanations.",
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+  {
+    id: "welcome-2",
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: "Welcome to your learning session! What topic would you like to explore today?",
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+];
+
+const CODING_ASSISTANT_MESSAGES: TamboThreadMessage[] = [
+  {
+    id: "system-3",
+    role: "system",
+    content: [
+      {
+        type: "text",
+        text: "You are a coding assistant. Help users write better code, explain programming concepts, and debug issues. Always provide code examples when relevant.",
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+  {
+    id: "welcome-3",
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: "👋 Hi! I'm your coding assistant. I can help you with programming questions, code reviews, debugging, and learning new concepts. What are you working on?",
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+];
+
+// Chat component that uses Tambo
+function ChatComponent() {
+  const { sendThreadMessage, thread, isIdle } = useTambo();
+  const [input, setInput] = React.useState("");
+
+  const handleSend = async () => {
+    if (!input.trim()) return;
+
+    try {
+      await sendThreadMessage(input);
+      setInput("");
+    } catch (error) {
+      console.error("Error sending message:", error);
+    }
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="messages">
+        {thread.messages.map((message) => (
+          <div key={message.id} className={`message ${message.role}`}>
+            <strong>{message.role}:</strong>
+            {message.content.map((content, _index) => (
+              <div key={_index}>
+                {content.type === "text"
+                  ? content.text
+                  : JSON.stringify(content)}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <div className="input-area">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyPress={(e) => {
+            if (e.key === "Enter") {
+              void handleSend();
+            }
+          }}
+          placeholder="Type your message..."
+          disabled={!isIdle}
+        />
+        <button onClick={handleSend} disabled={!isIdle || !input.trim()}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Main example app
+function InitialMessagesExample() {
+  const [selectedMode, setSelectedMode] = React.useState<
+    "support" | "education" | "coding"
+  >("support");
+
+  const getInitialMessages = () => {
+    switch (selectedMode) {
+      case "support":
+        return CUSTOMER_SUPPORT_MESSAGES;
+      case "education":
+        return EDUCATIONAL_MESSAGES;
+      case "coding":
+        return CODING_ASSISTANT_MESSAGES;
+      default:
+        return [];
+    }
+  };
+
+  return (
+    <div className="app">
+      <h1>Tambo Initial Messages Example</h1>
+
+      <div className="mode-selector">
+        <h3>Select Assistant Mode:</h3>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            value="support"
+            checked={selectedMode === "support"}
+            onChange={(e) =>
+              setSelectedMode(
+                e.target.value as "support" | "education" | "coding",
+              )
+            }
+          />
+          Customer Support
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            value="education"
+            checked={selectedMode === "education"}
+            onChange={(e) =>
+              setSelectedMode(
+                e.target.value as "support" | "education" | "coding",
+              )
+            }
+          />
+          Educational Assistant
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="mode"
+            value="coding"
+            checked={selectedMode === "coding"}
+            onChange={(e) =>
+              setSelectedMode(
+                e.target.value as "support" | "education" | "coding",
+              )
+            }
+          />
+          Coding Assistant
+        </label>
+      </div>
+
+      <TamboProvider
+        key={selectedMode} // Re-mount provider when mode changes
+        tamboUrl={process.env.REACT_APP_TAMBO_URL || "https://api.tambo.ai"}
+        apiKey={process.env.REACT_APP_TAMBO_API_KEY || ""}
+        initialMessages={getInitialMessages()}
+      >
+        <ChatComponent />
+      </TamboProvider>
+
+      <div className="initial-messages-preview">
+        <h3>Initial Messages for {selectedMode} mode:</h3>
+        <pre>{JSON.stringify(getInitialMessages(), null, 2)}</pre>
+      </div>
+    </div>
+  );
+}
+
+export default InitialMessagesExample;

--- a/docs/initial-messages.md
+++ b/docs/initial-messages.md
@@ -1,0 +1,200 @@
+# Initial Messages Feature
+
+The Initial Messages feature allows you to set up a "conversation state" when creating new threads in Tambo. This is useful for providing system instructions, context, or welcome messages that should be present at the start of every new conversation.
+
+## React SDK Usage
+
+### Basic Example
+
+```tsx
+import { TamboProvider, TamboThreadMessage } from "@tambo-ai/react-sdk";
+
+const initialMessages: TamboThreadMessage[] = [
+  {
+    id: "system-message",
+    role: "system",
+    content: [
+      {
+        type: "text",
+        text: "You are a helpful assistant specialized in customer support.",
+      },
+    ],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+  {
+    id: "welcome-message",
+    role: "assistant",
+    content: [{ type: "text", text: "Hello! How can I help you today?" }],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+];
+
+function App() {
+  return (
+    <TamboProvider
+      tamboUrl="https://api.tambo.ai"
+      apiKey="your-api-key"
+      initialMessages={initialMessages}
+    >
+      <YourChatComponent />
+    </TamboProvider>
+  );
+}
+```
+
+### With Components
+
+You can also include components in initial messages:
+
+```tsx
+const initialMessagesWithComponent: TamboThreadMessage[] = [
+  {
+    id: "system-message",
+    role: "system",
+    content: [{ type: "text", text: "You are a helpful assistant." }],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+  },
+  {
+    id: "welcome-component",
+    role: "assistant",
+    content: [{ type: "text", text: "Welcome! Here's a quick overview:" }],
+    createdAt: new Date().toISOString(),
+    componentState: {},
+    component: {
+      componentName: "WelcomeCard",
+      props: {
+        title: "Welcome to Support",
+        description: "I can help you with your questions.",
+      },
+    },
+  },
+];
+```
+
+## API Usage
+
+### Direct API Call
+
+When using the API directly, you can include `initialMessages` in the advance thread request:
+
+```typescript
+const response = await fetch("/threads/advancestream", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  },
+  body: JSON.stringify({
+    messageToAppend: {
+      content: [{ type: "text", text: "Hello!" }],
+      role: "user",
+    },
+    initialMessages: [
+      {
+        content: [{ type: "text", text: "You are a helpful assistant." }],
+        role: "system",
+      },
+    ],
+  }),
+});
+```
+
+## Behavior
+
+### New Threads
+
+- Initial messages are included when creating a **new** thread (placeholder thread)
+- They are sent to the AI model as part of the conversation context
+- They appear in the thread's message history
+
+### Existing Threads
+
+- Initial messages are **not** added to existing threads
+- Only applies when `threadId` is undefined (new thread creation)
+
+### Validation
+
+The API validates initial messages to ensure:
+
+- Each message has valid `content` and `role`
+- Roles are one of: `system`, `user`, `assistant`
+- Text content parts have the required `text` property
+- Content arrays are not empty
+
+## Interaction with Custom Instructions
+
+Initial messages work alongside the "custom instructions" feature:
+
+1. **Custom Instructions**: Set via the project settings dashboard, applied to all threads in the project
+2. **Initial Messages**: Set programmatically via the SDK/API, applied per thread creation
+
+Both are sent to the AI model, with custom instructions typically processed first, followed by initial messages, then the conversation history.
+
+## Error Handling
+
+Invalid initial messages will cause the thread creation to fail with a descriptive error:
+
+```
+Initial message at index 0 must have content
+Initial message at index 1 has invalid role "invalid-role". Allowed roles are: system, user, assistant
+Initial message at index 2, content part 0 with type 'text' must have text property
+```
+
+## Examples
+
+### Customer Support Bot
+
+```tsx
+const supportMessages: TamboThreadMessage[] = [
+  {
+    role: "system",
+    content: [
+      {
+        type: "text",
+        text: "You are a customer support agent for TechCorp. Be helpful, professional, and always ask for the customer's order number if they have an issue.",
+      },
+    ],
+    // ... other required fields
+  },
+  {
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: "Hi! I'm here to help with any questions about your TechCorp products. What can I assist you with today?",
+      },
+    ],
+    // ... other required fields
+  },
+];
+```
+
+### Educational Assistant
+
+```tsx
+const educationMessages: TamboThreadMessage[] = [
+  {
+    role: "system",
+    content: [
+      {
+        type: "text",
+        text: "You are an educational assistant. Always encourage learning, ask clarifying questions, and provide step-by-step explanations.",
+      },
+    ],
+    // ... other required fields
+  },
+  {
+    role: "assistant",
+    content: [
+      {
+        type: "text",
+        text: "Welcome to your learning session! What topic would you like to explore today?",
+      },
+    ],
+    // ... other required fields
+  },
+];
+```

--- a/react-sdk/src/providers/__tests__/tambo-thread-provider-initial-messages.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-thread-provider-initial-messages.test.tsx
@@ -1,0 +1,217 @@
+import TamboAI, { advanceStream } from "@tambo-ai/typescript-sdk";
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { DeepPartial } from "ts-essentials";
+import {
+  GenerationStage,
+  TamboThreadMessage,
+} from "../../model/generate-component-response";
+import { useTamboClient } from "../tambo-client-provider";
+import { TamboContextHelpersProvider } from "../tambo-context-helpers-provider";
+import { TamboRegistryProvider } from "../tambo-registry-provider";
+import { TamboThreadProvider, useTamboThread } from "../tambo-thread-provider";
+
+type PartialTamboAI = DeepPartial<TamboAI>;
+
+// Mock crypto.randomUUID
+Object.defineProperty(global, "crypto", {
+  value: {
+    randomUUID: jest.fn().mockReturnValue("test-uuid"),
+  },
+});
+
+// Mock the required providers
+jest.mock("../tambo-client-provider", () => ({
+  useTamboClient: jest.fn(),
+}));
+jest.mock("@tambo-ai/typescript-sdk", () => ({
+  advanceStream: jest.fn(),
+}));
+
+// Test utilities
+const createMockMessage = (
+  overrides: Partial<TamboThreadMessage> = {},
+): TamboThreadMessage => ({
+  id: "test-message-1",
+  content: [{ type: "text", text: "Hello" }],
+  role: "user",
+  threadId: "test-thread-1",
+  createdAt: new Date().toISOString(),
+  componentState: {},
+  ...overrides,
+});
+
+// Test wrapper
+const createWrapper = (initialMessages: TamboThreadMessage[] = []) => {
+  const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+    <TamboRegistryProvider components={[]} tools={[]}>
+      <TamboContextHelpersProvider>
+        <TamboThreadProvider initialMessages={initialMessages}>
+          {children}
+        </TamboThreadProvider>
+      </TamboContextHelpersProvider>
+    </TamboRegistryProvider>
+  );
+  TestWrapper.displayName = "TestWrapper";
+  return TestWrapper;
+};
+
+describe("TamboThreadProvider with initial messages", () => {
+  const mockClient: PartialTamboAI = {
+    beta: {
+      threads: {
+        advance: jest.fn(),
+        advanceById: jest.fn(),
+        cancel: jest.fn(),
+        messages: {
+          create: jest.fn(),
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useTamboClient as jest.Mock).mockReturnValue(mockClient);
+    (advanceStream as jest.Mock).mockImplementation(async function* () {
+      yield {
+        responseMessageDto: {
+          id: "response-1",
+          role: "assistant",
+          content: [{ type: "text", text: "Hello back!" }],
+          threadId: "new-thread-id",
+          componentState: {},
+          createdAt: new Date().toISOString(),
+        },
+        generationStage: GenerationStage.COMPLETE,
+      };
+    });
+  });
+
+  it("should initialize with empty messages when no initial messages provided", () => {
+    const { result } = renderHook(() => useTamboThread(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.thread.messages).toEqual([]);
+  });
+
+  it("should initialize with provided initial messages", () => {
+    const initialMessages: TamboThreadMessage[] = [
+      createMockMessage({
+        id: "initial-1",
+        role: "system",
+        content: [{ type: "text", text: "You are a helpful assistant." }],
+      }),
+      createMockMessage({
+        id: "initial-2",
+        role: "user",
+        content: [{ type: "text", text: "Hello!" }],
+      }),
+    ];
+
+    const { result } = renderHook(() => useTamboThread(), {
+      wrapper: createWrapper(initialMessages),
+    });
+
+    expect(result.current.thread.messages).toHaveLength(2);
+    expect(result.current.thread.messages[0].content[0].text).toBe(
+      "You are a helpful assistant.",
+    );
+    expect(result.current.thread.messages[1].content[0].text).toBe("Hello!");
+  });
+
+  it("should include initial messages when sending a message to a new thread", async () => {
+    const initialMessages: TamboThreadMessage[] = [
+      createMockMessage({
+        id: "initial-1",
+        role: "system",
+        content: [{ type: "text", text: "You are a helpful assistant." }],
+      }),
+    ];
+
+    const { result } = renderHook(() => useTamboThread(), {
+      wrapper: createWrapper(initialMessages),
+    });
+
+    await act(async () => {
+      await result.current.sendThreadMessage("Test message");
+    });
+
+    // Check that advanceStream was called with initial messages
+    expect(advanceStream).toHaveBeenCalledWith(
+      mockClient,
+      expect.objectContaining({
+        initialMessages: [
+          {
+            content: [{ type: "text", text: "You are a helpful assistant." }],
+            role: "system",
+            additionalContext: undefined,
+          },
+        ],
+      }),
+      undefined,
+    );
+  });
+
+  it("should not include initial messages when sending to an existing thread", async () => {
+    const initialMessages: TamboThreadMessage[] = [
+      createMockMessage({
+        id: "initial-1",
+        role: "system",
+        content: [{ type: "text", text: "You are a helpful assistant." }],
+      }),
+    ];
+
+    const { result } = renderHook(() => useTamboThread(), {
+      wrapper: createWrapper(initialMessages),
+    });
+
+    // Switch to an existing thread first
+    await act(async () => {
+      result.current.switchCurrentThread("existing-thread-id", false);
+    });
+
+    await act(async () => {
+      await result.current.sendThreadMessage("Test message");
+    });
+
+    // Check that advanceStream was called without initial messages
+    expect(advanceStream).toHaveBeenCalledWith(
+      mockClient,
+      expect.not.objectContaining({
+        initialMessages: expect.anything(),
+      }),
+      "existing-thread-id",
+    );
+  });
+
+  it("should reset to initial messages when starting a new thread", () => {
+    const initialMessages: TamboThreadMessage[] = [
+      createMockMessage({
+        id: "initial-1",
+        role: "system",
+        content: [{ type: "text", text: "You are a helpful assistant." }],
+      }),
+    ];
+
+    const { result } = renderHook(() => useTamboThread(), {
+      wrapper: createWrapper(initialMessages),
+    });
+
+    // Switch to an existing thread
+    act(() => {
+      result.current.switchCurrentThread("existing-thread-id", false);
+    });
+
+    // Start a new thread
+    act(() => {
+      result.current.startNewThread();
+    });
+
+    expect(result.current.thread.messages).toHaveLength(1);
+    expect(result.current.thread.messages[0].content[0].text).toBe(
+      "You are a helpful assistant.",
+    );
+  });
+});

--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -54,6 +54,7 @@ import {
  * @param props.contextHelpers - Configuration for which context helpers are enabled/disabled
  * @param props.userToken - The JWT id token to use to identify the user in the Tambo API. (preferred over contextKey)
  * @param props.contextKey - Optional context key to be used in the thread input provider
+ * @param props.initialMessages - Initial messages to be included in new threads
  * @returns The TamboProvider component
  */
 export const TamboProvider: React.FC<
@@ -75,6 +76,7 @@ export const TamboProvider: React.FC<
   streaming,
   contextHelpers,
   contextKey,
+  initialMessages,
 }) => {
   // Should only be used in browser
   if (typeof window === "undefined") {
@@ -90,7 +92,10 @@ export const TamboProvider: React.FC<
     >
       <TamboRegistryProvider components={components} tools={tools}>
         <TamboContextHelpersProvider contextHelpers={contextHelpers}>
-          <TamboThreadProvider streaming={streaming}>
+          <TamboThreadProvider
+            streaming={streaming}
+            initialMessages={initialMessages}
+          >
             <TamboThreadInputProvider contextKey={contextKey}>
               <TamboComponentProvider>
                 <TamboInteractableProvider>

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -194,6 +194,8 @@ export const TamboThreadContext = createContext<TamboThreadContextProps>({
 export interface TamboThreadProviderProps {
   /** Whether to stream the response */
   streaming?: boolean;
+  /** Initial messages to be included in new threads */
+  initialMessages?: TamboThreadMessage[];
 }
 
 /**
@@ -202,13 +204,33 @@ export interface TamboThreadProviderProps {
  * @param props - The props for the TamboThreadProvider
  * @param props.children - The children to wrap
  * @param props.streaming - Whether to stream the response by default. Defaults to true.
+ * @param props.initialMessages - Initial messages to be included in new threads
  * @returns The TamboThreadProvider component
  */
 export const TamboThreadProvider: React.FC<
   PropsWithChildren<TamboThreadProviderProps>
-> = ({ children, streaming = true }) => {
+> = ({ children, streaming = true, initialMessages = [] }) => {
+  // Create placeholder thread with initial messages
+  const placeholderThread: TamboThread = useMemo(
+    () => ({
+      id: "placeholder",
+      messages: initialMessages.map((msg) => ({
+        ...msg,
+        id: msg.id || crypto.randomUUID(),
+        threadId: "placeholder",
+        createdAt: msg.createdAt || new Date().toISOString(),
+        componentState: msg.componentState || {},
+      })),
+      createdAt: "",
+      projectId: "",
+      updatedAt: "",
+      metadata: {},
+    }),
+    [initialMessages],
+  );
+
   const [threadMap, setThreadMap] = useState<Record<string, TamboThread>>({
-    [PLACEHOLDER_THREAD.id]: PLACEHOLDER_THREAD,
+    [placeholderThread.id]: placeholderThread,
   });
   const client = useTamboClient();
   const { componentList, toolRegistry, componentToolAssociations } =
@@ -217,7 +239,7 @@ export const TamboThreadProvider: React.FC<
   const [ignoreResponse, setIgnoreResponse] = useState(false);
   const ignoreResponseRef = useRef(ignoreResponse);
   const [currentThreadId, setCurrentThreadId] = useState<string>(
-    PLACEHOLDER_THREAD.id,
+    placeholderThread.id,
   );
   const currentThread: TamboThread | undefined = threadMap[currentThreadId];
 
@@ -281,12 +303,12 @@ export const TamboThreadProvider: React.FC<
   useEffect(() => {
     if (
       currentThreadId &&
-      currentThreadId !== PLACEHOLDER_THREAD.id &&
+      currentThreadId !== placeholderThread.id &&
       !threadMap[currentThreadId]
     ) {
       fetchThread(currentThreadId);
     }
-  }, [currentThreadId, fetchThread, threadMap]);
+  }, [currentThreadId, fetchThread, threadMap, placeholderThread.id]);
 
   const addThreadMessage = useCallback(
     async (
@@ -389,14 +411,14 @@ export const TamboThreadProvider: React.FC<
   );
 
   const startNewThread = useCallback(() => {
-    setCurrentThreadId(PLACEHOLDER_THREAD.id);
+    setCurrentThreadId(placeholderThread.id);
     setThreadMap((prevMap) => {
       return {
         ...prevMap,
-        [PLACEHOLDER_THREAD.id]: PLACEHOLDER_THREAD,
+        [placeholderThread.id]: placeholderThread,
       };
     });
-  }, []);
+  }, [placeholderThread]);
 
   const updateThreadName = useCallback(
     async (name: string, threadId?: string) => {
@@ -409,7 +431,7 @@ export const TamboThreadProvider: React.FC<
         return { ...prevMap, [threadId]: { ...prevMap[threadId], name } };
       });
 
-      if (threadId !== PLACEHOLDER_THREAD.id) {
+      if (threadId !== placeholderThread.id) {
         const currentProject = await client.beta.projects.getCurrent();
         await client.beta.threads.update(threadId, {
           name,
@@ -417,13 +439,18 @@ export const TamboThreadProvider: React.FC<
         });
       }
     },
-    [currentThreadId, client.beta.projects, client.beta.threads],
+    [
+      currentThreadId,
+      client.beta.projects,
+      client.beta.threads,
+      placeholderThread.id,
+    ],
   );
 
   const generateThreadName = useCallback(
     async (threadId?: string) => {
       threadId ??= currentThreadId;
-      if (threadId === PLACEHOLDER_THREAD.id) {
+      if (threadId === placeholderThread.id) {
         console.warn("Cannot generate name for empty thread");
         return threadMap[threadId];
       }
@@ -445,12 +472,12 @@ export const TamboThreadProvider: React.FC<
       });
       return threadWithGeneratedName;
     },
-    [client.beta.threads, currentThreadId, threadMap],
+    [client.beta.threads, currentThreadId, threadMap, placeholderThread.id],
   );
 
   const switchCurrentThread = useCallback(
     async (threadId: string, fetch = true) => {
-      if (threadId === PLACEHOLDER_THREAD.id) {
+      if (threadId === placeholderThread.id) {
         console.warn("Switching to placeholder thread, may be a bug.");
         return;
       }
@@ -463,7 +490,7 @@ export const TamboThreadProvider: React.FC<
         const updatedThreadMap = {
           ...prevMap,
           [threadId]: {
-            ...prevMap[PLACEHOLDER_THREAD.id],
+            ...prevMap[placeholderThread.id],
             id: threadId,
           },
         };
@@ -473,7 +500,7 @@ export const TamboThreadProvider: React.FC<
         await fetchThread(threadId);
       }
     },
-    [fetchThread],
+    [fetchThread, placeholderThread],
   );
 
   const updateThreadStatus = useCallback(
@@ -743,7 +770,7 @@ export const TamboThreadProvider: React.FC<
     ): Promise<TamboThreadMessage> => {
       setIgnoreResponse(false);
       const {
-        threadId = currentThreadId ?? PLACEHOLDER_THREAD.id,
+        threadId = currentThreadId ?? placeholderThread.id,
         streamResponse = streaming,
         forceToolChoice,
         contextKey,
@@ -804,6 +831,14 @@ export const TamboThreadProvider: React.FC<
         ),
         forceToolChoice: forceToolChoice,
         toolCallCounts,
+        ...(threadId === placeholderThread.id &&
+          initialMessages.length > 0 && {
+            initialMessages: initialMessages.map((msg) => ({
+              content: msg.content,
+              role: msg.role,
+              additionalContext: msg.additionalContext,
+            })),
+          }),
       };
 
       if (streamResponse) {
@@ -812,7 +847,7 @@ export const TamboThreadProvider: React.FC<
           advanceStreamResponse = await advanceStream(
             client,
             params,
-            threadId === PLACEHOLDER_THREAD.id ? undefined : threadId,
+            threadId === placeholderThread.id ? undefined : threadId,
           );
         } catch (error) {
           updateThreadStatus(threadId, GenerationStage.ERROR);
@@ -832,7 +867,7 @@ export const TamboThreadProvider: React.FC<
 
       let advanceResponse: TamboAI.Beta.Threads.ThreadAdvanceResponse;
       try {
-        advanceResponse = await (threadId === PLACEHOLDER_THREAD.id
+        advanceResponse = await (threadId === placeholderThread.id
           ? client.beta.threads.advance(params)
           : client.beta.threads.advanceById(threadId, params));
       } catch (error) {
@@ -936,6 +971,8 @@ export const TamboThreadProvider: React.FC<
       handleAdvanceStream,
       streaming,
       getAdditionalContext,
+      placeholderThread.id,
+      initialMessages,
     ],
   );
 


### PR DESCRIPTION
# Add Initial Messages Support to TamboProvider

## Summary

This PR adds support for `initialMessages` to the TamboProvider and TamboThreadProvider, allowing developers to pre-populate new threads with initial messages when the Tambo chat interface is first loaded.

## Changes Made

### Core Features

#### TamboProvider Updates
- **New Prop**: Added `initialMessages?: TamboThreadMessage[]` prop to `TamboProvider`
- **JSDoc Update**: Updated component documentation to include the new `initialMessages` parameter
- **Prop Threading**: Properly threads the `initialMessages` prop down to `TamboThreadProvider`

#### TamboThreadProvider Updates
- **Interface Extension**: Added `initialMessages?: TamboThreadMessage[]` to `TamboThreadProviderProps`
- **Dynamic Placeholder Thread**: Replaced static `PLACEHOLDER_THREAD` with dynamic `placeholderThread` that includes initial messages
- **Message Preprocessing**: Initial messages are processed with default values:
  - Auto-generated `id` using `crypto.randomUUID()` if not provided
  - Set `threadId` to "placeholder"
  - Default `createdAt` to current timestamp if not provided  
  - Initialize empty `componentState` if not provided
- **Thread Creation Logic**: When creating a new thread from placeholder, initial messages are passed to the API call
- **Consistent References**: Updated all references from hardcoded `PLACEHOLDER_THREAD.id` to dynamic `placeholderThread.id`

### Technical Implementation Details

#### Memory Management
- Uses `useMemo` to create the placeholder thread, ensuring it only recreates when `initialMessages` change
- Proper dependency arrays updated throughout to include `placeholderThread` references

#### API Integration  
- Initial messages are correctly formatted and passed to the thread advance API call
- Only relevant message fields (`content`, `role`, `additionalContext`) are sent to the API
- Initial messages are only included when creating a new thread (placeholder thread ID)

#### Type Safety
- Leverages existing `TamboThreadMessage` interface which extends `TamboAI.Beta.Threads.ThreadMessage`
- Maintains backward compatibility with optional prop defaulting to empty array

## Usage Example

```typescript
const initialMessages: TamboThreadMessage[] = [
  {
    content: "Hello! How can I help you today?",
    role: "assistant"
  },
  {
    content: "I'm looking for help with React components",
    role: "user"
  }
];

<TamboProvider
  apiKey="your-api-key"
  initialMessages={initialMessages}
>
  <YourApp />
</TamboProvider>
```

## Files Changed

- `react-sdk/src/providers/tambo-provider.tsx` - Added initialMessages prop support
- `react-sdk/src/providers/tambo-thread-provider.tsx` - Core implementation of initial messages functionality




___
The other part of this feature is in  https://github.com/tambo-ai/tambo-cloud/pull/1715
___
