### PR TITLE
docs: Fix react-sdk docs for typos

### DIFF
--- a/react-sdk/README.md
+++ b/react-sdk/README.md
@@ -102,6 +102,34 @@ This is also handled automatically for you if you are using the `MessageThreadFu
 
 For custom components rendered by Tambo, you can use the `useTamboCurrentMessage` hook inside the component to access the current message.
 
+_Example (Tambo‑rendered custom component):_
+
+```tsx
+import { useTamboCurrentMessage } from "@tambo-ai/react";
+
+export function TamboRenderedMessage() {
+  const message = useTamboCurrentMessage();
+  return (
+    <div>
+      <div>Role: {message.role}</div>
+      <div>
+        {message.content.map((part, i) =>
+          part.type === "text" ? (
+            <div key={i}>{part.text}</div>
+          ) : (
+            <div key={i}>Non-text content: {part.type}</div>
+          ),
+        )}
+      </div>
+      {/* If Tambo provided rendered output, include it */}
+      <div>{message.renderedComponent}</div>
+    </div>
+  );
+}
+```
+
+If you're rendering your own message list (outside of a Tambo‑rendered component), you can instead pass each `message` as a prop, as shown below:
+
 ```tsx
 import { useTambo, type TamboThreadMessage } from "@tambo-ai/react";
 

--- a/react-sdk/README.md
+++ b/react-sdk/README.md
@@ -100,14 +100,10 @@ import { TamboProvider } from "@tambo-ai/react";
 
 This is also handled automatically for you if you are using the `MessageThreadFull` component.
 
-For custom components, you can use the `useMessageContext` hook to get the current message.
+For custom components rendered by Tambo, you can use the `useTamboCurrentMessage` hook inside the component to access the current message.
 
 ```tsx
-import {
-  useTambo,
-  useMessageContext,
-  type TamboThreadMessage,
-} from "@tambo-ai/react";
+import { useTambo, type TamboThreadMessage } from "@tambo-ai/react";
 
 function ChatHistory() {
   const { thread } = useTambo();
@@ -127,11 +123,11 @@ function CustomMessage({ message }: { message: TamboThreadMessage }) {
       {/* Render the message content */}
       <div>Role: {message.role}</div>
       <div>
-        {message.content.map((part) =>
+        {message.content.map((part, i) =>
           part.type === "text" ? (
-            <div key={part.id}>{part.text}</div>
+            <div key={i}>{part.text}</div>
           ) : (
-            <div key={part.id}>Non-text content: {part.type}</div>
+            <div key={i}>Non-text content: {part.type}</div>
           ),
         )}
       </div>
@@ -207,7 +203,15 @@ function ChatInterface() {
       <div>
         {thread.messages.map((message, index) => (
           <div key={index} className={`message ${message.role}`}>
-            <div>{message.content}</div>
+            <div>
+              {message.content.map((part, i) =>
+                part.type === "text" ? (
+                  <div key={i}>{part.text}</div>
+                ) : (
+                  <div key={i}>Non-text content: {part.type}</div>
+                ),
+              )}
+            </div>
             {message.renderedComponent}
           </div>
         ))}
@@ -360,11 +364,12 @@ const tools: TamboTool[] = [
 ```tsx
 import { TamboProvider } from "@tambo-ai/react";
 import { TamboMcpProvider } from "@tambo-ai/react/mcp";
+import { MCPTransport } from "@tambo-ai/react/mcp";
 
 const mcpServers = [
   {
     url: "https://mcp-server-1.com",
-    transport: "http",
+    transport: MCPTransport.HTTP,
     name: "mcp-server-1",
   },
 ];
