### PR TITLE
fix(react-sdk,docs): address streaming docs review feedback

### DIFF
--- a/docs/content/docs/concepts/streaming/streaming-best-practices.mdx
+++ b/docs/content/docs/concepts/streaming/streaming-best-practices.mdx
@@ -107,24 +107,35 @@ export const EmailComposer: TamboComponent<EmailComposerProps> = {
     const { streamStatus, propStatus } =
       useTamboStreamStatus<EmailComposerProps>();
 
-    // State seeds from props once streaming completes
-    // After that, user edits take precedence
+    // Seed state from props as they stream in
+    // Once user edits, their changes take precedence
     const [draft, setDraft] = useTamboComponentState<EmailDraft>(
       "emailDraft",
       { to: "", subject: "", body: "" },
-      subject && body ? { to: "", subject, body } : undefined,
+      { to: "", subject: subject ?? "", body: body ?? "" },
     );
 
     const isStreaming = streamStatus.isStreaming;
 
     function handleChange(field: keyof EmailDraft) {
       return (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        setDraft((prev) => ({ ...prev, [field]: e.target.value }));
+        const value = e.target.value;
+        setDraft((prev) => ({ ...prev, [field]: value }));
       };
     }
 
+    async function handleSubmit(e: React.FormEvent) {
+      e.preventDefault();
+      try {
+        // Send draft to your backend
+        await sendEmail(draft);
+      } catch (err) {
+        console.error("Failed to send:", err);
+      }
+    }
+
     return (
-      <form aria-busy={isStreaming}>
+      <form aria-busy={isStreaming} onSubmit={handleSubmit}>
         <label>
           To
           <input
@@ -167,6 +178,13 @@ export const EmailComposer: TamboComponent<EmailComposerProps> = {
     );
   },
 };
+```
+
+```tsx
+// Placeholder - implement your own email sending
+async function sendEmail(draft: EmailDraft): Promise<void> {
+  // Send to your backend API
+}
 ```
 
 ---

--- a/react-sdk/src/hooks/use-component-state.tsx
+++ b/react-sdk/src/hooks/use-component-state.tsx
@@ -14,7 +14,7 @@ type StateUpdateResult<T> = [currentState: T, setState: (newState: T) => void];
  * user edits take precedence over the original prop value.
  *
  * Pair with `useTamboStreamStatus` to disable inputs while streaming.
- * @see https://docs.tambo.co/concepts/streaming/streaming-best-practices
+ * @see {@link https://docs.tambo.co/concepts/streaming/streaming-best-practices}
  * @param keyName - Unique key within the message's componentState
  * @param initialValue - Default value if no componentState exists
  * @param setFromProp - Seeds state from props (updates during streaming, then user edits take over)

--- a/react-sdk/src/hooks/use-streaming-props.tsx
+++ b/react-sdk/src/hooks/use-streaming-props.tsx
@@ -6,7 +6,7 @@ import { useEffect } from "react";
  * Low-level helper that merges streamed props into state.
  * @deprecated Use `useTamboComponentState` with `setFromProp` instead.
  * This hook will be removed in 1.0.0.
- * @see https://docs.tambo.co/concepts/streaming/streaming-props
+ * @see {@link https://docs.tambo.co/concepts/streaming/streaming-props}
  * @param currentState - Current state object
  * @param setState - State setter function
  * @param streamingProps - Props to merge into state when they change

--- a/react-sdk/src/hooks/use-tambo-stream-status.tsx
+++ b/react-sdk/src/hooks/use-tambo-stream-status.tsx
@@ -298,7 +298,7 @@ function deriveGlobalStreamStatus<Props extends Record<string, any>>(
  * Use `propStatus.<field>?.isSuccess` before treating a prop as complete.
  *
  * Pair with `useTamboComponentState` to disable inputs while streaming.
- * @see https://docs.tambo.co/concepts/streaming/streaming-best-practices
+ * @see {@link https://docs.tambo.co/concepts/streaming/streaming-best-practices}
  * @template Props - Component props type
  * @returns `streamStatus` (overall) and `propStatus` (per-prop) flags
  * @throws {Error} When used during SSR/SSG


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #1457 that was left unresolved when Charlie's run failed partway through.

## Changes

### React SDK JSDoc fixes
- `use-component-state.tsx`: Use proper `@see {@link url}` format
- `use-streaming-props.tsx`: Use proper `@see {@link url}` format  
- `use-tambo-stream-status.tsx`: Use proper `@see {@link url}` format

### Docs fixes (streaming-best-practices.mdx Pattern 2)
- **Fix stale closure**: `handleChange` now captures `e.target.value` before calling `setDraft`
- **Fix all-or-nothing seeding**: Changed `setFromProp` from `subject && body ? {...}` to per-field seeding with `subject ?? ""` so fields appear as they stream
- **Add proper submit handler**: Added `handleSubmit` with try/catch error handling
- **Add placeholder function**: Added `sendEmail` stub for completeness

## Verification

```bash
npm run lint -- --filter=@tambo-ai/react --filter=@tambo-ai/docs  # ✓ passed (only pre-existing warnings)
npm run check-types -- --filter=@tambo-ai/react --filter=@tambo-ai/docs  # ✓ passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)