### PR TITLE
fix(thread-history): improve sidebar animation smoothness

### DIFF
--- a/cli/src/registry/thread-history/thread-history.tsx
+++ b/cli/src/registry/thread-history/thread-history.tsx
@@ -164,7 +164,7 @@ const ThreadHistory = React.forwardRef<HTMLDivElement, ThreadHistoryProps>(
           {...props}
         >
           <div
-            className={cn("flex flex-col h-full", isCollapsed ? "p-2" : "p-4")}
+            className={cn("flex flex-col h-full", isCollapsed ? "py-4 px-2" : "p-4")} // py-4 px-2 is for better alignment when isCollapsed 
           >
             {children}
           </div>
@@ -192,20 +192,24 @@ const ThreadHistoryHeader = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "flex items-center justify-between mb-4",
-        isCollapsed ? "p-1" : "p-2",
+        "flex items-center mb-4 relative",
+        isCollapsed ? "p-1" : "p-1",
         className,
       )}
       {...props}
     >
-      {!isCollapsed && (
-        <h2 className="text-sm text-muted-foreground">Tambo Conversations</h2>
-      )}
+      <h2 
+        className={cn(
+          "text-sm text-muted-foreground whitespace-nowrap ",
+          isCollapsed ? "opacity-0 max-w-0 overflow-hidden ": "opacity-100 max-w-none transition-all duration-300 delay-75")}
+      >
+        Tambo Conversations
+      </h2>
       <button
         onClick={() => setIsCollapsed(!isCollapsed)}
         className={cn(
-          "bg-container hover:bg-muted transition-colors p-1 hover:bg-backdrop rounded-md cursor-pointer",
-          position === "left" ? "ml-auto" : "",
+          `bg-container p-1 hover:bg-backdrop transition-colors rounded-md cursor-pointer absolute flex items-center justify-center`,
+          position === "left" ? "right-1" : "left-0",
         )}
         aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
       >
@@ -266,14 +270,17 @@ const ThreadHistoryNewButton = React.forwardRef<
       ref={ref}
       onClick={handleNewThread}
       className={cn(
-        "flex items-center gap-2 rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer",
-        isCollapsed ? "p-1 justify-center" : "p-2",
+        "flex items-center rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer relative",
+        isCollapsed ? "p-1 justify-center" : "p-2 gap-2",
       )}
-      title="New thread"
+       title="New thread"
       {...props}
     >
       <PlusIcon className="h-4 w-4 bg-green-600 rounded-full text-white" />
-      {!isCollapsed && <span className="text-sm font-medium">New thread</span>}
+      <span className={cn(
+        "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px] ",
+        isCollapsed ? "opacity-0 max-w-0 overflow-hidden pointer-events-none": "opacity-100 transition-all duration-300 delay-100"
+      )}>New thread</span>
     </button>
   );
 });
@@ -301,38 +308,47 @@ const ThreadHistorySearch = React.forwardRef<
 
   return (
     <div
-      ref={ref}
+     ref={ref}
+     className={cn(
+      "mb-4 relative",
+      className,
+    )}
+    {...props}
+  >
+    {/*visible when collapsed */}
+    <button
+      onClick={expandOnSearch}
       className={cn(
-        "mb-4",
-        isCollapsed ? "flex justify-center" : "relative",
-        className,
+        "p-1 hover:bg-backdrop rounded-md cursor-pointer absolute left-1/2 -translate-x-1/2",
+        isCollapsed 
+          ? "opacity-100 pointer-events-auto transition-all duration-300" 
+          : "opacity-0 pointer-events-none"
       )}
-      {...props}
+      title="Search threads"
     >
-      {isCollapsed ? (
-        <button
-          onClick={expandOnSearch}
-          className="p-1 hover:bg-backdrop rounded-md cursor-pointer transition-colors"
-          title="Search threads"
-        >
-          <SearchIcon className="h-4 w-4 text-gray-400" />
-        </button>
-      ) : (
-        <>
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <SearchIcon className="h-4 w-4 text-gray-400" />
-          </div>
-          <input
-            ref={searchInputRef}
-            type="text"
-            className="pl-10 pr-4 py-2 w-full text-sm rounded-md bg-container focus:outline-none"
-            placeholder="Search..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-        </>
-      )}
+      <SearchIcon className="h-4 w-4 text-gray-400" />
+    </button>
+    
+    {/*visible when expanded with delay */}
+
+    <div className={cn(  //using this as wrapper
+      isCollapsed 
+        ? "opacity-0 pointer-events-none" 
+        : "opacity-100 delay-100 transition-all duration-500"
+    )}>
+      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <SearchIcon className="h-4 w-4 text-gray-400" />
+      </div>
+      <input
+        ref={searchInputRef}
+        type="text"
+        className="pl-10 pr-4 py-2 w-full text-sm rounded-md bg-container focus:outline-none"
+        placeholder="Search..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+      />
     </div>
+  </div>
   );
 });
 ThreadHistorySearch.displayName = "ThreadHistory.Search";
