### PR TITLE
ci: pin npm@11.7.0 across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: "22"
 
       - name: Pin NPM version
-        run: npm install -g npm@11.5.2
+        run: npm install -g npm@11.7.0
 
       - name: Install dependencies
         # This (`npm install) is a workaround for the fact that release-please

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -131,9 +131,13 @@ jobs:
 
       - name: Set up Node.js
         if: steps.check-changes.outputs.changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
+
+      - name: Pin NPM version
+        if: steps.check-changes.outputs.changed == 'true'
+        run: npm install -g npm@11.7.0
 
       - name: Install dependencies
         if: steps.check-changes.outputs.changed == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,6 +51,9 @@ jobs:
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Pin NPM version
+        run: npm install -g npm@11.7.0
+
       - name: Install dependencies
         run: npm install
 
@@ -80,6 +83,9 @@ jobs:
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Pin NPM version
+        run: npm install -g npm@11.7.0
+
       - name: Install dependencies
         run: npm install
 
@@ -108,6 +114,9 @@ jobs:
           node-version: "22"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Pin NPM version
+        run: npm install -g npm@11.7.0
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/stainless-cloud.yml
+++ b/.github/workflows/stainless-cloud.yml
@@ -15,9 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # setup node
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: "22"
+      # pin npm version
+      - run: npm install -g npm@11.7.0
       # install dependencies
       - run: npm ci
         working-directory: tambo-cloud

--- a/.github/workflows/template-maintenance.yml
+++ b/.github/workflows/template-maintenance.yml
@@ -36,6 +36,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: ".github/scripts/package.json"
 
+      - name: Pin NPM version
+        run: npm install -g npm@11.7.0
+
       - name: Install script dependencies
         working-directory: .github/scripts
         run: npm ci
@@ -66,6 +69,9 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: ".github/scripts/package.json"
+
+      - name: Pin NPM version
+        run: npm install -g npm@11.7.0
 
       - name: Install script dependencies
         working-directory: .github/scripts

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "turbo": "^2.6.1",
     "typescript": "^5.9.3"
   },
-  "packageManager": "npm@10.9.2",
+  "packageManager": "npm@11.7.0",
   "workspaces": [
     "react-sdk",
     "showcase",
@@ -48,6 +48,6 @@
   },
   "volta": {
     "node": "22.21.0",
-    "npm": "11.6.2"
+    "npm": "11.7.0"
   }
 }


### PR DESCRIPTION
This will let us use trusted publishing

## Summary
- Update npm version from 11.5.2 to 11.7.0 (latest v11) in ci.yml
- Add npm@11.7.0 pinning to migrate-db.yml, release-please.yml, stainless-cloud.yml, and template-maintenance.yml
- Upgrade setup-node from v4 to v6 in migrate-db.yml and stainless-cloud.yml
- Update root package.json: `packageManager` from npm@10.9.2 to npm@11.7.0
- Update root package.json: volta npm from 11.6.2 to 11.7.0

Ensures consistent npm version across all CI workflows and local development.

## Test plan
- [ ] CI workflow passes
- [ ] Verify npm version is pinned in all affected workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)