### PR TITLE
feat(mcp): Add reconnection logic + method to MCP Client

### DIFF
--- a/react-sdk/src/mcp/__tests__/mcp-client.test.ts
+++ b/react-sdk/src/mcp/__tests__/mcp-client.test.ts
@@ -1,0 +1,424 @@
+import { MCPClient, MCPTransport } from "../mcp-client";
+
+// Mock the MCP SDK modules
+jest.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    connect: jest.fn(),
+    close: jest.fn(),
+    listTools: jest.fn(),
+    callTool: jest.fn(),
+    onclose: null,
+  })),
+}));
+
+jest.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: jest.fn().mockImplementation(() => ({
+    // SSE transport doesn't have sessionId
+  })),
+}));
+
+jest.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: jest
+    .fn()
+    .mockImplementation((url, options) => ({
+      sessionId: options?.sessionId,
+    })),
+}));
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+// Type the mocked modules
+const MockedClient = Client as jest.MockedClass<typeof Client>;
+const MockedSSEClientTransport = SSEClientTransport as jest.MockedClass<
+  typeof SSEClientTransport
+>;
+const MockedStreamableHTTPClientTransport =
+  StreamableHTTPClientTransport as jest.MockedClass<
+    typeof StreamableHTTPClientTransport
+  >;
+
+describe("MCPClient", () => {
+  let mockClientInstance: any;
+  let mockTransportInstance: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create mock instances
+    mockClientInstance = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn().mockResolvedValue(undefined),
+      listTools: jest.fn(),
+      callTool: jest.fn(),
+      onclose: null,
+    };
+
+    mockTransportInstance = {
+      sessionId: "test-session-id",
+    };
+
+    // Setup mocks
+    MockedClient.mockImplementation(() => mockClientInstance);
+    MockedStreamableHTTPClientTransport.mockImplementation(
+      () => mockTransportInstance,
+    );
+    MockedSSEClientTransport.mockImplementation(
+      () => ({}) as SSEClientTransport,
+    );
+  });
+
+  describe("create", () => {
+    it("should create and connect an MCPClient with HTTP transport by default", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const headers = { Authorization: "Bearer token" };
+
+      const client = await MCPClient.create(
+        endpoint,
+        MCPTransport.HTTP,
+        headers,
+      );
+
+      expect(MockedStreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL(endpoint),
+        { sessionId: undefined, requestInit: { headers } },
+      );
+      expect(MockedClient).toHaveBeenCalledWith({
+        name: "tambo-mcp-client",
+        version: "1.0.0",
+      });
+      expect(mockClientInstance.connect).toHaveBeenCalledWith(
+        mockTransportInstance,
+      );
+      expect(client).toBeInstanceOf(MCPClient);
+    });
+
+    it("should create and connect an MCPClient with SSE transport", async () => {
+      const endpoint = "https://api.example.com/mcp";
+
+      const client = await MCPClient.create(endpoint, MCPTransport.SSE);
+
+      expect(MockedSSEClientTransport).toHaveBeenCalledWith(new URL(endpoint), {
+        requestInit: { headers: {} },
+      });
+      expect(mockClientInstance.connect).toHaveBeenCalledWith({});
+      expect(client).toBeInstanceOf(MCPClient);
+    });
+
+    it("should create client with default headers when none provided", async () => {
+      const endpoint = "https://api.example.com/mcp";
+
+      await MCPClient.create(endpoint);
+
+      expect(MockedStreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL(endpoint),
+        { sessionId: undefined, requestInit: { headers: {} } },
+      );
+    });
+  });
+
+  describe("reconnect", () => {
+    it("should reconnect with the same session ID for HTTP transport", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+
+      // Clear previous calls
+      jest.clearAllMocks();
+
+      await client.reconnect();
+
+      expect(mockClientInstance.close).toHaveBeenCalled();
+      expect(MockedStreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL(endpoint),
+        { sessionId: "test-session-id", requestInit: { headers: {} } },
+      );
+      expect(MockedClient).toHaveBeenCalledWith({
+        name: "tambo-mcp-client",
+        version: "1.0.0",
+      });
+      expect(mockClientInstance.connect).toHaveBeenCalledWith(
+        mockTransportInstance,
+      );
+    });
+
+    it("should reconnect without session ID for SSE transport", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.SSE);
+
+      // Clear previous calls
+      jest.clearAllMocks();
+
+      await client.reconnect();
+
+      expect(mockClientInstance.close).toHaveBeenCalled();
+      expect(MockedSSEClientTransport).toHaveBeenCalledWith(new URL(endpoint), {
+        requestInit: { headers: {} },
+      });
+      expect(mockClientInstance.connect).toHaveBeenCalledWith({});
+    });
+
+    it("should handle close errors when reportErrorOnClose is true", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+      // Make close throw an error
+      mockClientInstance.close.mockRejectedValue(new Error("Close failed"));
+
+      await client.reconnect(true);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error closing Tambo MCP Client:",
+        expect.any(Error),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("should not log close errors when reportErrorOnClose is false", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+      // Make close throw an error
+      mockClientInstance.close.mockRejectedValue(new Error("Close failed"));
+
+      await client.reconnect(false);
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("onclose", () => {
+    it("should call reconnect when client closes", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+      const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
+      const reconnectSpy = jest.spyOn(client, "reconnect").mockResolvedValue();
+
+      // Simulate the onclose callback
+      await (client as any).onclose();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Tambo MCP Client closed, reconnecting...",
+      );
+      expect(reconnectSpy).toHaveBeenCalledWith(false);
+
+      consoleSpy.mockRestore();
+      reconnectSpy.mockRestore();
+    });
+  });
+
+  describe("listTools", () => {
+    it("should list all tools with pagination", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+
+      const mockTools = [
+        {
+          name: "tool1",
+          description: "First tool",
+          inputSchema: {
+            type: "object",
+            properties: { arg1: { type: "string" } },
+          },
+        },
+        {
+          name: "tool2",
+          description: "Second tool",
+          inputSchema: {
+            type: "object",
+            properties: { arg2: { type: "number" } },
+          },
+        },
+      ];
+
+      const mockResponse1 = {
+        tools: [mockTools[0]],
+        nextCursor: "cursor1",
+      };
+
+      const mockResponse2 = {
+        tools: [mockTools[1]],
+        nextCursor: undefined,
+      };
+
+      mockClientInstance.listTools
+        .mockResolvedValueOnce(mockResponse1)
+        .mockResolvedValueOnce(mockResponse2);
+
+      const result = await client.listTools();
+
+      expect(mockClientInstance.listTools).toHaveBeenCalledTimes(2);
+      expect(mockClientInstance.listTools).toHaveBeenNthCalledWith(
+        1,
+        { cursor: undefined },
+        {},
+      );
+      expect(mockClientInstance.listTools).toHaveBeenNthCalledWith(
+        2,
+        { cursor: "cursor1" },
+        {},
+      );
+      expect(result).toEqual([
+        {
+          name: "tool1",
+          description: "First tool",
+          inputSchema: {
+            type: "object",
+            properties: { arg1: { type: "string" } },
+          },
+        },
+        {
+          name: "tool2",
+          description: "Second tool",
+          inputSchema: {
+            type: "object",
+            properties: { arg2: { type: "number" } },
+          },
+        },
+      ]);
+    });
+
+    it("should handle single page of tools", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+
+      const mockTools = [
+        {
+          name: "tool1",
+          description: "Only tool",
+          inputSchema: {
+            type: "object",
+            properties: { arg1: { type: "string" } },
+          },
+        },
+      ];
+
+      const mockResponse = {
+        tools: mockTools,
+        nextCursor: undefined,
+      };
+
+      mockClientInstance.listTools.mockResolvedValue(mockResponse);
+
+      const result = await client.listTools();
+
+      expect(mockClientInstance.listTools).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([
+        {
+          name: "tool1",
+          description: "Only tool",
+          inputSchema: {
+            type: "object",
+            properties: { arg1: { type: "string" } },
+          },
+        },
+      ]);
+    });
+
+    it("should throw error for invalid input schema", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+
+      const mockTools = [
+        {
+          name: "invalid-tool",
+          description: "Tool with invalid schema",
+          inputSchema: { type: "string" }, // Invalid - should be object
+        },
+      ];
+
+      const mockResponse = {
+        tools: mockTools,
+        nextCursor: undefined,
+      };
+
+      mockClientInstance.listTools.mockResolvedValue(mockResponse);
+
+      await expect(client.listTools()).rejects.toThrow(
+        "Input schema for tool invalid-tool is not an object",
+      );
+    });
+  });
+
+  describe("callTool", () => {
+    it("should call a tool with arguments", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+
+      const mockResult = { success: true, data: "test result" };
+      mockClientInstance.callTool.mockResolvedValue(mockResult);
+
+      const result = await client.callTool("testTool", {
+        arg1: "value1",
+        arg2: 42,
+      });
+
+      expect(mockClientInstance.callTool).toHaveBeenCalledWith({
+        name: "testTool",
+        arguments: { arg1: "value1", arg2: 42 },
+      });
+      expect(result).toBe(mockResult);
+    });
+
+    it("should handle tool call errors", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const client = await MCPClient.create(endpoint, MCPTransport.HTTP);
+
+      const error = new Error("Tool call failed");
+      mockClientInstance.callTool.mockRejectedValue(error);
+
+      await expect(client.callTool("testTool", {})).rejects.toThrow(
+        "Tool call failed",
+      );
+    });
+  });
+
+  describe("transport initialization", () => {
+    it("should initialize HTTP transport with session ID", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const headers = { Authorization: "Bearer token" };
+
+      await MCPClient.create(endpoint, MCPTransport.HTTP, headers);
+
+      expect(MockedStreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL(endpoint),
+        { sessionId: undefined, requestInit: { headers } },
+      );
+    });
+
+    it("should initialize SSE transport without session ID", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const headers = { Authorization: "Bearer token" };
+
+      await MCPClient.create(endpoint, MCPTransport.SSE, headers);
+
+      expect(MockedSSEClientTransport).toHaveBeenCalledWith(new URL(endpoint), {
+        requestInit: { headers },
+      });
+    });
+  });
+
+  describe("client initialization", () => {
+    it("should initialize client with correct name and version", async () => {
+      const endpoint = "https://api.example.com/mcp";
+
+      await MCPClient.create(endpoint);
+
+      expect(MockedClient).toHaveBeenCalledWith({
+        name: "tambo-mcp-client",
+        version: "1.0.0",
+      });
+    });
+
+    it("should set onclose handler", async () => {
+      const endpoint = "https://api.example.com/mcp";
+      const _client = await MCPClient.create(endpoint);
+
+      expect(mockClientInstance.onclose).toBeDefined();
+      expect(typeof mockClientInstance.onclose).toBe("function");
+    });
+  });
+});