@@ -468,7 +484,7 @@ const ThreadHistoryList = React.forwardRef<
     content = (
       <div
         ref={ref}
-        className={cn("text-sm text-destructive p-2", className)}
+        className={cn(`text-sm text-destructive p-2 whitespace-nowrap ${ isCollapsed?"opacity-0 max-w-0 overflow-hidden":"opacity-100"}`,className)}
         {...props}
       >
         Error loading threads
@@ -478,7 +494,7 @@ const ThreadHistoryList = React.forwardRef<
     content = (
       <div
         ref={ref}
-        className={cn("text-sm text-muted-foreground p-2", className)}
+        className={cn(`text-sm text-muted-foreground p-2 whitespace-nowrap ${isCollapsed?"opacity-0 max-w-0 overflow-hidden":"opacity-100"}`,className)}
         {...props}
       >
         {searchQuery ? "No matching threads" : "No previous threads"}
@@ -627,5 +643,6 @@ export {
   ThreadHistoryList,
   ThreadHistoryNewButton,
   ThreadHistorySearch,
-  ThreadOptionsDropdown,
+  ThreadOptionsDropdown
 };
+

--- a/cli/src/registry/thread-history/thread-history.tsx
+++ b/cli/src/registry/thread-history/thread-history.tsx
@@ -164,7 +164,10 @@ const ThreadHistory = React.forwardRef<HTMLDivElement, ThreadHistoryProps>(
           {...props}
         >
           <div
-            className={cn("flex flex-col h-full", isCollapsed ? "py-4 px-2" : "p-4")} // py-4 px-2 is for better alignment when isCollapsed 
+            className={cn(
+              "flex flex-col h-full",
+              isCollapsed ? "py-4 px-2" : "p-4",
+            )} // py-4 px-2 is for better alignment when isCollapsed
           >
             {children}
           </div>
@@ -198,10 +201,13 @@ const ThreadHistoryHeader = React.forwardRef<
       )}
       {...props}
     >
-      <h2 
+      <h2
         className={cn(
           "text-sm text-muted-foreground whitespace-nowrap ",
-          isCollapsed ? "opacity-0 max-w-0 overflow-hidden ": "opacity-100 max-w-none transition-all duration-300 delay-75")}
+          isCollapsed
+            ? "opacity-0 max-w-0 overflow-hidden "
+            : "opacity-100 max-w-none transition-all duration-300 delay-75",
+        )}
       >
         Tambo Conversations
       </h2>
@@ -273,14 +279,20 @@ const ThreadHistoryNewButton = React.forwardRef<
         "flex items-center rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer relative",
         isCollapsed ? "p-1 justify-center" : "p-2 gap-2",
       )}
-       title="New thread"
+      title="New thread"
       {...props}
     >
       <PlusIcon className="h-4 w-4 bg-green-600 rounded-full text-white" />
-      <span className={cn(
-        "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px] ",
-        isCollapsed ? "opacity-0 max-w-0 overflow-hidden pointer-events-none": "opacity-100 transition-all duration-300 delay-100"
-      )}>New thread</span>
+      <span
+        className={cn(
+          "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px] ",
+          isCollapsed
+            ? "opacity-0 max-w-0 overflow-hidden pointer-events-none"
+            : "opacity-100 transition-all duration-300 delay-100",
+        )}
+      >
+        New thread
+      </span>
     </button>
   );
 });
