### PR TITLE
feat: merge cloud repo into mono repo

### DIFF
--- a/tambo-cloud/apps/web/components/ui/tambo/mcp-config-modal.tsx
+++ b/tambo-cloud/apps/web/components/ui/tambo/mcp-config-modal.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import { type McpServerInfo, MCPTransport } from "@tambo-ai/react/mcp";
-import { ChevronDown, X, Trash2 } from "lucide-react";
-import React from "react";
-import { createPortal } from "react-dom";
-import { motion } from "framer-motion";
+import { createMarkdownComponents } from "@/components/ui/tambo/markdown-components";
+import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@radix-ui/react-dropdown-menu";
-import { createMarkdownComponents } from "@/components/ui/tambo/markdown-components";
+import { type McpServerInfo, MCPTransport } from "@tambo-ai/react";
+import { motion } from "framer-motion";
+import { ChevronDown, Trash2, X } from "lucide-react";
+import React from "react";
+import { createPortal } from "react-dom";
 import { Streamdown } from "streamdown";
-import { cn } from "@/lib/utils";
 
 /**
  * Modal component for configuring client-side MCP (Model Context Protocol) servers.


### PR DESCRIPTION
Merges the `tambo-cloud` repo into `tambo` repo so we have a single repo for everything.
- `tambo-cloud` repo contents are now under `/tambo-cloud`
- commit history is retained (Do not squash this PR)
- Merges github workflows
- Merges turbo configurations
- adds scripts to root `package.json` to run cloud apps individually
- Updates "cross-repo" links in documentation