### PR TITLE
fix(cli): use base package name for mcp-components dependency

### DIFF
--- a/cli/src/registry/mcp-components/config.json
+++ b/cli/src/registry/mcp-components/config.json
@@ -3,7 +3,7 @@
   "type": "components:tambo",
   "description": "MCP prompt and resource picker buttons for message input",
   "dependencies": [
-    "@tambo-ai/react/mcp",
+    "@tambo-ai/react",
     "lucide-react",
     "@radix-ui/react-dropdown-menu"
   ],


### PR DESCRIPTION
## Summary
Fixed npm installation error for mcp-components by correcting the dependency specification. The CLI cannot install subpath specifiers like `@tambo-ai/react/mcp` directly.

## Changes
- Changed dependency from `@tambo-ai/react/mcp` to `@tambo-ai/react`
- Subpath imports continue to work via package.json exports

## Test plan
- Verify `tambo add mcp-components` installs without npm errors
- Confirm component imports from `@tambo-ai/react/mcp` still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)