@@ -307,48 +319,44 @@ const ThreadHistorySearch = React.forwardRef<
   };
 
   return (
-    <div
-     ref={ref}
-     className={cn(
-      "mb-4 relative",
-      className,
-    )}
-    {...props}
-  >
-    {/*visible when collapsed */}
-    <button
-      onClick={expandOnSearch}
-      className={cn(
-        "p-1 hover:bg-backdrop rounded-md cursor-pointer absolute left-1/2 -translate-x-1/2",
-        isCollapsed 
-          ? "opacity-100 pointer-events-auto transition-all duration-300" 
-          : "opacity-0 pointer-events-none"
-      )}
-      title="Search threads"
-    >
-      <SearchIcon className="h-4 w-4 text-gray-400" />
-    </button>
-    
-    {/*visible when expanded with delay */}
-
-    <div className={cn(  //using this as wrapper
-      isCollapsed 
-        ? "opacity-0 pointer-events-none" 
-        : "opacity-100 delay-100 transition-all duration-500"
-    )}>
-      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+    <div ref={ref} className={cn("mb-4 relative", className)} {...props}>
+      {/*visible when collapsed */}
+      <button
+        onClick={expandOnSearch}
+        className={cn(
+          "p-1 hover:bg-backdrop rounded-md cursor-pointer absolute left-1/2 -translate-x-1/2",
+          isCollapsed
+            ? "opacity-100 pointer-events-auto transition-all duration-300"
+            : "opacity-0 pointer-events-none",
+        )}
+        title="Search threads"
+      >
         <SearchIcon className="h-4 w-4 text-gray-400" />
+      </button>
+
+      {/*visible when expanded with delay */}
+
+      <div
+        className={cn(
+          //using this as wrapper
+          isCollapsed
+            ? "opacity-0 pointer-events-none"
+            : "opacity-100 delay-100 transition-all duration-500",
+        )}
+      >
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+          <SearchIcon className="h-4 w-4 text-gray-400" />
+        </div>
+        <input
+          ref={searchInputRef}
+          type="text"
+          className="pl-10 pr-4 py-2 w-full text-sm rounded-md bg-container focus:outline-none"
+          placeholder="Search..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
       </div>
-      <input
-        ref={searchInputRef}
-        type="text"
-        className="pl-10 pr-4 py-2 w-full text-sm rounded-md bg-container focus:outline-none"
-        placeholder="Search..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-      />
     </div>
-  </div>
   );
 });
 ThreadHistorySearch.displayName = "ThreadHistory.Search";
@@ -484,7 +492,10 @@ const ThreadHistoryList = React.forwardRef<
     content = (
       <div
         ref={ref}
-        className={cn(`text-sm text-destructive p-2 whitespace-nowrap ${ isCollapsed?"opacity-0 max-w-0 overflow-hidden":"opacity-100"}`,className)}
+        className={cn(
+          `text-sm text-destructive p-2 whitespace-nowrap ${isCollapsed ? "opacity-0 max-w-0 overflow-hidden" : "opacity-100"}`,
+          className,
+        )}
         {...props}
       >
         Error loading threads
@@ -494,7 +505,10 @@ const ThreadHistoryList = React.forwardRef<
     content = (
       <div
         ref={ref}
-        className={cn(`text-sm text-muted-foreground p-2 whitespace-nowrap ${isCollapsed?"opacity-0 max-w-0 overflow-hidden":"opacity-100"}`,className)}
+        className={cn(
+          `text-sm text-muted-foreground p-2 whitespace-nowrap ${isCollapsed ? "opacity-0 max-w-0 overflow-hidden" : "opacity-100"}`,
+          className,
+        )}
         {...props}
       >
         {searchQuery ? "No matching threads" : "No previous threads"}
@@ -643,6 +657,5 @@ export {
   ThreadHistoryList,
   ThreadHistoryNewButton,
   ThreadHistorySearch,
-  ThreadOptionsDropdown
+  ThreadOptionsDropdown,
 };
-

--- a/showcase/src/components/ui/thread-history.tsx
+++ b/showcase/src/components/ui/thread-history.tsx
@@ -164,7 +164,10 @@ const ThreadHistory = React.forwardRef<HTMLDivElement, ThreadHistoryProps>(
           {...props}
         >
           <div
-            className={cn("flex flex-col h-full", isCollapsed ? "py-4 px-2" : "p-4")} // py-4 px-2 is for better alignment when isCollapsed is true
+            className={cn(
+              "flex flex-col h-full",
+              isCollapsed ? "py-4 px-2" : "p-4",
+            )} // py-4 px-2 is for better alignment when isCollapsed is true
           >
             {children}
           </div>
@@ -198,10 +201,13 @@ const ThreadHistoryHeader = React.forwardRef<
       )}
       {...props}
     >
-      <h2 
+      <h2
         className={cn(
           "text-sm text-muted-foreground whitespace-nowrap ",
-          isCollapsed ? "opacity-0 max-w-0 overflow-hidden ": "opacity-100 max-w-none transition-all duration-300 delay-75")} 
+          isCollapsed
+            ? "opacity-0 max-w-0 overflow-hidden "
+            : "opacity-100 max-w-none transition-all duration-300 delay-75",
+        )}
       >
         Tambo Conversations
       </h2>
