### PR TITLE
fix(react): correct schema parsing logic

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -137,6 +137,13 @@ const config = {
       use: ["@svgr/webpack"],
     });
 
+    // don't resolve optional peers from '@standard-community/standard-json'
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      effect: false,
+      sury: false,
+    };
+
     return config;
   },
 };

--- a/react-sdk/src/schema/schema.ts
+++ b/react-sdk/src/schema/schema.ts
@@ -27,7 +27,7 @@ import {
   looksLikeJSONSchema,
 } from "./json-schema";
 import { isStandardSchema } from "./standard-schema";
-import { getZodFunctionArgs, handleZodSchemaToJson } from "./zod";
+import { getZodFunctionArgs, handleZodSchemaToJson, isZodSchema } from "./zod";
 
 // Register the Zod vendor converter with standard-json
 loadVendor("zod", handleZodSchemaToJson);
@@ -193,7 +193,9 @@ export const getParametersFromToolSchema = (
   // Convert to JSON Schema if needed
   let jsonSchema: JSONSchema7;
   // zod 3 and 4 are both compatible with StandardSchema
-  if (isStandardSchema(argsSchema)) {
+  if (isZodSchema(argsSchema)) {
+    jsonSchema = handleZodSchemaToJson(argsSchema);
+  } else if (isStandardSchema(argsSchema)) {
     // uses @standard-community/standard-json for conversion
     jsonSchema = schemaToJsonSchema(argsSchema);
   } else if (looksLikeJSONSchema(argsSchema)) {

--- a/react-sdk/src/schema/zod.ts
+++ b/react-sdk/src/schema/zod.ts
@@ -5,8 +5,12 @@ import {
   ZodType,
   ZodTypeAny,
 } from "zod/v3";
-import { $ZodFunction, $ZodType } from "zod/v4/core";
-import { z, toJSONSchema as zod4ToJSONSchema } from "zodInternalAlias";
+import {
+  $ZodFunction,
+  $ZodType,
+  toJSONSchema as zod4ToJSONSchema,
+} from "zod/v4/core";
+import { z } from "zodInternalAlias";
 
 /**
  * @returns True if the schema is a Zod 3 function schema
@@ -99,7 +103,6 @@ export function getZodFunctionReturns(schema: unknown) {
  */
 export function handleZodSchemaToJson(schema: unknown) {
   // If Zod4 schema detected, use the toJSONSchema function from "zod/v4/core"
-  // @ts-expect-error -- using zod4ToJSONSchema from zodInternalAlias but types from zod/v4/core
   if (isZod4Schema(schema)) return zod4ToJSONSchema(schema);
 
   try {

--- a/showcase/next.config.ts
+++ b/showcase/next.config.ts
@@ -9,6 +9,13 @@ const nextConfig: NextConfig = {
       test: /\.svg$/,
       use: ["@svgr/webpack"],
     });
+
+    // don't resolve optional peers from '@standard-community/standard-json'
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      effect: false,
+      sury: false,
+    };
     return config;
   },
 };


### PR DESCRIPTION
- **fix(react-sdk): correct check order for zod schemas**
- **fix(web/showcase): fix warning from optional peer deps**

Essentially, the `looksLikeJSONSchema` was matching too eagerly and was preventing any schema from being converted to a plain JSONSchema object. The valibot schemas are not working, but there isn't enough tests for this either so we'll have to revisit that later.