### PR TITLE
chore(showcase): add robots.txt and sitemap link

### DIFF
--- a/showcase/src/app/robots.ts
+++ b/showcase/src/app/robots.ts
@@ -1,10 +1,21 @@
+import { getBaseUrl, isProduction } from "@/lib/site";
+
 export default function robots() {
+  const baseUrl = getBaseUrl();
+  const allowIndexing = isProduction();
+
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-    },
-    sitemap: "https://ui.tambo.co/sitemap.xml",
+    rules: allowIndexing
+      ? {
+          userAgent: "*",
+          allow: "/",
+        }
+      : [
+          {
+            userAgent: "*",
+            disallow: "/",
+          },
+        ],
+    sitemap: `${baseUrl}/sitemap.xml`,
   };
 }
-

--- a/showcase/src/app/sitemap.ts
+++ b/showcase/src/app/sitemap.ts
@@ -1,5 +1,7 @@
+import { getBaseUrl } from "@/lib/site";
+
 export default function sitemap() {
-  const baseUrl = "https://ui.tambo.co";
+  const baseUrl = getBaseUrl();
   return [
     {
       url: `${baseUrl}/`,
@@ -15,4 +17,3 @@ export default function sitemap() {
     },
   ];
 }
-

--- a/showcase/src/lib/site.ts
+++ b/showcase/src/lib/site.ts
@@ -1,0 +1,9 @@
+export function getBaseUrl(): string {
+  const envBase = process.env.NEXT_PUBLIC_SITE_URL;
+  return envBase && envBase.trim().length > 0 ? envBase : "https://ui.tambo.co";
+}
+
+export function isProduction(): boolean {
+  // Next.js exposes NODE_ENV at build time
+  return process.env.NODE_ENV === "production";
+}


### PR DESCRIPTION
Add `robots.ts` and `sitemap.ts` to the `showcase` app to enable crawling and provide a sitemap, following Next.js App Router best practices.

---
<a href="https://cursor.com/background-agent?bcId=bc-efbb1cfd-cba0-4c18-a7f4-d1b932008aeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-efbb1cfd-cba0-4c18-a7f4-d1b932008aeb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

