### PR TITLE
Investigate sitemap fetch error

### DIFF
--- a/docs/src/app/robots.ts
+++ b/docs/src/app/robots.ts
@@ -1,6 +1,6 @@
 import { MetadataRoute } from "next";
 
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.ai";
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
 
 export default function robots(): MetadataRoute.Robots {
   return {


### PR DESCRIPTION
Update the default sitemap URL in `robots.ts` to resolve Google Search Console's "Couldn't fetch" error.

The `robots.txt` was incorrectly advertising `https://docs.tambo.ai/sitemap.xml` due to a hardcoded base URL, while the sitemap was submitted for `https://docs.tambo.co/sitemap.xml`. This mismatch prevented Googlebot from fetching the sitemap.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e4328d7-c1b5-4a09-9c5f-0ad22e10b6c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e4328d7-c1b5-4a09-9c5f-0ad22e10b6c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

