### PR TITLE
chore: don't show EditWithTamboButton when component is in thread

### DIFF
--- a/apps/web/components/ui/tambo/edit-with-tambo-button.tsx
+++ b/apps/web/components/ui/tambo/edit-with-tambo-button.tsx
@@ -15,6 +15,7 @@ import {
   useTambo,
   useTamboContextAttachment,
   useTamboCurrentComponent,
+  useTamboCurrentMessage,
 } from "@tambo-ai/react";
 import { Bot, ChevronDown, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -71,6 +72,14 @@ export function EditWithTamboButton({
   const { addContextAttachment, setCustomSuggestions } =
     useTamboContextAttachment();
 
+  // Try to get the message, but don't throw if not in context
+  let message: ReturnType<typeof useTamboCurrentMessage> | null = null;
+  try {
+    message = useTamboCurrentMessage();
+  } catch {
+    // Not in a Tambo-generated message - that's fine
+  }
+
   const [prompt, setPrompt] = useState("");
   // NOTE: Using isIdle from useTambo() instead of tracking error/pending state locally.
   // The useTambo() hook already manages generation state and error handling through sendThreadMessage,
@@ -90,6 +99,11 @@ export function EditWithTamboButton({
 
   // If no component, the current component is not an interactable - don't render.
   if (!component) {
+    return null;
+  }
+
+  // If in a Tambo thread (message with threadId), don't show the button
+  if (message?.threadId) {
     return null;
   }
 

--- a/cli/src/registry/edit-with-tambo-button/edit-with-tambo-button.tsx
+++ b/cli/src/registry/edit-with-tambo-button/edit-with-tambo-button.tsx
@@ -18,6 +18,7 @@ import {
   type Suggestion,
   useTambo,
   useTamboCurrentComponent,
+  useTamboCurrentMessage,
 } from "@tambo-ai/react";
 import type { Editor } from "@tiptap/react";
 import { Bot, ChevronDown, X } from "lucide-react";
@@ -83,6 +84,14 @@ export function EditWithTamboButton({
   const component = useTamboCurrentComponent();
   const { sendThreadMessage, isIdle } = useTambo();
 
+  // Try to get the message, but don't throw if not in context
+  let message: ReturnType<typeof useTamboCurrentMessage> | null = null;
+  try {
+    message = useTamboCurrentMessage();
+  } catch {
+    // Not in a Tambo-generated message - that's fine
+  }
+
   const [prompt, setPrompt] = useState("");
   // NOTE: Using isIdle from useTambo() instead of tracking error/pending state locally.
   // The useTambo() hook already manages generation state and error handling through sendThreadMessage,
@@ -96,6 +105,11 @@ export function EditWithTamboButton({
 
   // If no component, the current component is not an interactable - don't render.
   if (!component) {
+    return null;
+  }
+
+  // If in a Tambo thread (message with threadId), don't show the button
+  if (message?.threadId) {
     return null;
   }
 

--- a/showcase/src/components/tambo/edit-with-tambo-button.tsx
+++ b/showcase/src/components/tambo/edit-with-tambo-button.tsx
@@ -28,6 +28,7 @@ import {
   type Suggestion,
   useTambo,
   useTamboCurrentComponent,
+  useTamboCurrentMessage,
 } from "@tambo-ai/react";
 import type { Editor } from "@tiptap/react";
 import { Bot, ChevronDown, X } from "lucide-react";
@@ -93,6 +94,14 @@ export function EditWithTamboButton({
   const component = useTamboCurrentComponent();
   const { sendThreadMessage, isIdle } = useTambo();
 
+  // Try to get the message, but don't throw if not in context
+  let message: ReturnType<typeof useTamboCurrentMessage> | null = null;
+  try {
+    message = useTamboCurrentMessage();
+  } catch {
+    // Not in a Tambo-generated message - that's fine
+  }
+
   const [prompt, setPrompt] = useState("");
   // NOTE: Using isIdle from useTambo() instead of tracking error/pending state locally.
   // The useTambo() hook already manages generation state and error handling through sendThreadMessage,
@@ -106,6 +115,11 @@ export function EditWithTamboButton({
 
   // If no component, the current component is not an interactable - don't render.
   if (!component) {
+    return null;
+  }
+
+  // If in a Tambo thread (message with threadId), don't show the button
+  if (message?.threadId) {
     return null;
   }
 


### PR DESCRIPTION
- Using `useTamboCurrentMessage` to determine if the component is in a tambo thread or not.
- we do not want to show the interaction button when a component using it is generated in thread inline by tambo.