@@ -209,7 +215,7 @@ const ThreadHistoryHeader = React.forwardRef<
         onClick={() => setIsCollapsed(!isCollapsed)}
         className={cn(
           `bg-container p-1 hover:bg-backdrop rounded-md cursor-pointer absolute flex items-center justify-center`,
-          position === "left" ? "right-1" : "left-0", //right-1 is for better alignment 
+          position === "left" ? "right-1" : "left-0", //right-1 is for better alignment
         )}
         aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
       >
@@ -244,6 +250,7 @@ const ThreadHistoryNewButton = React.forwardRef<
 
       try {
         await startNewThread();
+        await refetch();
         onThreadChange?.();
       } catch (error) {
         console.error("Failed to create new thread:", error);
@@ -270,15 +277,22 @@ const ThreadHistoryNewButton = React.forwardRef<
       onClick={handleNewThread}
       className={cn(
         "flex items-center rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer relative",
-        isCollapsed ? "p-1 justify-center" : "p-2 gap-2",)}
+        isCollapsed ? "p-1 justify-center" : "p-2 gap-2",
+      )}
       title="New thread"
       {...props}
     >
       <PlusIcon className="h-4 w-4 bg-green-600 rounded-full text-white" />
-      <span className={cn(
-        "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px] ",
-        isCollapsed ? "opacity-0 max-w-0 overflow-hidden pointer-events-none": "opacity-100 transition-all duration-300 delay-100"
-      )}>New thread</span>
+      <span
+        className={cn(
+          "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px] ",
+          isCollapsed
+            ? "opacity-0 max-w-0 overflow-hidden pointer-events-none"
+            : "opacity-100 transition-all duration-300 delay-100",
+        )}
+      >
+        New thread
+      </span>
     </button>
   );
 });
