### PR TITLE
feat(sdk): Add onCallUnregisteredTool callback for handling unexpected tool callbacks

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@tambo-ai/react": "*",
-    "@tambo-ai/typescript-sdk": "^0.69.0",
+    "@tambo-ai/typescript-sdk": "^0.70.0",
     "chalk": "^5.6.0",
     "cli-table3": "^0.6.5",
     "clipboardy": "^4.0.0",

--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createMarkdownComponents } from "@/components/ui/markdown-components";
 import { checkHasContent, getSafeContent } from "@/lib/thread-hooks";
 import { cn } from "@/lib/utils";
 import type { TamboThreadMessage } from "@tambo-ai/react";
@@ -11,7 +12,6 @@ import { Check, ChevronDown, ExternalLink, Loader2, X } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
 import { Streamdown } from "streamdown";
-import { createMarkdownComponents } from "@/components/ui/markdown-components";
 
 /**
  * CSS variants for the message container
@@ -380,9 +380,7 @@ const ToolcallInfo = React.forwardRef<HTMLDivElement, ToolcallInfoProps>(
 
 ToolcallInfo.displayName = "ToolcallInfo";
 
-function keyifyParameters(
-  parameters: TamboAI.ToolCallRequest["parameters"] | undefined,
-) {
+function keyifyParameters(parameters: TamboAI.ToolCallParameter[] | undefined) {
   if (!parameters) return;
   return Object.fromEntries(
     parameters.map((p) => [p.parameterName, p.parameterValue]),

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tambo-ai/react": "*",
-    "@tambo-ai/typescript-sdk": "^0.69.0",
+    "@tambo-ai/typescript-sdk": "^0.70.0",
     "class-variance-authority": "^0.7.1",
     "dompurify": "^3.2.6",
     "framer-motion": "^12.23.12",

--- a/docs/src/components/tambo/message.tsx
+++ b/docs/src/components/tambo/message.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createMarkdownComponents } from "@/components/tambo/markdown-components";
 import { checkHasContent, getSafeContent } from "@/lib/thread-hooks";
 import { cn } from "@/lib/utils";
 import type { TamboThreadMessage } from "@tambo-ai/react";
@@ -11,7 +12,6 @@ import { Check, ChevronDown, ExternalLink, Loader2, X } from "lucide-react";
 import * as React from "react";
 import { useState } from "react";
 import { Streamdown } from "streamdown";
-import { createMarkdownComponents } from "@/components/tambo/markdown-components";
 
 /**
  * CSS variants for the message container
@@ -380,9 +380,7 @@ const ToolcallInfo = React.forwardRef<HTMLDivElement, ToolcallInfoProps>(
 
 ToolcallInfo.displayName = "ToolcallInfo";
 
-function keyifyParameters(
-  parameters: TamboAI.ToolCallRequest["parameters"] | undefined,
-) {
+function keyifyParameters(parameters: TamboAI.ToolCallParameter[] | undefined) {
   if (!parameters) return;
   return Object.fromEntries(
     parameters.map((p) => [p.parameterName, p.parameterValue]),

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       "version": "0.31.0",
       "dependencies": {
         "@tambo-ai/react": "*",
-        "@tambo-ai/typescript-sdk": "^0.69.0",
+        "@tambo-ai/typescript-sdk": "^0.70.0",
         "chalk": "^5.6.0",
         "cli-table3": "^0.6.5",
         "clipboardy": "^4.0.0",
@@ -71,9 +71,9 @@
       }
     },
     "cli/node_modules/@types/node": {
-      "version": "22.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
-      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -112,7 +112,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@tambo-ai/react": "*",
-        "@tambo-ai/typescript-sdk": "^0.69.0",
+        "@tambo-ai/typescript-sdk": "^0.70.0",
         "class-variance-authority": "^0.7.1",
         "dompurify": "^3.2.6",
         "framer-motion": "^12.23.12",
@@ -160,9 +160,9 @@
       }
     },
     "docs/node_modules/tailwindcss": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
-      "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
+      "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2385,21 +2385,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.4",
+        "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2407,9 +2407,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8184,9 +8184,9 @@
       "link": true
     },
     "node_modules/@tambo-ai/typescript-sdk": {
-      "version": "0.69.0",
-      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.69.0.tgz",
-      "integrity": "sha512-ebl1SPPhv6dFZmIxQjRDwN2kraX5Tbn07vwyWIhUI+KwSNWFNu2NVNZ56VY2JYvPholyZh8OzpEN1WhSkJx1/Q==",
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/@tambo-ai/typescript-sdk/-/typescript-sdk-0.70.0.tgz",
+      "integrity": "sha512-xO/rlU6OI5NQe0xILa7GP/dELDyYw0Prrncy83XCU90N8oMPP1gjJ07VzVhT2u/u903lQlWiF3SnrPffLeTDCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -8949,9 +8949,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
-      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "version": "20.19.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
+      "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -9778,9 +9778,9 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.0.tgz",
+      "integrity": "sha512-YdhtCd19sKRKfAAUsrcC1wzm4JuzJoiX4pOJqIoW2qmKj5WzG/dL8uUJ0361zaXtHqK7gEhOwtAtz7t3Yq3X5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9794,9 +9794,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
-      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9806,9 +9806,9 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10629,9 +10629,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -12593,9 +12593,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -14523,9 +14523,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -14733,9 +14733,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -19154,13 +19154,13 @@
       }
     },
     "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
-      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-east-asian-width": "^1.0.0"
+        "get-east-asian-width": "^1.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -19170,9 +19170,9 @@
       }
     },
     "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
-      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21547,9 +21547,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
-      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -21709,9 +21709,9 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
-      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -24051,9 +24051,9 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -25918,9 +25918,9 @@
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26343,7 +26343,7 @@
       "version": "0.48.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.4",
-        "@tambo-ai/typescript-sdk": "^0.69.0",
+        "@tambo-ai/typescript-sdk": "^0.70.0",
         "@tanstack/react-query": "^5.85.5",
         "partial-json": "^0.1.7",
         "react-fast-compare": "^3.2.2",
@@ -26392,9 +26392,9 @@
       }
     },
     "react-sdk/node_modules/@types/node": {
-      "version": "22.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
-      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26409,7 +26409,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@react-leaflet/core": "^2.1.0",
         "@tambo-ai/react": "*",
-        "@tambo-ai/typescript-sdk": "^0.69.0",
+        "@tambo-ai/typescript-sdk": "^0.70.0",
         "@vercel/og": "^0.6.3",
         "class-variance-authority": "^0.7.1",
         "dompurify": "^3.2.6",
@@ -26460,9 +26460,9 @@
       }
     },
     "showcase/node_modules/@types/node": {
-      "version": "22.17.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
-      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "version": "22.18.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.1.tgz",
+      "integrity": "sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.4",
-    "@tambo-ai/typescript-sdk": "^0.69.0",
+    "@tambo-ai/typescript-sdk": "^0.70.0",
     "@tanstack/react-query": "^5.85.5",
     "partial-json": "^0.1.7",
     "react-fast-compare": "^3.2.2",

--- a/react-sdk/src/providers/__tests__/tambo-registry-provider.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-registry-provider.test.tsx
@@ -1,0 +1,331 @@
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { z } from "zod";
+import { TamboComponent, TamboTool } from "../../model/component-metadata";
+import {
+  TamboRegistryProvider,
+  useTamboRegistry,
+} from "../tambo-registry-provider";
+
+// Shared tool registry for all tests
+const createMockTools = (): TamboTool[] => [
+  {
+    name: "test-tool-1",
+    description: "First test tool",
+    tool: jest.fn().mockResolvedValue("test-tool-1-result"),
+    toolSchema: z
+      .function()
+      .args(z.string().describe("input parameter"))
+      .returns(z.string()),
+  },
+  {
+    name: "test-tool-2",
+    description: "Second test tool",
+    tool: jest.fn().mockResolvedValue("test-tool-2-result"),
+    toolSchema: z
+      .function()
+      .args(z.number().describe("number parameter"))
+      .returns(z.string()),
+  },
+];
+
+const createMockComponents = (tools: TamboTool[]): TamboComponent[] => [
+  {
+    name: "TestComponent",
+    component: () => <div>TestComponent</div>,
+    description: "Test component",
+    propsSchema: z.object({
+      test: z.string(),
+    }),
+    associatedTools: tools,
+  },
+];
+
+describe("TamboRegistryProvider", () => {
+  const mockTools = createMockTools();
+  const mockComponents = createMockComponents(mockTools);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Component and tool registration", () => {
+    it("should register components and tools correctly", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider components={mockComponents}>
+          {children}
+        </TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      expect(result.current.componentList).toHaveProperty("TestComponent");
+      expect(result.current.toolRegistry).toHaveProperty("test-tool-1");
+      expect(result.current.toolRegistry).toHaveProperty("test-tool-2");
+      expect(result.current.componentToolAssociations).toHaveProperty(
+        "TestComponent",
+      );
+      expect(result.current.componentToolAssociations.TestComponent).toEqual([
+        "test-tool-1",
+        "test-tool-2",
+      ]);
+    });
+
+    it("should provide onCallUnregisteredTool in context", () => {
+      const mockonCallUnregisteredTool = jest
+        .fn()
+        .mockResolvedValue("test-result");
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider
+          components={mockComponents}
+          onCallUnregisteredTool={mockonCallUnregisteredTool}
+        >
+          {children}
+        </TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      // The onCallUnregisteredTool should be available in the context
+      expect(result.current.onCallUnregisteredTool).toBeDefined();
+      expect(typeof result.current.onCallUnregisteredTool).toBe("function");
+    });
+
+    it("should handle tool registration and association", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider>{children}</TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      // Register a new tool
+      act(() => {
+        result.current.registerTool(mockTools[0]);
+      });
+
+      expect(result.current.toolRegistry).toHaveProperty("test-tool-1");
+
+      // Register a new component
+      act(() => {
+        result.current.registerComponent(mockComponents[0]);
+      });
+
+      expect(result.current.componentList).toHaveProperty("TestComponent");
+      expect(result.current.componentToolAssociations).toHaveProperty(
+        "TestComponent",
+      );
+    });
+
+    it("should handle multiple tool registration", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider>{children}</TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      // Register multiple tools
+      act(() => {
+        result.current.registerTools(mockTools);
+      });
+
+      expect(result.current.toolRegistry).toHaveProperty("test-tool-1");
+      expect(result.current.toolRegistry).toHaveProperty("test-tool-2");
+      expect(Object.keys(result.current.toolRegistry)).toHaveLength(2);
+    });
+
+    it("should handle tool association with components", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider components={mockComponents}>
+          {children}
+        </TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      // Add a new tool association
+      act(() => {
+        const newTool: TamboTool = {
+          name: "new-tool",
+          description: "New tool",
+          tool: jest.fn().mockResolvedValue("new-tool-result"),
+          toolSchema: z
+            .function()
+            .args(z.string().describe("input"))
+            .returns(z.string()),
+        };
+        result.current.addToolAssociation("TestComponent", newTool);
+      });
+
+      expect(result.current.componentToolAssociations.TestComponent).toContain(
+        "new-tool",
+      );
+    });
+
+    it("should throw error when adding tool association to non-existent component", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider>{children}</TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      const newTool: TamboTool = {
+        name: "new-tool",
+        description: "New tool",
+        tool: jest.fn().mockResolvedValue("new-tool-result"),
+        toolSchema: z
+          .function()
+          .args(z.string().describe("input"))
+          .returns(z.string()),
+      };
+
+      expect(() => {
+        act(() => {
+          result.current.addToolAssociation("NonExistentComponent", newTool);
+        });
+      }).toThrow("Component NonExistentComponent not found in registry");
+    });
+
+    it("should validate tool schemas and throw error for invalid schemas", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider>{children}</TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      const invalidTool: TamboTool = {
+        name: "invalid-tool",
+        description: "Invalid tool",
+        tool: jest.fn().mockResolvedValue("result"),
+        toolSchema: z.record(z.string()), // This should cause validation to fail
+      };
+
+      // This should throw during registration due to invalid schema
+      expect(() => {
+        act(() => {
+          result.current.registerTool(invalidTool);
+        });
+      }).toThrow(
+        'z.record() is not supported in toolSchema of tool "invalid-tool"',
+      );
+    });
+
+    it("should validate component schemas and throw error for invalid schemas", () => {
+      const invalidComponent: TamboComponent = {
+        name: "InvalidComponent",
+        component: () => <div>Invalid</div>,
+        description: "Invalid component",
+        propsSchema: z.record(z.string()), // This should cause validation to fail
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider>{children}</TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      // This should throw during registration due to invalid schema
+      expect(() => {
+        act(() => {
+          result.current.registerComponent(invalidComponent);
+        });
+      }).toThrow(
+        'z.record() is not supported in propsSchema of component "InvalidComponent"',
+      );
+    });
+
+    it("should throw error when component has both propsSchema and propsDefinition", () => {
+      const invalidComponent: TamboComponent = {
+        name: "InvalidComponent",
+        component: () => <div>Invalid</div>,
+        description: "Invalid component",
+        propsSchema: z.object({ test: z.string() }),
+        propsDefinition: { test: "string" }, // Both defined - should throw
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider>{children}</TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      expect(() => {
+        act(() => {
+          result.current.registerComponent(invalidComponent);
+        });
+      }).toThrow(
+        "Component InvalidComponent cannot have both propsSchema and propsDefinition defined",
+      );
+    });
+
+    it("should throw error when component has neither propsSchema nor propsDefinition", () => {
+      const invalidComponent: TamboComponent = {
+        name: "InvalidComponent",
+        component: () => <div>Invalid</div>,
+        description: "Invalid component",
+        // Neither propsSchema nor propsDefinition defined - should throw
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider>{children}</TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      expect(() => {
+        act(() => {
+          result.current.registerComponent(invalidComponent);
+        });
+      }).toThrow(
+        "Component InvalidComponent must have either propsSchema (recommended) or propsDefinition defined",
+      );
+    });
+  });
+
+  describe("Tool call handling", () => {
+    it("should provide onCallUnregisteredTool callback for handling unknown tools", async () => {
+      const mockonCallUnregisteredTool = jest
+        .fn()
+        .mockResolvedValue("unknown-tool-result");
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider
+          components={mockComponents}
+          onCallUnregisteredTool={mockonCallUnregisteredTool}
+        >
+          {children}
+        </TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      // Verify the callback is available
+      expect(result.current.onCallUnregisteredTool).toBeDefined();
+      expect(typeof result.current.onCallUnregisteredTool).toBe("function");
+
+      // Simulate calling the unknown tool handler
+      const toolName = "unknown-tool";
+      const args = [{ parameterName: "input", parameterValue: "test-input" }];
+
+      await act(async () => {
+        if (result.current.onCallUnregisteredTool) {
+          await result.current.onCallUnregisteredTool(toolName, args);
+        }
+      });
+
+      expect(mockonCallUnregisteredTool).toHaveBeenCalledWith(toolName, args);
+    });
+
+    it("should handle onCallUnregisteredTool being undefined", () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <TamboRegistryProvider components={mockComponents}>
+          {children}
+        </TamboRegistryProvider>
+      );
+
+      const { result } = renderHook(() => useTamboRegistry(), { wrapper });
+
+      expect(result.current.onCallUnregisteredTool).toBeUndefined();
+    });
+  });
+});

--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -75,7 +75,7 @@ export const TamboProvider: React.FC<
   streaming,
   contextHelpers,
   contextKey,
-  onCallUnknownTool,
+  onCallUnregisteredTool,
 }) => {
   // Should only be used in browser
   if (typeof window === "undefined") {
@@ -92,7 +92,7 @@ export const TamboProvider: React.FC<
       <TamboRegistryProvider
         components={components}
         tools={tools}
-        onCallUnknownTool={onCallUnknownTool}
+        onCallUnregisteredTool={onCallUnregisteredTool}
       >
         <TamboContextHelpersProvider contextHelpers={contextHelpers}>
           <TamboThreadProvider streaming={streaming}>

--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -75,6 +75,7 @@ export const TamboProvider: React.FC<
   streaming,
   contextHelpers,
   contextKey,
+  onCallUnknownTool,
 }) => {
   // Should only be used in browser
   if (typeof window === "undefined") {
@@ -88,7 +89,11 @@ export const TamboProvider: React.FC<
       environment={environment}
       userToken={userToken}
     >
-      <TamboRegistryProvider components={components} tools={tools}>
+      <TamboRegistryProvider
+        components={components}
+        tools={tools}
+        onCallUnknownTool={onCallUnknownTool}
+      >
         <TamboContextHelpersProvider contextHelpers={contextHelpers}>
           <TamboThreadProvider streaming={streaming}>
             <TamboThreadInputProvider contextKey={contextKey}>

--- a/react-sdk/src/providers/tambo-registry-provider.tsx
+++ b/react-sdk/src/providers/tambo-registry-provider.tsx
@@ -25,7 +25,7 @@ export interface TamboRegistryContext {
   registerTool: (tool: TamboTool) => void;
   registerTools: (tools: TamboTool[]) => void;
   addToolAssociation: (componentName: string, tool: TamboTool) => void;
-  onCallUnknownTool?: (
+  onCallUnregisteredTool?: (
     toolName: string,
     args: TamboAI.ToolCallRequest["parameters"],
   ) => Promise<string>;
@@ -67,10 +67,10 @@ export interface TamboRegistryProviderProps {
    * Note that this is generally only for agents, where the agent code may
    * request tool calls that are not registered in the tool registry.
    */
