### PR TITLE
fix(web): allow Enter key to select items from TipTap suggestion popover

### DIFF
--- a/apps/web/components/ui/tambo/text-editor.tsx
+++ b/apps/web/components/ui/tambo/text-editor.tsx
@@ -983,11 +983,11 @@ const TextEditorInner = React.forwardRef<TamboEditor, TextEditorProps>(
             resourceSuggestionRef.current.state.isOpen ||
             promptSuggestionRef.current.state.isOpen;
 
-          // Prevent Enter from submitting form when selecting from any menu
-          if (event.key === "Enter" && !event.shiftKey && anyMenuOpen) {
-            event.preventDefault();
-            event.stopPropagation();
-            return true;
+          // When menu is open, let the suggestion plugin handle keyboard events
+          // (ArrowUp, ArrowDown, Enter, Escape). Returning false allows the
+          // event to propagate to the suggestion plugin's onKeyDown handler.
+          if (anyMenuOpen) {
+            return false;
           }
 
           // Only handle Enter key for form submission - let TipTap handle everything else

--- a/cli/src/registry/message-input/text-editor.tsx
+++ b/cli/src/registry/message-input/text-editor.tsx
@@ -983,11 +983,11 @@ const TextEditorInner = React.forwardRef<TamboEditor, TextEditorProps>(
             resourceSuggestionRef.current.state.isOpen ||
             promptSuggestionRef.current.state.isOpen;
 
-          // Prevent Enter from submitting form when selecting from any menu
-          if (event.key === "Enter" && !event.shiftKey && anyMenuOpen) {
-            event.preventDefault();
-            event.stopPropagation();
-            return true;
+          // When menu is open, let the suggestion plugin handle keyboard events
+          // (ArrowUp, ArrowDown, Enter, Escape). Returning false allows the
+          // event to propagate to the suggestion plugin's onKeyDown handler.
+          if (anyMenuOpen) {
+            return false;
           }
 
           // Only handle Enter key for form submission - let TipTap handle everything else

--- a/showcase/src/components/tambo/text-editor.tsx
+++ b/showcase/src/components/tambo/text-editor.tsx
@@ -993,11 +993,11 @@ const TextEditorInner = React.forwardRef<TamboEditor, TextEditorProps>(
             resourceSuggestionRef.current.state.isOpen ||
             promptSuggestionRef.current.state.isOpen;
 
-          // Prevent Enter from submitting form when selecting from any menu
-          if (event.key === "Enter" && !event.shiftKey && anyMenuOpen) {
-            event.preventDefault();
-            event.stopPropagation();
-            return true;
+          // When menu is open, let the suggestion plugin handle keyboard events
+          // (ArrowUp, ArrowDown, Enter, Escape). Returning false allows the
+          // event to propagate to the suggestion plugin's onKeyDown handler.
+          if (anyMenuOpen) {
+            return false;
           }
 
           // Only handle Enter key for form submission - let TipTap handle everything else


### PR DESCRIPTION
## Summary
- Fixed Enter key not working to select items from "@" mention and "/" command popovers in the TipTap editor
- The issue was caused by `editorProps.handleKeyDown` intercepting Enter key events before they could reach the suggestion plugin

## Test plan
- [ ] Open the text editor in the web app
- [ ] Type "@" to open the resource mention popover
- [ ] Use arrow keys to navigate through items (should work)
- [ ] Press Enter to select an item (should now work)
- [ ] Repeat with "/" command popover