### PR TITLE
fix: add max image uploads and show image error

### DIFF
--- a/cli/src/registry/message-input/message-input.tsx
+++ b/cli/src/registry/message-input/message-input.tsx
@@ -441,7 +441,7 @@ const MessageInputInternal = React.forwardRef<
       } catch (error) {
         console.error("Failed to submit message:", error);
         setDisplayValue(value);
-        // On submit failure, clear error
+        // On submit failure, also clear image error
         setImageError(null);
         setSubmitError(
           error instanceof Error
@@ -520,6 +520,11 @@ const MessageInputInternal = React.forwardRef<
           await addImages(files);
         } catch (error) {
           console.error("Failed to add dropped images:", error);
+          setImageError(
+            error instanceof Error
+              ? error.message
+              : "Failed to add images. Please try again.",
+          );
         }
       }
     },
@@ -569,6 +574,7 @@ const MessageInputInternal = React.forwardRef<
       editorRef,
       submitError,
       imageError,
+      setImageError,
       elicitation,
       resolveElicitation,
     ],
@@ -754,15 +760,22 @@ const MessageInputTextarea = ({
   }, []);
 
   // Handle image paste - mark as pasted and add to thread
+  const pendingImagesRef = React.useRef(0);
+
   const handleAddImage = React.useCallback(
     async (file: File) => {
-      if (images.length >= MAX_IMAGES) {
+      if (images.length + pendingImagesRef.current >= MAX_IMAGES) {
         setImageError(`Max ${MAX_IMAGES} uploads at a time`);
         return;
       }
       setImageError(null);
-      file[IS_PASTED_IMAGE] = true;
-      await addImage(file);
+      pendingImagesRef.current += 1;
+      try {
+        file[IS_PASTED_IMAGE] = true;
+        await addImage(file);
+      } finally {
+        pendingImagesRef.current -= 1;
+      }
     },
     [addImage, images, setImageError],
   );


### PR DESCRIPTION
### Description

- This PR enforces a maximum number of staged images in the message input and surfaces image-specific errors.

### Before 

![Screenshot_11-12-2025_18127_ui tambo co](https://github.com/user-attachments/assets/e888fb42-3151-47de-9856-d8ff98ebfc6f)

###After

<img width="1920" height="795" alt="Screenshot (550)" src="https://github.com/user-attachments/assets/39493c54-3310-44bc-a87d-187b1d918f8c" />


-Note -  If this behavior isn’t desired or overlaps with other planned work on MessageInput, feel free to close this PR.