### PR TITLE
docs: refine thread auto-naming guidance

### DIFF
--- a/docs/content/docs/concepts/message-threads/index.mdx
+++ b/docs/content/docs/concepts/message-threads/index.mdx
@@ -5,6 +5,8 @@ description: Understand how conversations are structured in Tambo.
 
 Message threads are the core building block for creating interactive AI experiences with Tambo. They provide a structured way to manage conversations between users and Tambo, with hooks that make it easy to interact with thread state, send messages, and display responses. Each thread maintains a history of messages and can include both text content and rendered components, allowing for rich conversational interfaces where users can see both chat history and dynamic UI components.
 
+[Thread auto-naming](./thread-auto-naming) explains how to keep conversation titles in sync with configurable defaults and per-surface overrides.
+
 ```tsx
 const { thread } = useTambo()
 const { value, setValue, submit } = useTamboThreadInput();

--- a/docs/content/docs/concepts/message-threads/meta.json
+++ b/docs/content/docs/concepts/message-threads/meta.json
@@ -5,6 +5,7 @@
     "showing-responses",
     "switching-thread",
     "thread-status",
+    "thread-auto-naming",
     "image-attachments"
   ]
 }

--- a/docs/content/docs/concepts/message-threads/thread-auto-naming.mdx
+++ b/docs/content/docs/concepts/message-threads/thread-auto-naming.mdx
@@ -1,0 +1,150 @@
+---
+title: Thread auto-naming
+description: Configure automatic thread names, placeholders, and retriggers using the existing thread context.
+---
+
+import LearnMore from "@/components/learn-more";
+
+Clear thread titles help users recognize conversations at a glance. The thread auto-naming utilities reuse the existing `TamboProvider`, thread hooks, and showcase components so you can orchestrate placeholders, trigger thresholds, and retriggers without building parallel state.
+
+<LearnMore
+  title="Sending messages"
+  description="Trigger naming once users begin a conversation."
+  href="/concepts/message-threads/sending-messages"
+/>
+
+## Configure global defaults with `TamboProvider`
+
+Set baseline behaviour on `TamboProvider`. The provider passes `autoThreadNaming` options through to the thread context, so every descendant surface shares the same placeholder rules and trigger schedule unless you override them locally.
+
+```tsx
+import { TamboProvider } from "@tambo-ai/react";
+
+export function App({ children }: { children: React.ReactNode }) {
+  return (
+    <TamboProvider
+      tamboUrl={process.env.NEXT_PUBLIC_TAMBO_URL}
+      apiKey={process.env.NEXT_PUBLIC_TAMBO_API_KEY}
+      components={components}
+      autoThreadNaming={{
+        placeholder: "New conversation…",
+        minMessages: 2,
+        triggers: [1, 5],
+        debounceMs: 800,
+      }}
+    >
+      {children}
+    </TamboProvider>
+  );
+}
+```
+
+- **`placeholder`** renders immediately via `updateThreadName`, giving thread lists a consistent draft title.
+- **`minMessages`** defers naming until the thread holds enough context—for example, set `2` to wait for the assistant’s first response.
+- **`triggers`** lists the message counts that invoke automatic naming. The sample configuration runs after the first user message and again after the fifth message.
+- **`debounceMs`** guards against rapid retriggers when assistants send multiple back-to-back messages.
+
+Every thread created within the provider uses these defaults. Surfaces can refine the behaviour with the hook-level API described below.
+
+## Refine behaviour per surface with `useThreadAutoNaming`
+
+Call `useThreadAutoNaming` inside any component that renders thread metadata. The hook composes with `useTamboThread`, exposing helpers for scheduling additional triggers, regenerating on demand, or overriding the placeholder.
+
+```tsx
+import { useEffect } from "react";
+import { useThreadAutoNaming } from "@tambo-ai/react";
+
+export function SupportConversationHeader() {
+  const {
+    name,
+    status,
+    placeholder,
+    setPlaceholder,
+    scheduleTrigger,
+    regenerate,
+  } = useThreadAutoNaming({
+    placeholder: "Starting support case…",
+    minMessages: 1,
+    triggers: [1],
+  });
+
+  useEffect(() => {
+    scheduleTrigger({ count: 5 });
+  }, [scheduleTrigger]);
+
+  return (
+    <header>
+      <h1>{status === "generating" ? "Naming…" : name ?? placeholder}</h1>
+      <button
+        type="button"
+        onClick={() => regenerate({ count: 10 })}
+        disabled={status === "generating"}
+      >
+        Refresh name after 10 messages
+      </button>
+      <button type="button" onClick={() => setPlaceholder("Untitled chat")}>Override placeholder</button>
+    </header>
+  );
+}
+```
+
+Hook return values:
+
+- **`name`** – the most recent committed thread name.
+- **`placeholder`** – the active placeholder while a name is pending.
+- **`status`** – `"idle" | "generating" | "error"` for UI feedback.
+- **`scheduleTrigger({ count })`** – enqueue a future automatic run when the thread reaches a message count.
+- **`regenerate({ count })`** – run immediately and record which message count caused the attempt (useful for analytics and deterministic prompts).
+- **`setPlaceholder(value)`** – override the provider default for the current surface.
+
+The hook falls back to the provider configuration whenever you omit an option, so components only need to specify what they intend to override.
+
+## Deliver ready-made UI with `ThreadNameStatus`
+
+The showcase package includes headless and styled building blocks for thread titles. `ThreadNameStatus` wraps `useThreadAutoNaming`, handling placeholders, loading states, and retries so you can slot the component into `ThreadHistory` or your own header layout.
+
+```tsx
+import {
+  ThreadHistory,
+  ThreadHistoryHeader,
+  ThreadHistoryList,
+  ThreadHistoryNewButton,
+  ThreadHistorySearch,
+  ThreadNameStatus,
+} from "@tambo-ai/showcase";
+
+export function Inbox() {
+  return (
+    <ThreadHistory contextKey="sales-inbox" position="left">
+      <ThreadHistoryHeader>
+        <ThreadNameStatus
+          placeholder="New conversation"
+          loadingText="Naming conversation…"
+          retryCounts={[5]}
+        />
+      </ThreadHistoryHeader>
+      <ThreadHistoryNewButton />
+      <ThreadHistorySearch />
+      <ThreadHistoryList />
+    </ThreadHistory>
+  );
+}
+```
+
+- `ThreadNameStatus` renders the committed name or placeholder and includes a retry button that calls `regenerate` under the hood.
+- The `retryCounts` prop feeds `scheduleTrigger`, allowing the banner to refresh names after specific milestones.
+- You can replace the visual wrapper with a custom design while reusing the hook and callback shape.
+
+## Configuration reference
+
+| Option | Location | Description |
+| --- | --- | --- |
+| `placeholder` | Provider + hook + `ThreadNameStatus` | Draft name shown before generation completes. |
+| `minMessages` | Provider + hook | Minimum total messages required before any triggers execute. |
+| `triggers` | Provider | Array of message counts that automatically invoke `generateThreadName`. |
+| `retryCounts` | `ThreadNameStatus` | Additional counts that auto-schedule reruns from the component layer. |
+| `debounceMs` | Provider | Guard against rapid retriggers when multiple assistant messages arrive quickly. |
+| `scheduleTrigger` | Hook | Imperative helper to enqueue additional runs. |
+| `regenerate` | Hook + `ThreadNameStatus` | Force an immediate naming attempt and track the triggering count. |
+
+Together these APIs keep thread naming logic inside the existing thread context while giving teams flexibility over timing, placeholders, and UI affordances.

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -24,6 +24,31 @@ A react component library for [tambo ai](https://tambo.co).
   - `ThreadContent`: Content container for message threads
   - `ThreadList`: List of message threads
   - `ThreadHistory`: Historical view of message threads
+  - `ThreadNameStatus`: Displays placeholders, loading state, and retry controls for automatic thread naming
+
+#### Thread naming defaults
+
+Use the component library to expose the automatic naming workflow without recreating the supporting logic.
+
+```tsx
+import {
+  ThreadHistory,
+  ThreadHistoryHeader,
+  ThreadNameStatus,
+} from "@tambo-ai/showcase";
+
+export function ThreadPanel() {
+  return (
+    <ThreadHistory contextKey="support" position="left">
+      <ThreadHistoryHeader>
+        <ThreadNameStatus placeholder="New conversation" retryCounts={[5]} />
+      </ThreadHistoryHeader>
+    </ThreadHistory>
+  );
+}
+```
+
+`ThreadNameStatus` forwards retry counts to the shared `useThreadAutoNaming` hook so lists can refresh names after the first and fifth messages while keeping logic aligned with the thread context.
 
 - **Message Elements**
   - `Message`: Individual message component


### PR DESCRIPTION
## Summary
- rewrite the thread auto-naming concept guide to focus on provider defaults, hook overrides, and component support
- clarify the message threads overview link copy to highlight configurable auto-naming behaviour
- remove the auto-naming section from the React SDK README and tighten the showcase README description for naming defaults

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68ddbd376d7c8332b23f04da735ec401