--- a/react-sdk/src/mcp/mcp-client.ts
+++ b/react-sdk/src/mcp/mcp-client.ts
@@ -47,7 +47,7 @@ export class MCPClient {
    * This is the recommended way to create an MCPClient as it handles both
    * instantiation and connection setup.
    * @param endpoint - The URL of the MCP server to connect to
-   * @param transport - The transport type to use for the MCP client. Defaults to HTTP.
+   * @param transportType - The transport type to use for the MCP client. Defaults to HTTP.
    * @param headers - Optional custom headers to include in requests
    * @returns A connected MCPClient instance ready for use
    * @throws Will throw an error if connection fails
@@ -62,13 +62,17 @@ export class MCPClient {
     return mcpClient;
   }
   /**
-   * Reconnects to the MCP server, retaining the same session ID.
-   *
+   * Reconnects to the MCP server, optionally retaining the same session ID.
+   * @param newSession - Whether to create a new session (true) or reuse existing session ID (false)
+   * @param reportErrorOnClose - Whether to report errors when closing the client
    * Note that only StreamableHTTPClientTransport supports session IDs.
    */
-  async reconnect(reportErrorOnClose = true) {
-    const sessionId =
-      "sessionId" in this.transport ? this.transport.sessionId : undefined;
+  async reconnect(newSession = false, reportErrorOnClose = true) {
+    const sessionId = newSession
+      ? undefined
+      : "sessionId" in this.transport
+        ? this.transport.sessionId
+        : undefined;
     try {
       await this.client.close();
     } catch (error) {
@@ -84,7 +88,7 @@ export class MCPClient {
 
   private async onclose() {
     console.warn("Tambo MCP Client closed, reconnecting...");
-    await this.reconnect(false);
+    await this.reconnect(false, false);
   }
 
   private initializeTransport(sessionId: string | undefined) {

--- a/react-sdk/src/mcp/mcp-client.ts
+++ b/react-sdk/src/mcp/mcp-client.ts
@@ -23,6 +23,42 @@ export class MCPClient {
   private transportType: MCPTransport;
   private endpoint: string;
   private headers: Record<string, string>;
+  /**
+   * Tracks an in-flight reconnect so concurrent triggers coalesce
+   * (single-flight). When set, additional calls to `reconnect()` or
+   * the automatic `onclose` handler will await the same Promise instead of
+   * starting another reconnect sequence.
+   */
+  private reconnecting?: Promise<void>;
+  /**
+   * Timer id for a scheduled automatic reconnect (used by `onclose`).
+   * Present only while waiting for the backoff delay to elapse.
+   */
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  /**
+   * Count of consecutive automatic reconnect failures used to compute
+   * exponential backoff. Reset to 0 after a successful connection.
+   */
+  private backoffAttempts = 0;
+
+  /**
+   * Backoff policy (discoverable constants)
+   * - BACKOFF_INITIAL_MS: initial delay for the first automatic retry
+   * - BACKOFF_MULTIPLIER: exponential growth factor for each failed attempt
+   * - BACKOFF_MAX_MS: upper bound for the delay
+   * - BACKOFF_JITTER_RATIO: jitter range as a fraction of the base delay
+   *
+   * Jitter is applied symmetrically in [-ratio, +ratio]. For example, with a
+   * 500ms base delay and 0.2 ratio, the actual delay is in [400ms, 600ms].
+   *
+   * The backoff applies only to automatic reconnects started from the
+   * `onclose` handler. Explicit/manual calls to `reconnect()` run immediately
+   * (no backoff), and will preempt any scheduled automatic attempt.
+   */
+  static readonly BACKOFF_INITIAL_MS = 500;
+  static readonly BACKOFF_MULTIPLIER = 2;
+  static readonly BACKOFF_MAX_MS = 30_000;
+  static readonly BACKOFF_JITTER_RATIO = 0.2;
 
   /**
    * Private constructor to enforce using the static create method.
@@ -63,32 +99,135 @@ export class MCPClient {
   }
   /**
    * Reconnects to the MCP server, optionally retaining the same session ID.
+   *
+   * Single‑flight semantics:
+   * - If a reconnect is already in progress (triggered either manually or by
+   * the automatic `onclose` handler), additional calls will await the
+   * in-flight reconnect rather than start another one.
+   * - If an automatic reconnect has been scheduled but not yet started (i.e.,
+   * we are waiting in a backoff delay), calling `reconnect()` manually will
+   * cancel the scheduled attempt and perform an immediate reconnect.
+   *
+   * Backoff policy:
+   * - Backoff delays with jitter are applied only for automatic reconnects
+   * (via `onclose`). Manual calls to `reconnect()` do not use backoff.
    * @param newSession - Whether to create a new session (true) or reuse existing session ID (false)
    * @param reportErrorOnClose - Whether to report errors when closing the client
    * Note that only StreamableHTTPClientTransport supports session IDs.
    */
   async reconnect(newSession = false, reportErrorOnClose = true) {
-    const sessionId = newSession
-      ? undefined
-      : "sessionId" in this.transport
-        ? this.transport.sessionId
-        : undefined;
-    try {
-      await this.client.close();
-    } catch (error) {
-      if (reportErrorOnClose) {
-        console.error("Error closing Tambo MCP Client:", error);
-      }
+    // If a reconnect is already running, coalesce into it.
+    if (this.reconnecting) {
+      return await this.reconnecting;
     }
-    this.transport = this.initializeTransport(sessionId);
-    this.client = this.initializeClient();
 
-    await this.client.connect(this.transport);
+    // Manual reconnect preempts any scheduled automatic attempt.
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+    }
+
+    const doReconnect = async () => {
+      const sessionId = newSession
+        ? undefined
+        : "sessionId" in this.transport
+          ? this.transport.sessionId
+          : undefined;
+
+      // Prevent re-entrant onclose during deliberate close by detaching
+      // the handler from the previous client instance.
+      const prevClient = this.client as any;
+      // Prevent re-entrant onclose callbacks from the previous client
+      prevClient.onclose = undefined;
+
+      try {
+        await prevClient.close();
+      } catch (error) {
+        if (reportErrorOnClose) {
+          console.error("Error closing Tambo MCP Client:", error);
+        }
+      }
+
+      this.transport = this.initializeTransport(sessionId);
+      this.client = this.initializeClient();
+      await this.client.connect(this.transport);
+    };
+
+    this.reconnecting = doReconnect()
+      .then(() => {
+        // Successful manual reconnect: reset backoff.
+        this.backoffAttempts = 0;
+      })
+      .finally(() => {
+        this.reconnecting = undefined;
+      });
+
+    return await this.reconnecting;
   }
 
-  private async onclose() {
-    console.warn("Tambo MCP Client closed, reconnecting...");
-    await this.reconnect(false, false);
+  /**
+   * Called by the underlying MCP SDK when the connection closes.
+   * Schedules an automatic reconnect with bounded exponential backoff and
+   * jitter. If a reconnect is already scheduled or running, this is a no-op.
+   */
+  private onclose() {
+    this.scheduleAutoReconnect();
+  }
+
+  /**
+   * Compute the next backoff delay with symmetric jitter.
+   */
+  private computeBackoffDelayMs(): number {
+    const base = Math.min(
+      MCPClient.BACKOFF_MAX_MS,
+      MCPClient.BACKOFF_INITIAL_MS *
+        Math.pow(MCPClient.BACKOFF_MULTIPLIER, this.backoffAttempts),
+    );
+    const jitterRange = MCPClient.BACKOFF_JITTER_RATIO * base;
+    const jitter = (Math.random() * 2 - 1) * jitterRange; // [-range, +range]
+    const ms = Math.max(0, Math.round(base + jitter));
+    return ms;
+  }
+
+  /**
+   * Schedule an automatic reconnect attempt if one is not already scheduled
+   * or running. Uses the backoff policy and self-reschedules on failure.
+   */
+  private scheduleAutoReconnect() {
+    if (this.reconnecting || this.reconnectTimer) {
+      return;
+    }
+
+    const delayMs = this.computeBackoffDelayMs();
+    console.warn(
+      "Tambo MCP Client closed; attempting automatic reconnect in",
+      `${delayMs}ms`,
+    );
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      // Start the actual reconnect (single-flight)
+      this.reconnecting = this.reconnect(false, false)
+        .then(() => {
+          // Success: reset attempts
+          this.backoffAttempts = 0;
+        })
+        .catch((err) => {
+          // Failure: increase attempts; scheduling occurs in finally below so the
+          // new timer isn't blocked by `this.reconnecting` being truthy.
+          this.backoffAttempts += 1;
+          console.warn(
+            "Automatic reconnect failed; will retry with backoff.",
+            err,
+          );
+        })
+        .finally(() => {
+          this.reconnecting = undefined;
+          if (this.backoffAttempts > 0) {
+            this.scheduleAutoReconnect();
+          }
+        });
+    }, delayMs);
   }
 
   private initializeTransport(sessionId: string | undefined) {

--- a/react-sdk/src/mcp/mcp-client.ts
+++ b/react-sdk/src/mcp/mcp-client.ts
@@ -135,12 +135,8 @@ export class MCPClient {
           : undefined;
 
       // Prevent re-entrant onclose during deliberate close by detaching
-      // the handler from the previous client instance without using `any`.
-      interface ClosableWithOptionalOnClose {
-        close: () => Promise<void>;
-        onclose?: (() => void) | null;
-      }
-      const prevClient = this.client as unknown as ClosableWithOptionalOnClose;
+      // the handler from the previous client instance.
+      const prevClient = this.client;
       // Prevent re-entrant onclose callbacks from the previous client
       prevClient.onclose = undefined;
 


### PR DESCRIPTION
This simply adds a reconnect() - it does not (yet) actually have an auto-reconnect or anything 