@@ -305,35 +319,31 @@ const ThreadHistorySearch = React.forwardRef<
   };
 
   return (
-    <div
-      ref={ref}
-      className={cn(
-        "mb-4 relative",
-        className,
-      )}
-      {...props}
-    >
+    <div ref={ref} className={cn("mb-4 relative", className)} {...props}>
       {/*visible when collapsed */}
       <button
         onClick={expandOnSearch}
         className={cn(
           "p-1 hover:bg-backdrop rounded-md cursor-pointer absolute left-1/2 -translate-x-1/2",
-          isCollapsed 
-            ? "opacity-100 pointer-events-auto transition-all duration-300" 
-            : "opacity-0 pointer-events-none"
+          isCollapsed
+            ? "opacity-100 pointer-events-auto transition-all duration-300"
+            : "opacity-0 pointer-events-none",
         )}
         title="Search threads"
       >
         <SearchIcon className="h-4 w-4 text-gray-400" />
       </button>
-      
+
       {/*visible when expanded with delay */}
 
-      <div className={cn(  //using this as wrapper
-        isCollapsed 
-          ? "opacity-0 pointer-events-none" 
-          : "opacity-100 delay-100 transition-all duration-500"
-      )}>
+      <div
+        className={cn(
+          //using this as wrapper
+          isCollapsed
+            ? "opacity-0 pointer-events-none"
+            : "opacity-100 delay-100 transition-all duration-500",
+        )}
+      >
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <SearchIcon className="h-4 w-4 text-gray-400" />
         </div>
@@ -482,7 +492,10 @@ const ThreadHistoryList = React.forwardRef<
     content = (
       <div
         ref={ref}
-        className={cn(`text-sm text-destructive p-2 whitespace-nowrap ${ isCollapsed?"opacity-0 max-w-0 overflow-hidden":"opacity-100"}`,className)}
+        className={cn(
+          `text-sm text-destructive p-2 whitespace-nowrap ${isCollapsed ? "opacity-0 max-w-0 overflow-hidden" : "opacity-100"}`,
+          className,
+        )}
         {...props}
       >
         Error loading threads
@@ -492,7 +505,10 @@ const ThreadHistoryList = React.forwardRef<
     content = (
       <div
         ref={ref}
-        className={cn(`text-sm text-muted-foreground p-2 whitespace-nowrap ${isCollapsed?"opacity-0 max-w-0 overflow-hidden":"opacity-100"}`,className)}
+        className={cn(
+          `text-sm text-muted-foreground p-2 whitespace-nowrap ${isCollapsed ? "opacity-0 max-w-0 overflow-hidden" : "opacity-100"}`,
+          className,
+        )}
         {...props}
       >
         {searchQuery ? "No matching threads" : "No previous threads"}
@@ -641,6 +657,5 @@ export {
   ThreadHistoryList,
   ThreadHistoryNewButton,
   ThreadHistorySearch,
-  ThreadOptionsDropdown
+  ThreadOptionsDropdown,
 };
-

--- a/showcase/src/components/ui/thread-history.tsx
+++ b/showcase/src/components/ui/thread-history.tsx
@@ -164,7 +164,7 @@ const ThreadHistory = React.forwardRef<HTMLDivElement, ThreadHistoryProps>(
           {...props}
         >
           <div
-            className={cn("flex flex-col h-full", isCollapsed ? "p-2" : "p-4")}
+            className={cn("flex flex-col h-full", isCollapsed ? "py-4 px-2" : "p-4")} // py-4 px-2 is for better alignment when isCollapsed is true
           >
             {children}
           </div>
@@ -192,20 +192,24 @@ const ThreadHistoryHeader = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "flex items-center justify-between mb-4",
-        isCollapsed ? "p-1" : "p-2",
+        "flex items-center mb-4 relative",
+        isCollapsed ? "p-1" : "p-1",
         className,
       )}
       {...props}
     >
-      {!isCollapsed && (
-        <h2 className="text-sm text-muted-foreground">Tambo Conversations</h2>
-      )}
+      <h2 
+        className={cn(
+          "text-sm text-muted-foreground whitespace-nowrap ",
+          isCollapsed ? "opacity-0 max-w-0 overflow-hidden ": "opacity-100 max-w-none transition-all duration-300 delay-75")} 
+      >
+        Tambo Conversations
+      </h2>
       <button
         onClick={() => setIsCollapsed(!isCollapsed)}
         className={cn(
-          "bg-container hover:bg-muted transition-colors p-1 hover:bg-backdrop rounded-md cursor-pointer",
-          position === "left" ? "ml-auto" : "",
+          `bg-container p-1 hover:bg-backdrop rounded-md cursor-pointer absolute flex items-center justify-center`,
+          position === "left" ? "right-1" : "left-0", //right-1 is for better alignment 
         )}
         aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
       >
@@ -265,14 +269,16 @@ const ThreadHistoryNewButton = React.forwardRef<
       ref={ref}
       onClick={handleNewThread}
       className={cn(
-        "flex items-center gap-2 rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer",
-        isCollapsed ? "p-1 justify-center" : "p-2",
-      )}
+        "flex items-center rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer relative",
+        isCollapsed ? "p-1 justify-center" : "p-2 gap-2",)}
       title="New thread"
       {...props}
     >
       <PlusIcon className="h-4 w-4 bg-green-600 rounded-full text-white" />
