### PR TITLE
Fix tambo docs file and provider errors

### DIFF
--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,15 +1,20 @@
 import "@/app/global.css";
-import { RootProvider } from "fumadocs-ui/provider";
-import { ThemeProvider } from "next-themes";
-import { Inter } from "next/font/google";
+import { WebVitalsReporter } from "@/components/web-vitals";
 import {
   PostHogPageview,
   PostHogRootProvider,
 } from "@/providers/posthog-provider";
-import { Suspense } from "react";
-import { WebVitalsReporter } from "@/components/web-vitals";
+import { RootProvider } from "fumadocs-ui/provider";
 import type { Metadata } from "next";
-import { TamboRootProvider } from "@/providers/tambo-provider";
+import { ThemeProvider } from "next-themes";
+import dynamic from "next/dynamic";
+import { Inter } from "next/font/google";
+import { Suspense } from "react";
+
+const TamboRootProvider = dynamic(
+  () => import("@/providers/tambo-provider").then((m) => m.TamboRootProvider),
+  { ssr: false },
+);
 
 const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.ai";
 


### PR DESCRIPTION
Dynamically import `TamboRootProvider` with `ssr: false` to prevent it from being rendered on the server.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bde610e-6f01-44ed-b4eb-f6b49f072869">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bde610e-6f01-44ed-b4eb-f6b49f072869">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

