### PR TITLE
Add programmatic OG image support

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,15 +1,15 @@
 import "@/app/global.css";
-import { RootProvider } from "fumadocs-ui/provider";
-import { ThemeProvider } from "next-themes";
-import { Inter } from "next/font/google";
+import { WebVitalsReporter } from "@/components/web-vitals";
 import {
   PostHogPageview,
   PostHogRootProvider,
 } from "@/providers/posthog-provider";
-import { Suspense } from "react";
-import { WebVitalsReporter } from "@/components/web-vitals";
-import type { Metadata } from "next";
 import { TamboRootProvider } from "@/providers/tambo-provider";
+import { RootProvider } from "fumadocs-ui/provider";
+import type { Metadata } from "next";
+import { ThemeProvider } from "next-themes";
+import { Inter } from "next/font/google";
+import { Suspense } from "react";
 
 const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.ai";
 
@@ -28,12 +28,21 @@ export const metadata: Metadata = {
     url: baseUrl,
     siteName: "Tambo AI Docs",
     type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Tambo AI Documentation"
+      }
+    ]
   },
   twitter: {
     card: "summary_large_image",
     title: "Tambo AI Documentation",
     description:
       "The documentation for Tambo AI - Build AI-powered applications with React components and streaming.",
+    images: "/twitter-image",
   },
   robots: {
     index: true,

--- a/docs/src/app/opengraph-image.tsx
+++ b/docs/src/app/opengraph-image.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "Tambo AI Documentation";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+  const title = "Tambo AI";
+  const tagline =
+    "Build AI-powered applications with React components and streaming.";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          background: "#0B0B0B",
+          color: "white",
+          padding: "72px",
+          fontFamily: "Inter, Arial, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 800,
+            marginBottom: 24,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: 36,
+            opacity: 0.9,
+            maxWidth: 900,
+            lineHeight: 1.3,
+          }}
+        >
+          {tagline}
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}
+

--- a/docs/src/app/twitter-image.tsx
+++ b/docs/src/app/twitter-image.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "Tambo AI Documentation";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+  const title = "Tambo AI";
+  const tagline =
+    "Build AI-powered applications with React components and streaming.";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          background: "#0B0B0B",
+          color: "white",
+          padding: "72px",
+          fontFamily: "Inter, Arial, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 800,
+            marginBottom: 24,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: 36,
+            opacity: 0.9,
+            maxWidth: 900,
+            lineHeight: 1.3,
+          }}
+        >
+          {tagline}
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}
+

--- a/showcase/src/app/layout.tsx
+++ b/showcase/src/app/layout.tsx
@@ -30,6 +30,27 @@ export const metadata: Metadata = {
     initialScale: 1,
     maximumScale: 1,
   },
+  openGraph: {
+    title: "tambo",
+    description: "Build AI-powered apps with just one line of code",
+    url: "https://tambo.co",
+    siteName: "tambo",
+    type: "website",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "tambo"
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "tambo",
+    description: "Build AI-powered apps with just one line of code",
+    images: "/twitter-image",
+  },
 };
 
 export default function RootLayout({

--- a/showcase/src/app/opengraph-image.tsx
+++ b/showcase/src/app/opengraph-image.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "tambo";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+  const title = "tambo";
+  const tagline = "Build AI-powered apps with just one line of code";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          background: "#0B0B0B",
+          color: "white",
+          padding: "72px",
+          fontFamily: "Inter, Arial, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 96,
+            fontWeight: 800,
+            marginBottom: 24,
+            letterSpacing: -2,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: 40,
+            opacity: 0.9,
+            maxWidth: 900,
+            lineHeight: 1.3,
+          }}
+        >
+          {tagline}
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}
+

--- a/showcase/src/app/twitter-image.tsx
+++ b/showcase/src/app/twitter-image.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "tambo";
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+  const title = "tambo";
+  const tagline = "Build AI-powered apps with just one line of code";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          background: "#0B0B0B",
+          color: "white",
+          padding: "72px",
+          fontFamily: "Inter, Arial, sans-serif",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 96,
+            fontWeight: 800,
+            marginBottom: 24,
+            letterSpacing: -2,
+          }}
+        >
+          {title}
+        </div>
+        <div
+          style={{
+            fontSize: 40,
+            opacity: 0.9,
+            maxWidth: 900,
+            lineHeight: 1.3,
+          }}
+        >
+          {tagline}
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}
+


### PR DESCRIPTION
Add Open Graph and Twitter metadata with programmatic Vercel OG images to improve social sharing and SEO for `docs` and `showcase`.

---
<a href="https://cursor.com/background-agent?bcId=bc-08166c48-74d8-4867-8dd1-d929f1059cf8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08166c48-74d8-4867-8dd1-d929f1059cf8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

