### PR TITLE
chore(api): remove includeInternal - we always pass true anyway

### DIFF
--- a/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
+++ b/react-sdk/src/providers/__tests__/tambo-thread-provider.test.tsx
@@ -201,9 +201,7 @@ describe("TamboThreadProvider", () => {
       await result.current.switchCurrentThread("test-thread-1");
     });
 
-    expect(mockThreadsApi.retrieve).toHaveBeenCalledWith("test-thread-1", {
-      includeInternal: true,
-    });
+    expect(mockThreadsApi.retrieve).toHaveBeenCalledWith("test-thread-1");
     expect(result.current.thread.id).toBe("test-thread-1");
   });
 
@@ -1118,9 +1116,6 @@ describe("TamboThreadProvider", () => {
       // Verify that the thread retrieval was called
       expect(mockThreadsApi.retrieve).toHaveBeenCalledWith(
         "existing-thread-123",
-        {
-          includeInternal: true,
-        },
       );
 
       // Verify that neither setQueryData nor refetchQueries were called

--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -280,10 +280,8 @@ export const TamboThreadProvider: React.FC<
   );
 
   const fetchThread = useCallback(
-    async (threadId: string, includeInternalMessages = true) => {
-      const thread = await client.beta.threads.retrieve(threadId, {
-        includeInternal: includeInternalMessages,
-      });
+    async (threadId: string) => {
+      const thread = await client.beta.threads.retrieve(threadId);
       const threadWithRenderedComponents = {
         ...thread,
         messages: thread.messages.map((message) => {


### PR DESCRIPTION
I'm deprecating this from the API, and making the api always return "internal" messages (which don't really have any meaning now)