### PR TITLE
fix(config): remove build dependency from tests while preserving web tests

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -100,6 +100,9 @@
     },
     "clean": { "cache": false },
     "start": { "dependsOn": ["^build"] },
-    "test": { "dependsOn": ["^test"] }
+    "test": { "dependsOn": ["^test"] },
+    "@tambo-ai-cloud/web#test": {
+      "dependsOn": ["@tambo-ai/react#build", "^test"]
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Removes the `^build` dependency from the `test` task so tests can run faster without building dependencies first
- Adds a task-specific override for `@tambo-ai-cloud/web#test` that depends on `@tambo-ai/react#build` because the web tests mock `@tambo-ai/react` and Jest needs to resolve the module before mocking it

## Test plan

- [x] All tests pass with `npm test`
- [x] Web tests can mock `@tambo-ai/react` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)