### PR TITLE
chore: remove error log about tambo in browser

### DIFF
--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -81,11 +81,6 @@ export const TamboProvider: React.FC<
   initialMessages,
   onCallUnregisteredTool,
 }) => {
-  // Should only be used in browser
-  if (typeof window === "undefined") {
-    console.error("TamboProvider must be used within a browser");
-  }
-
   return (
     <TamboClientProvider
       tamboUrl={tamboUrl}


### PR DESCRIPTION
Removes an unnecessary console error about Tambo needing to be used in a browser.
The check was being run once on the server, causing the error to appear even when the setup was correct.