### PR TITLE
Review showcase site metadata

### DIFF
--- a/showcase/src/app/layout.tsx
+++ b/showcase/src/app/layout.tsx
@@ -7,16 +7,17 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: {
-    template: "%s | tambo",
-    default: "tambo | Build AI-powered apps with just one line of code",
+    template: "%s | tambo-ui",
+    default: "tambo-ui | A component library for Generative Interfaces",
   },
-  description: "Build AI-powered apps with just one line of code",
+  description:
+    "Build natural language interfaces with React. Use our component library to build your app in a weekend.",
   keywords: ["Tambo", "Showcase", "Components", "AI", "App Development"],
-  metadataBase: new URL("https://tambo.co"),
+  metadataBase: new URL("https://ui.tambo.co"),
   authors: [
     {
       name: "tambo",
-      url: "https://tambo.co",
+      url: "https://ui.tambo.co",
     },
   ],
   alternates: {


### PR DESCRIPTION
Update showcase site metadata to reflect the correct deployment domain (`ui.tambo.co`) and new branding for the title and description.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e491ea5-b750-46b8-942d-3fffed826481">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e491ea5-b750-46b8-942d-3fffed826481">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

