### PR TITLE
feat(sidebar): highlight active link

### DIFF
--- a/showcase/src/components/sidebar-link.tsx
+++ b/showcase/src/components/sidebar-link.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { type NavigationItem } from "@/lib/navigation";
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { memo } from "react";
+
+export const SidebarLink = memo(function SidebarLink({
+  item,
+  level = 0,
+}: {
+  item: NavigationItem;
+  level?: number;
+}) {
+  const pathname = usePathname();
+  const isActive = pathname === item.href; // check if current pathname is equal to the link href
+
+  return (
+    <Link
+      href={item.href}
+      className={cn(
+        "block px-3 hover:bg-accent rounded-md transition-colors",
+        level === 0
+          ? "py-2 text-base font-medium"
+          : "py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/30",
+        isActive && "bg-accent/30 text-foreground", // Active link style
+      )}
+    >
+      {item.title}
+    </Link>
+  );
+});
+
+SidebarLink.displayName = "SidebarLink";

--- a/showcase/src/components/sidebar-link.tsx
+++ b/showcase/src/components/sidebar-link.tsx
@@ -4,15 +4,13 @@ import { type NavigationItem } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { memo } from "react";
 
-export const SidebarLink = memo(function SidebarLink({
-  item,
-  level = 0,
-}: {
+interface SidebarLinkProps {
   item: NavigationItem;
   level?: number;
-}) {
+}
+
+export const SidebarLink = ({ item, level = 0 }: SidebarLinkProps) => {
   const pathname = usePathname();
   const isActive = pathname === item.href; // check if current pathname is equal to the link href
 
@@ -30,6 +28,6 @@ export const SidebarLink = memo(function SidebarLink({
       {item.title}
     </Link>
   );
-});
+};
 
 SidebarLink.displayName = "SidebarLink";

--- a/showcase/src/components/sidebar.tsx
+++ b/showcase/src/components/sidebar.tsx
@@ -1,31 +1,11 @@
 import { navigation, NavigationItem } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
-import Link from "next/link";
 import { memo, useMemo } from "react";
+import { SidebarLink } from "./sidebar-link";
 
 interface SidebarProps {
   className?: string;
 }
-
-// Memoized sidebar link component
-const SidebarLink = memo(
-  ({ item, level = 0 }: { item: NavigationItem; level?: number }) => {
-    return (
-      <Link
-        href={item.href}
-        className={cn(
-          "block px-3 hover:bg-accent rounded-md",
-          level === 0
-            ? "py-2 text-base font-medium"
-            : "py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-accent/30",
-        )}
-      >
-        {item.title}
-      </Link>
-    );
-  },
-);
-SidebarLink.displayName = "SidebarLink";
 
 // Memoized navigation section component
 const NavSection = memo(


### PR DESCRIPTION
### Description
- This PR highlights the current component in the sidebar to improve navigation ux.

### File Changes
- Added showcase/src/components/sidebar-link.tsx (client) to compute active state via usepathname and style the active link.
- Updated showcase/src/components/sidebar.tsx (server) to render SidebarLink.


### Demo

- Before

https://github.com/user-attachments/assets/8012f1dc-e6a5-428b-ba69-1b235e9278bb

- After

https://github.com/user-attachments/assets/85f1b511-e2c4-49db-b799-13541b6aab72


### PR checklist
- [X] Semantic PR title using Conventional Commits (`feat`, `fix`, `!` for breaking)
- [X] Visual change demo video attached (≤ 2 min)
- [X] Showcase updated for component changes
- [X] CLI updated to support new components or options

---
###vNote
 - please let me know if I've missed any guidelines...happy to make adjustments. 
 ps: feel free to close the pr if this is not needed. :)