### PR TITLE
fix(cli): Fixed cli logs typos on self-hosted flow

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -165,8 +165,12 @@ function displaySelfHostInstructions(): void {
   console.log(
     chalk.gray("  1. Create .env files (see repo .env.example files)"),
   );
-  console.log(chalk.gray("  2. Start Postgres via ./scripts/cloud/tambo-start.sh"));
-  console.log(chalk.gray("  3. Initialize DB via ./scripts/cloud/init-database.sh"));
+  console.log(
+    chalk.gray("  2. Start Postgres via ./scripts/cloud/tambo-start.sh"),
+  );
+  console.log(
+    chalk.gray("  3. Initialize DB via ./scripts/cloud/init-database.sh"),
+  );
   console.log(chalk.gray("  4. npm run dev (web + api)\n"));
 }
 


### PR DESCRIPTION
It fixes the outdated logs of the self-hosted instructions, which are pointing to the wrong folder.