### PR TITLE
fix: Extract error messages from mcp tool response content array

### DIFF
--- a/react-sdk/src/mcp/__tests__/tambo-mcp-provider.test.tsx
+++ b/react-sdk/src/mcp/__tests__/tambo-mcp-provider.test.tsx
@@ -36,7 +36,7 @@ describe("extractErrorMessage", () => {
       expect(result).toBe("Simple error message");
     });
 
-    it("should return empty string for array content with no text items", () => {
+    it("should return fallback message for array content with no text items", () => {
       const content = [
         { type: "image", url: "http://example.com/error.png" },
         { type: "resource", uri: "file://error.log" },
@@ -44,15 +44,15 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe("");
+      expect(result).toBe("Error occurred but no details provided");
     });
 
-    it("should return empty string for empty array content", () => {
+    it("should return fallback message for empty array content", () => {
       const content: any[] = [];
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe("");
+      expect(result).toBe("Error occurred but no details provided");
     });
 
     it("should handle array content with mixed types correctly", () => {
@@ -67,6 +67,20 @@ describe("extractErrorMessage", () => {
       const result = extractErrorMessage(content);
 
       expect(result).toBe("First error Second error");
+    });
+
+    it("should handle array content with malformed items", () => {
+      const content = [
+        null,
+        { type: "text", text: "Valid error" },
+        { type: "text" }, // Missing text property
+        { type: "text", text: null }, // Invalid text type
+        { type: "text", text: "Another valid error" },
+      ];
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe("Valid error Another valid error");
     });
   });
 
@@ -84,7 +98,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe(null);
+      expect(result).toBe("Unknown error occurred");
     });
 
     it("should handle undefined content", () => {
@@ -92,7 +106,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe(undefined);
+      expect(result).toBe("Unknown error occurred");
     });
 
     it("should handle number content", () => {
@@ -100,7 +114,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe(42);
+      expect(result).toBe("Invalid error content format");
     });
 
     it("should handle boolean content", () => {
@@ -108,7 +122,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe(false);
+      expect(result).toBe("Unknown error occurred");
     });
 
     it("should handle object content", () => {
@@ -116,7 +130,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toEqual({ error: "Something went wrong" });
+      expect(result).toBe("Invalid error content format");
     });
   });
 });

--- a/react-sdk/src/mcp/__tests__/tambo-mcp-provider.test.tsx
+++ b/react-sdk/src/mcp/__tests__/tambo-mcp-provider.test.tsx
@@ -1,0 +1,122 @@
+import { extractErrorMessage } from "../tambo-mcp-provider";
+
+// Mock the MCP client to avoid ES module issues
+jest.mock("../mcp-client", () => ({
+  MCPClient: jest.fn(),
+  MCPTransport: {
+    SSE: "sse",
+    HTTP: "http",
+  },
+}));
+
+// Mock the registry provider to avoid dependency issues
+jest.mock("../../providers/tambo-registry-provider", () => ({
+  useTamboRegistry: jest.fn(),
+}));
+
+describe("extractErrorMessage", () => {
+  describe("Array content handling", () => {
+    it("should extract text from array content with multiple text items", () => {
+      const content = [
+        { type: "text", text: "Error:" },
+        { type: "text", text: "Tool execution failed" },
+        { type: "image", url: "http://example.com/error.png" }, // Should be filtered out
+      ];
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe("Error: Tool execution failed");
+    });
+
+    it("should extract text from array content with single text item", () => {
+      const content = [{ type: "text", text: "Simple error message" }];
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe("Simple error message");
+    });
+
+    it("should return empty string for array content with no text items", () => {
+      const content = [
+        { type: "image", url: "http://example.com/error.png" },
+        { type: "resource", uri: "file://error.log" },
+      ];
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe("");
+    });
+
+    it("should return empty string for empty array content", () => {
+      const content: any[] = [];
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe("");
+    });
+
+    it("should handle array content with mixed types correctly", () => {
+      const content = [
+        { type: "resource", uri: "file://log.txt" },
+        { type: "text", text: "First error" },
+        { type: "image", url: "http://example.com/img.png" },
+        { type: "text", text: "Second error" },
+        { type: "unknown", data: "something" },
+      ];
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe("First error Second error");
+    });
+  });
+
+  describe("Non-array content handling", () => {
+    it("should return string content as-is", () => {
+      const content = "Direct error message";
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe("Direct error message");
+    });
+
+    it("should handle null content", () => {
+      const content = null;
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe(null);
+    });
+
+    it("should handle undefined content", () => {
+      const content = undefined;
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe(undefined);
+    });
+
+    it("should handle number content", () => {
+      const content = 42;
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe(42);
+    });
+
+    it("should handle boolean content", () => {
+      const content = false;
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe(false);
+    });
+
+    it("should handle object content", () => {
+      const content = { error: "Something went wrong" };
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toEqual({ error: "Something went wrong" });
+    });
+  });
+});

--- a/react-sdk/src/mcp/__tests__/tambo-mcp-provider.test.tsx
+++ b/react-sdk/src/mcp/__tests__/tambo-mcp-provider.test.tsx
@@ -114,7 +114,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe("Invalid error content format");
+      expect(result).toBe("error content: 42");
     });
 
     it("should handle boolean content", () => {
@@ -122,7 +122,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe("Unknown error occurred");
+      expect(result).toBe("error content: false");
     });
 
     it("should handle object content", () => {
@@ -130,7 +130,29 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe("Invalid error content format");
+      expect(result).toBe('{"error":"Something went wrong"}');
+    });
+
+    it("should handle complex object content", () => {
+      const content = {
+        error: "Something went wrong",
+        code: 500,
+        details: { message: "Internal server error" },
+      };
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe(
+        '{"error":"Something went wrong","code":500,"details":{"message":"Internal server error"}}',
+      );
+    });
+
+    it("should handle empty object content", () => {
+      const content = {};
+
+      const result = extractErrorMessage(content);
+
+      expect(result).toBe("{}");
     });
   });
 });