-  onCallUnknownTool?: (
+  onCallUnregisteredTool?: (
     toolName: string,
     args: TamboAI.ToolCallRequest["parameters"],
-  ) => void;
+  ) => Promise<string>;
 }
 
 /**
@@ -80,11 +80,17 @@ export interface TamboRegistryProviderProps {
  * @param props.children - The children to wrap
  * @param props.components - The components to register
  * @param props.tools - The tools to register
+ * @param props.onCallUnregisteredTool - The function to call when an unknown tool is called (optional)
  * @returns The TamboRegistryProvider component
  */
 export const TamboRegistryProvider: React.FC<
   PropsWithChildren<TamboRegistryProviderProps>
-> = ({ children, components: userComponents, tools: userTools }) => {
+> = ({
+  children,
+  components: userComponents,
+  tools: userTools,
+  onCallUnregisteredTool,
+}) => {
   const [componentList, setComponentList] = useState<ComponentRegistry>({});
   const [toolRegistry, setToolRegistry] = useState<Record<string, TamboTool>>(
     {},
@@ -214,6 +220,7 @@ export const TamboRegistryProvider: React.FC<
     registerTool,
     registerTools,
     addToolAssociation,
+    onCallUnregisteredTool,
   };
 
   return (

--- a/react-sdk/src/providers/tambo-registry-provider.tsx
+++ b/react-sdk/src/providers/tambo-registry-provider.tsx
@@ -59,6 +59,14 @@ export interface TamboRegistryProviderProps {
   /** The tools to register */
   tools?: TamboTool[];
 
+  /**
+   * A function to call when an unknown tool is called. If this function is not
+   * provided, an error will be thrown when a tool call is requested by the
+   * server.
+   *
+   * Note that this is generally only for agents, where the agent code may
+   * request tool calls that are not registered in the tool registry.
+   */
   onCallUnknownTool?: (
     toolName: string,
     args: TamboAI.ToolCallRequest["parameters"],

--- a/react-sdk/src/providers/tambo-registry-provider.tsx
+++ b/react-sdk/src/providers/tambo-registry-provider.tsx
@@ -1,4 +1,5 @@
 "use client";
+import type TamboAI from "@tambo-ai/typescript-sdk";
 import React, {
   createContext,
   PropsWithChildren,
@@ -24,6 +25,10 @@ export interface TamboRegistryContext {
   registerTool: (tool: TamboTool) => void;
   registerTools: (tools: TamboTool[]) => void;
   addToolAssociation: (componentName: string, tool: TamboTool) => void;
+  onCallUnknownTool?: (
+    toolName: string,
+    args: TamboAI.ToolCallRequest["parameters"],
+  ) => Promise<string>;
 }
 
 export const TamboRegistryContext = createContext<TamboRegistryContext>({
@@ -53,6 +58,11 @@ export interface TamboRegistryProviderProps {
   components?: TamboComponent[];
   /** The tools to register */
   tools?: TamboTool[];
+
+  onCallUnknownTool?: (
+    toolName: string,
+    args: TamboAI.ToolCallRequest["parameters"],
+  ) => void;
 }
 
 /**

--- a/react-sdk/src/providers/tambo-registry-provider.tsx
+++ b/react-sdk/src/providers/tambo-registry-provider.tsx
@@ -27,7 +27,7 @@ export interface TamboRegistryContext {
   addToolAssociation: (componentName: string, tool: TamboTool) => void;
   onCallUnregisteredTool?: (
     toolName: string,
-    args: TamboAI.ToolCallRequest["parameters"],
+    args: TamboAI.ToolCallParameter[],
   ) => Promise<string>;
 }
 
@@ -69,7 +69,7 @@ export interface TamboRegistryProviderProps {
    */
   onCallUnregisteredTool?: (
     toolName: string,
-    args: TamboAI.ToolCallRequest["parameters"],
+    args: TamboAI.ToolCallParameter[],
   ) => Promise<string>;
 }
 

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -860,6 +860,7 @@ export const TamboThreadProvider: React.FC<
           const toolCallResponse = await handleToolCall(
             advanceResponse.responseMessageDto,
             toolRegistry,
+            onCallUnregisteredTool,
           );
           const toolResponseString =
             typeof toolCallResponse.result === "string"
@@ -942,6 +943,7 @@ export const TamboThreadProvider: React.FC<
       handleAdvanceStream,
       streaming,
       getAdditionalContext,
+      onCallUnregisteredTool,
     ],
   );
 

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -211,8 +211,12 @@ export const TamboThreadProvider: React.FC<
     [PLACEHOLDER_THREAD.id]: PLACEHOLDER_THREAD,
   });
   const client = useTamboClient();
-  const { componentList, toolRegistry, componentToolAssociations } =
-    useTamboRegistry();
+  const {
+    componentList,
+    toolRegistry,
+    componentToolAssociations,
+    onCallUnknownTool,
+  } = useTamboRegistry();
   const { getAdditionalContext } = useTamboContextHelpers();
   const [ignoreResponse, setIgnoreResponse] = useState(false);
   const ignoreResponseRef = useRef(ignoreResponse);
@@ -581,6 +585,7 @@ export const TamboThreadProvider: React.FC<
           const toolCallResponse = await handleToolCall(
             chunk.responseMessageDto,
             toolRegistry,
+            onCallUnknownTool,
           );
           if (ignoreResponseRef.current) {
             setIgnoreResponse(false);
@@ -723,6 +728,7 @@ export const TamboThreadProvider: React.FC<
       client,
       componentList,
       currentThread?.id,
+      onCallUnknownTool,
       switchCurrentThread,
       toolRegistry,
       updateThreadMessage,

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -215,7 +215,7 @@ export const TamboThreadProvider: React.FC<
     componentList,
     toolRegistry,
     componentToolAssociations,
-    onCallUnknownTool,
+    onCallUnregisteredTool,
   } = useTamboRegistry();
   const { getAdditionalContext } = useTamboContextHelpers();
   const [ignoreResponse, setIgnoreResponse] = useState(false);
@@ -585,7 +585,7 @@ export const TamboThreadProvider: React.FC<
           const toolCallResponse = await handleToolCall(
             chunk.responseMessageDto,
             toolRegistry,
-            onCallUnknownTool,
+            onCallUnregisteredTool,
           );
           if (ignoreResponseRef.current) {
             setIgnoreResponse(false);
@@ -728,7 +728,7 @@ export const TamboThreadProvider: React.FC<
       client,
       componentList,
       currentThread?.id,
-      onCallUnknownTool,
+      onCallUnregisteredTool,
       switchCurrentThread,
       toolRegistry,
       updateThreadMessage,

--- a/react-sdk/src/util/tool-caller.ts
+++ b/react-sdk/src/util/tool-caller.ts
@@ -14,6 +14,10 @@ import { mapTamboToolToContextTool } from "./registry";
 export const handleToolCall = async (
   message: TamboAI.Beta.Threads.ThreadMessage,
   toolRegistry: TamboToolRegistry,
+  onCallUnknownTool?: (
+    toolName: string,
+    args: TamboAI.ToolCallRequest["parameters"],
+  ) => Promise<string>,
 ): Promise<{
   result: string;
   error?: string;
@@ -24,6 +28,17 @@ export const handleToolCall = async (
 
   try {
     const tool = findTool(message.toolCallRequest.toolName, toolRegistry);
+    if (!tool) {
+      if (onCallUnknownTool) {
+        onCallUnknownTool(
+          message.toolCallRequest.toolName,
+          message.toolCallRequest.parameters,
+        );
+      }
+      throw new Error(
+        `Tool ${message.toolCallRequest.toolName} not found in registry`,
+      );
+    }
     return {
       result: await runToolChoice(message.toolCallRequest, tool),
     };
@@ -40,7 +55,7 @@ const findTool = (toolName: string, toolRegistry: TamboToolRegistry) => {
   const registryTool = toolRegistry[toolName];
 
   if (!registryTool) {
-    throw new Error(`Tool ${toolName} not found in registry`);
+    return null;
   }
 
   const contextTool = mapTamboToolToContextTool(registryTool);

--- a/react-sdk/src/util/tool-caller.ts
+++ b/react-sdk/src/util/tool-caller.ts
@@ -16,7 +16,7 @@ export const handleToolCall = async (
   toolRegistry: TamboToolRegistry,
   onCallUnregisteredTool?: (
     toolName: string,
-    args: TamboAI.ToolCallRequest["parameters"],
+    args: TamboAI.ToolCallParameter[],
   ) => Promise<string>,
 ): Promise<{
   result: string;

--- a/react-sdk/src/util/tool-caller.ts
+++ b/react-sdk/src/util/tool-caller.ts
@@ -14,7 +14,7 @@ import { mapTamboToolToContextTool } from "./registry";
 export const handleToolCall = async (
   message: TamboAI.Beta.Threads.ThreadMessage,
   toolRegistry: TamboToolRegistry,
-  onCallUnknownTool?: (
+  onCallUnregisteredTool?: (
     toolName: string,
     args: TamboAI.ToolCallRequest["parameters"],
   ) => Promise<string>,
@@ -29,11 +29,14 @@ export const handleToolCall = async (
   try {
     const tool = findTool(message.toolCallRequest.toolName, toolRegistry);
     if (!tool) {
-      if (onCallUnknownTool) {
-        onCallUnknownTool(
+      if (onCallUnregisteredTool) {
+        const result = await onCallUnregisteredTool(
           message.toolCallRequest.toolName,
           message.toolCallRequest.parameters,
         );
+        return {
+          result,
+        };
       }
       throw new Error(
         `Tool ${message.toolCallRequest.toolName} not found in registry`,

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -15,7 +15,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@react-leaflet/core": "^2.1.0",
     "@tambo-ai/react": "*",
-    "@tambo-ai/typescript-sdk": "^0.69.0",
+    "@tambo-ai/typescript-sdk": "^0.70.0",
     "class-variance-authority": "^0.7.1",
     "dompurify": "^3.2.6",
     "framer-motion": "^12.23.12",
@@ -33,8 +33,8 @@
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
     "react-markdown": "^10.1.0",
-    "streamdown": "^1.1.5",
     "recharts": "^3.1.2",
+    "streamdown": "^1.1.5",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {

--- a/showcase/src/components/ui/message.tsx
+++ b/showcase/src/components/ui/message.tsx
@@ -392,9 +392,7 @@ const ToolcallInfo = React.forwardRef<HTMLDivElement, ToolcallInfoProps>(
 
 ToolcallInfo.displayName = "ToolcallInfo";
 
-function keyifyParameters(
-  parameters: TamboAI.ToolCallRequest["parameters"] | undefined,
-) {
+function keyifyParameters(parameters: TamboAI.ToolCallParameter[] | undefined) {
   if (!parameters) return;
   return Object.fromEntries(
     parameters.map((p) => [p.parameterName, p.parameterValue]),


### PR DESCRIPTION
This allows for having a handler when an unregistered tool is called

```ts
const handleTool = useCallback(async (toolName: string, args) => {
  console.log("Found an unknown tool", toolName);
  return "Nope!";
},[]);

...
return <TamboProvider tools={myTools} onCallUnknownTool={handleTool}>...</TamboProvider>;
```


- **add new onCallUnknownTool handler**
- **add docs**
