### PR TITLE
fix(ui): When tool calls are big, allow scrolling

### DIFF
--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -346,7 +346,7 @@ const ToolcallInfo = React.forwardRef<HTMLDivElement, ToolcallInfoProps>(
           <div
             id={toolDetailsId}
             className={cn(
-              "flex flex-col gap-1 p-3 overflow-hidden transition-[max-height,opacity,padding] duration-300 w-full",
+              "flex flex-col gap-1 p-3 overflow-auto transition-[max-height,opacity,padding] duration-300 w-full",
               isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0 p-0",
             )}
           >

--- a/docs/src/components/tambo/message.tsx
+++ b/docs/src/components/tambo/message.tsx
@@ -346,7 +346,7 @@ const ToolcallInfo = React.forwardRef<HTMLDivElement, ToolcallInfoProps>(
           <div
             id={toolDetailsId}
             className={cn(
-              "flex flex-col gap-1 p-3 overflow-hidden transition-[max-height,opacity,padding] duration-300 w-full",
+              "flex flex-col gap-1 p-3 overflow-auto transition-[max-height,opacity,padding] duration-300 w-full",
               isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0 p-0",
             )}
           >


### PR DESCRIPTION
just adds a scrollbar when the tool call region is really big (like when tool call parameters are huge)