### PR TITLE
fix: show 'done thinking' when reasoning message completes

### DIFF
--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { markdownComponents } from "@/components/tambo/markdown-components";
+import {
+  checkHasContent,
+  getMessageImages,
+  getSafeContent,
+} from "@/lib/thread-hooks";
 import { cn } from "@/lib/utils";
 import type { TamboThreadMessage } from "@tambo-ai/react";
 import { useTambo } from "@tambo-ai/react";
@@ -12,11 +17,6 @@ import Image from "next/image";
 import * as React from "react";
 import { useState } from "react";
 import { Streamdown } from "streamdown";
-import {
-  checkHasContent,
-  getMessageImages,
-  getSafeContent,
-} from "@/lib/thread-hooks";
 
 /**
  * CSS variants for the message container
@@ -525,7 +525,7 @@ const ReasoningInfo = React.forwardRef<HTMLDivElement, ReasoningInfoProps>(
             )}
           >
             <span className={isLoading ? "animate-thinking-gradient" : ""}>
-              Thinking{" "}
+              {isLoading ? "Thinking " : "Done thinking "}{" "}
               {message.reasoning.length > 1
                 ? `(${message.reasoning.length} steps)`
                 : ""}


### PR DESCRIPTION
Updates message UI component to show "done thinking" when the message completes rather than saying "Thinking" even after completion. In future we can update this to show "thought for x seconds".