### PR TITLE
chore: don't show EditWithTamboButton when component is in thread

### DIFF
--- a/apps/web/components/ui/tambo/edit-with-tambo-button.tsx
+++ b/apps/web/components/ui/tambo/edit-with-tambo-button.tsx
@@ -93,6 +93,11 @@ export function EditWithTamboButton({
     return null;
   }
 
+  // If in a Tambo thread (message with threadId), don't show the button
+  if (component.threadId) {
+    return null;
+  }
+
   // Close popover when generation completes
   useEffect(() => {
     if (shouldCloseOnComplete && !isGenerating) {

--- a/cli/src/registry/edit-with-tambo-button/edit-with-tambo-button.tsx
+++ b/cli/src/registry/edit-with-tambo-button/edit-with-tambo-button.tsx
@@ -99,6 +99,11 @@ export function EditWithTamboButton({
     return null;
   }
 
+  // If in a Tambo thread (message with threadId), don't show the button
+  if (component.threadId) {
+    return null;
+  }
+
   const isGenerating = !isIdle;
 
   // Close popover when generation completes

--- a/docs/content/docs/api-reference/react-hooks.mdx
+++ b/docs/content/docs/api-reference/react-hooks.mdx
@@ -384,8 +384,8 @@ Use when you need full message/thread context. For component metadata only, see 
 
 `const component = useTamboCurrentComponent()`
 
-Returns component metadata (`componentName`, `props`, `interactableId`, `description`) from the parent component context. Returns `null` if used outside a component. Works with both inline rendered and interactable components.
+Returns component metadata (`componentName`, `props`, `interactableId`, `description`, `threadId`) from the parent component context. Returns `null` if used outside a component. Works with both inline rendered and interactable components.
 
-Use when you only need component information. For full message context, see [`useTamboCurrentMessage`](#usetambocurrentmessage).
+Use when you need component information or thread ID without full message context. For complete message data, see [`useTamboCurrentMessage`](#usetambocurrentmessage).
 
 See [Interactable Components](/concepts/components/interactable-components#accessing-component-context-from-child-components) for detailed patterns and examples.

--- a/docs/content/docs/concepts/components/interactable-components.mdx
+++ b/docs/content/docs/concepts/components/interactable-components.mdx
@@ -444,10 +444,10 @@ When building child components inside an interactable (like inline editors, tool
 
 <Callout title="Related Hooks">
 
-- [`useTamboCurrentComponent`](/api-reference/react-hooks#usetambocurrentcomponent) - Access component metadata (this guide)
-- [`useTamboCurrentMessage`](/api-reference/react-hooks#usetambocurrentmessage) - Access full message object with component and thread data
+- [`useTamboCurrentComponent`](/api-reference/react-hooks#usetambocurrentcomponent) - Access component metadata including thread ID (this guide)
+- [`useTamboCurrentMessage`](/api-reference/react-hooks#usetambocurrentmessage) - Access full message object with timestamps and complete state
 
-Use `useTamboCurrentComponent` when you only need component information. Use `useTamboCurrentMessage` when you need the complete message context, including thread ID, timestamps, and component state.
+Use `useTamboCurrentComponent` when you need component information or thread ID. Use `useTamboCurrentMessage` when you need the complete message context with timestamps and additional metadata.
 
 </Callout>
 

--- a/react-sdk/src/hooks/use-current-message.test.tsx
+++ b/react-sdk/src/hooks/use-current-message.test.tsx
@@ -246,6 +246,7 @@ describe("useTamboCurrentComponent", () => {
       },
       interactableId: undefined,
       description: undefined,
+      threadId: "test-thread-id",
     });
   });
 
@@ -289,6 +290,7 @@ describe("useTamboCurrentComponent", () => {
       },
       interactableId: "interactable-456",
       description: "Shows current weather",
+      threadId: "test-thread-id",
     });
   });
 
@@ -351,6 +353,7 @@ describe("useTamboCurrentComponent", () => {
       props: undefined,
       interactableId: "interactable-only",
       description: "Interactable only",
+      threadId: "test-thread-id",
     });
   });
 
@@ -381,6 +384,7 @@ describe("useTamboCurrentComponent", () => {
       },
       interactableId: undefined,
       description: undefined,
+      threadId: "test-thread-id",
     });
   });
 
@@ -400,6 +404,7 @@ describe("useTamboCurrentComponent", () => {
       props: undefined,
       interactableId: undefined,
       description: undefined,
+      threadId: "test-thread-id",
     });
   });
 });

--- a/react-sdk/src/hooks/use-current-message.tsx
+++ b/react-sdk/src/hooks/use-current-message.tsx
@@ -94,6 +94,8 @@ export interface TamboCurrentComponent {
   interactableId?: string;
   /** Description (only present for components wrapped with withInteractable) */
   description?: string;
+  /** Thread ID from the message (only present when the component is part of a thread) */
+  threadId?: string;
 }
 
 /**
@@ -133,5 +135,6 @@ export const useTamboCurrentComponent = (): TamboCurrentComponent | null => {
     props: message.component?.props as Record<string, any> | undefined,
     interactableId: message.interactableMetadata?.id ?? undefined,
     description: message.interactableMetadata?.description ?? undefined,
+    threadId: message.threadId,
   };
 };

--- a/showcase/src/components/tambo/edit-with-tambo-button.tsx
+++ b/showcase/src/components/tambo/edit-with-tambo-button.tsx
@@ -109,6 +109,11 @@ export function EditWithTamboButton({
     return null;
   }
 
+  // If in a Tambo thread (message with threadId), don't show the button
+  if (component.threadId) {
+    return null;
+  }
+
   const isGenerating = !isIdle;
 
   // Close popover when generation completes


### PR DESCRIPTION
- updated `useTamboCurrentComponent` to also return threadId, so that we can detect whether the component is rendered inline or not.