@@ -374,7 +379,9 @@ const mcpServers = [
   apiKey={process.env.NEXT_PUBLIC_TAMBO_API_KEY!}
   components={components}
 >
-  <TamboMcpProvider mcpServers={mcpServers}>{children}</TamboMcpProvider>
+  <TamboMcpProvider mcpServers={mcpServers}>
+    <YourApp />
+  </TamboMcpProvider>
 </TamboProvider>;
 ```
 

--- a/react-sdk/README.md
+++ b/react-sdk/README.md
@@ -229,8 +229,8 @@ function ChatInterface() {
     <div>
       {/* Display messages */}
       <div>
-        {thread.messages.map((message, index) => (
-          <div key={index} className={`message ${message.role}`}>
+        {thread.messages.map((message) => (
+          <div key={message.id} className={`message ${message.role}`}>
             <div>
               {message.content.map((part, i) =>
                 part.type === "text" ? (

--- a/react-sdk/src/providers/hooks/use-tambo-session-token.tsx
+++ b/react-sdk/src/providers/hooks/use-tambo-session-token.tsx
@@ -13,8 +13,8 @@ import { useEffect } from "react";
  * This hook is used by the TamboClientProvider.
  * @param client - The Tambo client.
  * @param queryClient - The query client.
- * @param userToken - The user token.
- * @returns The Tambo session token.
+ * @param userToken - The third-party OAuth token to exchange for a Tambo session.
+ * @returns React Query result for the session token (token data, fetching state, errors).
  */
 export function useTamboSessionToken(
   client: TamboAI,

--- a/react-sdk/src/providers/tambo-context-helpers-provider.tsx
+++ b/react-sdk/src/providers/tambo-context-helpers-provider.tsx
@@ -118,14 +118,14 @@ export const TamboContextHelpersProvider: React.FC<
 
 /**
  * Hook to access context helpers functionality.
- * Safe to call even when no provider is present: proxies to the global registry.
- * @returns The context helpers context props (registry-backed).
+ * Must be used within a TamboContextHelpersProvider. Throws if no provider is present.
+ * @returns The context helpers context props.
  */
 export const useTamboContextHelpers = () => {
   const context = useContext(TamboContextHelpersContext);
   if (context) return context;
 
-  // Fallback to global registry so the API is standalone outside any provider
+  // No provider present: expose methods that throw with a helpful error
   return {
     getAdditionalContext: async () => {
       throw new Error("No provider found");

--- a/react-sdk/src/providers/tambo-context-helpers-provider.tsx
+++ b/react-sdk/src/providers/tambo-context-helpers-provider.tsx
@@ -133,16 +133,24 @@ export const useTamboContextHelpers = () => {
   // No provider present: return methods that throw with a helpful error when used
   return {
     getAdditionalContext: async () => {
-      throw new Error("No provider found");
+      throw new Error(
+        "useTamboContextHelpers must be used within a TamboContextHelpersProvider",
+      );
     },
     getContextHelpers: () => {
-      throw new Error("No provider found");
+      throw new Error(
+        "useTamboContextHelpers must be used within a TamboContextHelpersProvider",
+      );
     },
     addContextHelper: (_name: string, _helper: ContextHelperFn) => {
-      throw new Error("No provider found");
+      throw new Error(
+        "useTamboContextHelpers must be used within a TamboContextHelpersProvider",
+      );
     },
     removeContextHelper: (_name: string) => {
-      throw new Error("No provider found");
+      throw new Error(
+        "useTamboContextHelpers must be used within a TamboContextHelpersProvider",
+      );
     },
   } as TamboContextHelpersContextProps;
 };

--- a/react-sdk/src/providers/tambo-context-helpers-provider.tsx
+++ b/react-sdk/src/providers/tambo-context-helpers-provider.tsx
@@ -118,14 +118,19 @@ export const TamboContextHelpersProvider: React.FC<
 
 /**
  * Hook to access context helpers functionality.
- * Must be used within a TamboContextHelpersProvider. Throws if no provider is present.
- * @returns The context helpers context props.
+ *
+ * Behavior without a provider: this hook does NOT throw immediately. If it is
+ * called outside of a `TamboContextHelpersProvider`, it returns a fallback
+ * object whose methods will throw when invoked. This "lazy-throw" pattern is
+ * intentional so the error surfaces at the actual point of use.
+ * @returns The context helpers API when a provider is present; otherwise, a
+ * fallback object whose methods throw if called.
  */
 export const useTamboContextHelpers = () => {
   const context = useContext(TamboContextHelpersContext);
   if (context) return context;
 
-  // No provider present: expose methods that throw with a helpful error
+  // No provider present: return methods that throw with a helpful error when used
   return {
     getAdditionalContext: async () => {
       throw new Error("No provider found");

--- a/react-sdk/src/providers/tambo-prop-stream-provider/index.tsx
+++ b/react-sdk/src/providers/tambo-prop-stream-provider/index.tsx
@@ -4,7 +4,7 @@ import { Streaming } from "./streaming";
 import { Success } from "./success";
 
 /**
- * The TamboPropsStreamProvider provides a context for managing stream states
+ * The TamboPropStreamProvider provides a context for managing stream states
  * with compound components for Pending, Streaming, and Success states.
  * @param children - The children to wrap
  * @returns The TamboPropStreamProvider component

--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -52,7 +52,7 @@ import {
  * @param props.tools - The tools to register
  * @param props.streaming - Whether to stream the response by default. Defaults to true.
  * @param props.contextHelpers - Configuration for which context helpers are enabled/disabled
- * @param props.userToken - The JWT id token to use to identify the user in the Tambo API. (preferred over contextKey)
+ * @param props.userToken - The user's OAuth token (access or ID) used to identify the user and exchange for a Tambo session token (preferred over contextKey)
  * @param props.contextKey - Optional context key to be used in the thread input provider
  * @param props.onCallUnregisteredTool - Callback function called when an unregistered tool is called
  * @returns The TamboProvider component


### PR DESCRIPTION
Corrected JSDoc comments and README examples to accurately reflect `react-sdk` API behavior and usage.

This PR addresses several inaccuracies in the `react-sdk`'s JSDoc and README, including:
- Clarifying `useTamboSessionToken` and `TamboProvider` `userToken` descriptions.
- Updating `useTamboContextHelpers` JSDoc to enforce provider usage.
- Fixing a typo in `TamboPropStreamProvider` JSDoc.
- Correcting README examples for `useTamboCurrentMessage`, `message.content` mapping, and `TamboMcpProvider` usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb1c314c-41d6-4d0e-8cb0-8c7c0ef84b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb1c314c-41d6-4d0e-8cb0-8c7c0ef84b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

