### PR TITLE
chore(docs): add redirect for docs-prefixed URLs

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -8,6 +8,13 @@ const config = {
   trailingSlash: false,
   async redirects() {
     return [
+      // Handle the trailing-slash variant explicitly to avoid a double redirect
+      // when `trailingSlash: false` normalizes "/docs/" -> "/docs" first.
+      {
+        source: "/docs/",
+        destination: "/",
+        permanent: true,
+      },
       {
         source: "/docs",
         destination: "/",

--- a/docs/src/components/ai-actions/open-dropdown.tsx
+++ b/docs/src/components/ai-actions/open-dropdown.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { GithubLogo, ChatGPTLogo, T3Logo, ClaudeLogo } from "./logos";
 import Image from "next/image";
-import octoIcon from "../../../public/logo/icon/Octo-Icon.svg";
 
 interface OpenDropdownProps {
   markdownUrl: string;
@@ -21,7 +20,7 @@ type LinkItem = {
 
 const TamboLogo = () => (
   <Image
-    src={octoIcon}
+    src="/logo/icon/Octo-Icon.svg"
     alt="Tambo"
     width={24}
     height={24}

--- a/docs/src/lib/source.ts
+++ b/docs/src/lib/source.ts
@@ -19,12 +19,15 @@ export const source = loader({
   },
 });
 
-const invalidDocsPrefixedPage = source
+// Guard against any content nested under a top-level "/docs" slug.
+// Aggregate all offenders into a single actionable error message.
+const docsPrefixedPages = source
   .getPages()
-  .find((page) => page.slugs[0] === "docs");
+  .filter((page) => page.slugs[0] === "docs");
 
-if (invalidDocsPrefixedPage) {
+if (docsPrefixedPages.length > 0) {
+  const list = docsPrefixedPages.map((p) => `- ${p.path}`).join("\n");
   throw new Error(
-    `Docs content cannot be placed under a '/docs' route. Found: ${invalidDocsPrefixedPage.path}`,
+    `Docs content cannot be placed under a '/docs' route. Found ${docsPrefixedPages.length} page(s):\n${list}`,
   );
 }


### PR DESCRIPTION
## Summary

Sometimes LLMs assume that the docs are located at /docs so if we redirect the will avoid getting 404s.

- redirect any `/docs`-prefixed request back to the canonical route
- fail the docs build if a page is created under a `/docs` slug

## Testing
- npm run check-types --workspace @tambo-ai/docs *(fails: Cannot find module '../../../public/logo/icon/Octo-Icon.svg')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d44175b708332b8d23c62108aa005)