-      {!isCollapsed && <span className="text-sm font-medium">New thread</span>}
+      <span className={cn(
+        "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px] ",
+        isCollapsed ? "opacity-0 max-w-0 overflow-hidden pointer-events-none": "opacity-100 transition-all duration-300 delay-100"
+      )}>New thread</span>
     </button>
   );
 });
@@ -302,35 +308,44 @@ const ThreadHistorySearch = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "mb-4",
-        isCollapsed ? "flex justify-center" : "relative",
+        "mb-4 relative",
         className,
       )}
       {...props}
     >
-      {isCollapsed ? (
-        <button
-          onClick={expandOnSearch}
-          className="p-1 hover:bg-backdrop rounded-md cursor-pointer transition-colors"
-          title="Search threads"
-        >
+      {/*visible when collapsed */}
+      <button
+        onClick={expandOnSearch}
+        className={cn(
+          "p-1 hover:bg-backdrop rounded-md cursor-pointer absolute left-1/2 -translate-x-1/2",
+          isCollapsed 
+            ? "opacity-100 pointer-events-auto transition-all duration-300" 
+            : "opacity-0 pointer-events-none"
+        )}
+        title="Search threads"
+      >
+        <SearchIcon className="h-4 w-4 text-gray-400" />
+      </button>
+      
+      {/*visible when expanded with delay */}
+
+      <div className={cn(  //using this as wrapper
+        isCollapsed 
+          ? "opacity-0 pointer-events-none" 
+          : "opacity-100 delay-100 transition-all duration-500"
+      )}>
+        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <SearchIcon className="h-4 w-4 text-gray-400" />
-        </button>
-      ) : (
-        <>
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <SearchIcon className="h-4 w-4 text-gray-400" />
-          </div>
-          <input
-            ref={searchInputRef}
-            type="text"
-            className="pl-10 pr-4 py-2 w-full text-sm rounded-md bg-container focus:outline-none"
-            placeholder="Search..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-        </>
-      )}
+        </div>
+        <input
+          ref={searchInputRef}
+          type="text"
+          className="pl-10 pr-4 py-2 w-full text-sm rounded-md bg-container focus:outline-none"
+          placeholder="Search..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </div>
     </div>
   );
 });
@@ -467,7 +482,7 @@ const ThreadHistoryList = React.forwardRef<
     content = (
       <div
         ref={ref}
-        className={cn("text-sm text-destructive p-2", className)}
+        className={cn(`text-sm text-destructive p-2 whitespace-nowrap ${ isCollapsed?"opacity-0 max-w-0 overflow-hidden":"opacity-100"}`,className)}
         {...props}
       >
         Error loading threads
@@ -477,7 +492,7 @@ const ThreadHistoryList = React.forwardRef<
     content = (
       <div
         ref={ref}
-        className={cn("text-sm text-muted-foreground p-2", className)}
+        className={cn(`text-sm text-muted-foreground p-2 whitespace-nowrap ${isCollapsed?"opacity-0 max-w-0 overflow-hidden":"opacity-100"}`,className)}
         {...props}
       >
         {searchQuery ? "No matching threads" : "No previous threads"}
@@ -626,5 +641,6 @@ export {
   ThreadHistoryList,
   ThreadHistoryNewButton,
   ThreadHistorySearch,
-  ThreadOptionsDropdown,
+  ThreadOptionsDropdown
 };
+


### PR DESCRIPTION
### Description
- This PR fixes the sidebar animation of the thread-history component when collapsing and expanding. The sidebar now opens smoothly without text wrapping issue.

### Changes
- Improved animation transitions for sidebar collapse/expand
- Fixed buggy feel while opening the sidebar

### Demo
-Before
https://github.com/user-attachments/assets/611423c1-18d5-44f5-812c-b3b762446331

-After
https://github.com/user-attachments/assets/98f8c2d3-91d9-41d9-9fcc-2767b4ed6627

https://github.com/user-attachments/assets/027829dd-7cbc-40be-805d-1aa9f4a574a4




### PR checklist
- [X] Semantic PR title using Conventional Commits (`feat`, `fix`, `!` for breaking)
- [X] Visual change demo video attached (≤ 2 min)
- [X] Showcase updated for component changes
- [X] CLI updated to support new components or options

---
###Note
 -First-time contributing to tambo, please let me know if I've missed any guidelines...happy to make adjustments.