### PR TITLE
chore(publish): Only build publishable packages on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Publish @tambo-ai/react to npm
+      - name: Publish @tambo-ai/react to npm --filter=@tambo-ai/react --filter=tambo --filter=create-tambo-app
         if: ${{ needs.release-please.outputs.react-sdk--release_created == 'true' }}
         working-directory: ./react-sdk
         env:


### PR DESCRIPTION
this keeps us from building docs + showcase, just speeds up the publishing process by ~2-4 mins