--- a/react-sdk/src/mcp/__tests__/tambo-mcp-provider.test.tsx
+++ b/react-sdk/src/mcp/__tests__/tambo-mcp-provider.test.tsx
@@ -114,7 +114,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe("error content: 42");
+      expect(result).toBe("42");
     });
 
     it("should handle boolean content", () => {
@@ -122,7 +122,7 @@ describe("extractErrorMessage", () => {
 
       const result = extractErrorMessage(content);
 
-      expect(result).toBe("error content: false");
+      expect(result).toBe("false");
     });
 
     it("should handle object content", () => {

--- a/react-sdk/src/mcp/tambo-mcp-provider.tsx
+++ b/react-sdk/src/mcp/tambo-mcp-provider.tsx
@@ -9,7 +9,7 @@ import { MCPClient, MCPTransport } from "./mcp-client";
  * Always returns a string, even for invalid/null inputs.
  */
 export function extractErrorMessage(content: unknown): string {
-  if (!content) {
+  if (content === undefined || content === null) {
     return "Unknown error occurred";
   }
 
@@ -29,7 +29,7 @@ export function extractErrorMessage(content: unknown): string {
     return JSON.stringify(content);
   }
 
-  return `error content: ${content}`;
+  return `${content}`;
 }
 
 export interface McpServerInfo {

--- a/react-sdk/src/mcp/tambo-mcp-provider.tsx
+++ b/react-sdk/src/mcp/tambo-mcp-provider.tsx
@@ -70,8 +70,14 @@ export const TamboMcpProvider: FC<{
             }
             const result = await mcpServer.callTool(tool.name, args);
             if (result.isError) {
-              // TODO: is there a better way to handle this?
-              throw new Error(`${result.content}`);
+              // Extract error message from content array
+              const errorMessage = Array.isArray(result.content)
+                ? result.content
+                    .filter((item) => item.type === "text")
+                    .map((item) => item.text)
+                    .join(" ")
+                : result.content;
+              throw new Error(errorMessage);
             }
             return result.content;
           },

--- a/react-sdk/src/mcp/tambo-mcp-provider.tsx
+++ b/react-sdk/src/mcp/tambo-mcp-provider.tsx
@@ -3,6 +3,20 @@ import { TamboTool } from "../model/component-metadata";
 import { useTamboRegistry } from "../providers/tambo-registry-provider";
 import { MCPClient, MCPTransport } from "./mcp-client";
 
+/**
+ * Extracts error message from MCP tool result content.
+ * Handles both array and non-array content formats.
+ */
+export function extractErrorMessage(content: any): string {
+  if (Array.isArray(content)) {
+    return content
+      .filter((item) => item.type === "text")
+      .map((item) => item.text)
+      .join(" ");
+  }
+  return content;
+}
+
 export interface McpServerInfo {
   name?: string;
   url: string;
@@ -70,13 +84,7 @@ export const TamboMcpProvider: FC<{
             }
             const result = await mcpServer.callTool(tool.name, args);
             if (result.isError) {
-              // Extract error message from content array
-              const errorMessage = Array.isArray(result.content)
-                ? result.content
-                    .filter((item) => item.type === "text")
-                    .map((item) => item.text)
-                    .join(" ")
-                : result.content;
+              const errorMessage = extractErrorMessage(result.content);
               throw new Error(errorMessage);
             }
             return result.content;

--- a/react-sdk/src/mcp/tambo-mcp-provider.tsx
+++ b/react-sdk/src/mcp/tambo-mcp-provider.tsx
@@ -5,16 +5,31 @@ import { MCPClient, MCPTransport } from "./mcp-client";
 
 /**
  * Extracts error message from MCP tool result content.
- * Handles both array and non-array content formats.
+ * Handles both array and string content formats.
+ * Always returns a string, even for invalid/null inputs.
  */
-export function extractErrorMessage(content: any): string {
-  if (Array.isArray(content)) {
-    return content
-      .filter((item) => item.type === "text")
-      .map((item) => item.text)
-      .join(" ");
+export function extractErrorMessage(content: unknown): string {
+  if (!content) {
+    return "Unknown error occurred";
   }
-  return content;
+
+  if (Array.isArray(content)) {
+    const textItems = content
+      .filter(
+        (item) => item && item.type === "text" && typeof item.text === "string",
+      )
+      .map((item) => item.text);
+
+    return textItems.length > 0
+      ? textItems.join(" ")
+      : "Error occurred but no details provided";
+  }
+
+  if (typeof content === "string") {
+    return content;
+  }
+
+  return "Invalid error content format";
 }
 
 export interface McpServerInfo {

--- a/react-sdk/src/mcp/tambo-mcp-provider.tsx
+++ b/react-sdk/src/mcp/tambo-mcp-provider.tsx
@@ -25,11 +25,11 @@ export function extractErrorMessage(content: unknown): string {
       : "Error occurred but no details provided";
   }
 
-  if (typeof content === "string") {
-    return content;
+  if (typeof content === "object") {
+    return JSON.stringify(content);
   }
 
-  return "Invalid error content format";
+  return `error content: ${content}`;
 }
 
 export interface McpServerInfo {


### PR DESCRIPTION
Updates our MCP tool call error handling to expect the `resonse` object to contain a `content` field that is an array of content part objects, rather than assuming it will be a string. Described here https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling

Avoids returning "Error: [object Object]" to tambo, which doesn't tell tambo anything about the error's reason. 