### PR TITLE
Update sitemap domain to docs.tambo.co

### DIFF
--- a/docs/src/app/sitemap.ts
+++ b/docs/src/app/sitemap.ts
@@ -1,7 +1,7 @@
-import { MetadataRoute } from "next";
 import { source } from "@/lib/source";
+import { MetadataRoute } from "next";
 
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.ai";
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const pages = source.getPages();


### PR DESCRIPTION
Update sitemap base URL to use the correct domain `docs.tambo.co`.

---
<a href="https://cursor.com/background-agent?bcId=bc-1643dd1c-5d20-4845-a049-f99ddfbd2198">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1643dd1c-5d20-4845-a049-f99ddfbd2198">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

