### PR TITLE
fix(cli): fix build output structure for correct dist/cli.js location

### DIFF
--- a/cli/tsconfig.build.json
+++ b/cli/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "paths": {
+      "@/*": ["src/*"],
+      "@/components/tambo/*": ["src/registry/*"],
+      "@/lib/*": ["src/lib/*"]
+    }
+  },
   "exclude": ["__tests__", "**/*.test.ts", "**/*.test.tsx", "tests"]
 }


### PR DESCRIPTION
## Summary
- Fix CLI build output structure so `dist/cli.js` is at the correct location instead of `dist/cli/src/cli.js`

## Why
The v0.43.0 CLI release was broken because the TypeScript build was outputting files to a nested `dist/cli/src/` structure instead of flat `dist/`. This happened because:
1. The `tsconfig.json` has path mappings pointing to `../react-sdk/src`
2. TypeScript included those files in compilation and set `rootDir` to the common ancestor
3. The resulting output structure didn't match `package.json`'s `bin` entry (`./dist/cli.js`)

This fix adds `rootDir: "./src"` and removes the `@tambo-ai/react` path mappings from `tsconfig.build.json` so builds use the installed npm package instead of source files.

## Test Plan
- [x] `npm run build` produces `dist/cli.js` at root level
- [x] `node dist/cli.js --version` outputs `0.43.0`
- [x] `npm run check-types` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.ai/code)