### PR TITLE
fix: throw error when registered interactable's name is too long

### DIFF
--- a/react-sdk/src/providers/tambo-interactable-provider.tsx
+++ b/react-sdk/src/providers/tambo-interactable-provider.tsx
@@ -259,11 +259,8 @@ export const TamboInteractableProvider: React.FC<PropsWithChildren> = ({
       // Validate component name
       assertValidName(component.name, "component");
 
-      // Add a count part to the component name to make it unique when using multiple instances of the same component.
-      const count = interactableComponents.filter(
-        (c) => c.name === component.name,
-      ).length;
-      const tamboGeneratedNamePart = `-${count}`;
+      // Add a random part to the component name to make it unique when using multiple instances of the same component.
+      const tamboGeneratedNamePart = `-${Math.random().toString(36).slice(2, 5)}`;
       const id = `${component.name}${tamboGeneratedNamePart}`;
       const newComponent: TamboInteractableComponent = {
         ...component,
@@ -278,7 +275,7 @@ export const TamboInteractableProvider: React.FC<PropsWithChildren> = ({
 
       return id;
     },
-    [registerInteractableComponentUpdateTool, interactableComponents],
+    [registerInteractableComponentUpdateTool],
   );
 
   const removeInteractableComponent = useCallback((id: string) => {


### PR DESCRIPTION
Throws an error if the length of an interactable's `componentName` is too long, when combined with tambo's internal tool naming, for LLMs.

For now defaults to 60 chars total, where most LLMs allow 64 character tools.

Also removes some of tambo's internal tool naming to save space for the developer's `componentName`