### PR TITLE
fix: allow provider keys to contain '.'

### DIFF
--- a/packages/core/src/encrypt.test.ts
+++ b/packages/core/src/encrypt.test.ts
@@ -60,11 +60,12 @@ describe("extractProviderKey", () => {
     expect(providerKey).toBe("sk-ant-api03-key.with.dots.in.it");
   });
 
-  it("throws error when delimiter is missing", () => {
+  it("handles missing delimiter with backward compatibility", () => {
     const decrypted = "nodelimiterhere";
+    const { providerName, providerKey } = extractProviderNameAndKey(decrypted);
 
-    expect(() => extractProviderNameAndKey(decrypted)).toThrow(
-      "Invalid provider key format - missing delimiter",
-    );
+    // Backward compatibility: old splitFromEnd would return empty providerName
+    expect(providerName).toBe("");
+    expect(providerKey).toBe("nodelimiterhere");
   });
 });

--- a/packages/core/src/encrypt.ts
+++ b/packages/core/src/encrypt.ts
@@ -18,7 +18,9 @@ export function extractProviderNameAndKey(decrypted: string): {
   // Split on first '.' to handle providerKeys that contain '.'
   const firstDotIndex = decrypted.indexOf(".");
   if (firstDotIndex === -1) {
-    throw new Error("Invalid provider key format - missing delimiter");
+    // Backward compatibility: old format without delimiter would have returned
+    // empty providerName and entire string as providerKey
+    return { providerName: "", providerKey: decrypted };
   }
 
   const providerName = decrypted.substring(0, firstDotIndex);


### PR DESCRIPTION
Fixes an issue where keys from LLM providers that contain '.' were being split incorrectly before sending to the LLM, causing 'incorrect API Key' errors