### PR TITLE
chore(repo): update testing and linting config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,8 +18,7 @@
     {"name": "@tambo-ai-cloud/backend", "rootPath": "packages/backend", "jestCommandLine": "npx turbo -F @tambo-ai-cloud/backend test --"},
     {"name": "@tambo-ai/react", "rootPath": "react-sdk", "jestCommandLine": "npx turbo -F @tambo-ai/react test --"},
     {"name": "@tambo-ai/showcase", "rootPath": "showcase", "jestCommandLine": "npx turbo -F @tambo-ai/showcase test --"},
-    {"name": "tambo-cli", "rootPath": "cli", "jestCommandLine": "npm run test:esm --"},
-    {"name": "tambo-cli/react", "rootPath": "cli", "jestCommandLine": "npm run test:react --"},
+    {"name": "tambo-cli", "rootPath": "cli", "jestCommandLine": "npx turbo -F tambo test --"},
   ],
   "testing.automaticallyOpenTestResults": "neverOpen"
 }

--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -1,7 +1,7 @@
 import config from "@tambo-ai/eslint-config/base";
-import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
 
-export default tseslint.config(...config, {
+export default defineConfig(...config, {
   rules: {
     // Temporarily turning this off to reduce noise
     "@typescript-eslint/no-explicit-any": "off",

--- a/cli/jest.config.ts
+++ b/cli/jest.config.ts
@@ -41,11 +41,8 @@ const sharedConfig: Config = {
 
 const config: Config = {
   collectCoverageFrom: [
-    "<rootDir>/src/**/*.{js,jsx,ts,tsx}",
-    "!<rootDir>/src/**/*.test.{js,jsx,ts,tsx}",
-    "!<rootDir>/src/**/__tests__/**",
-    "!<rootDir>/src/**/__mocks__/**",
-    "!<rootDir>/dist/**",
+    "<rootDir>/src/**/*.(ts|tsx)",
+    "!<rootDir>/src/**/*.test.(ts|tsx)",
   ],
   coverageThreshold: {
     global: {

--- a/packages/eslint-config/base.mjs
+++ b/packages/eslint-config/base.mjs
@@ -20,7 +20,7 @@ export default defineConfig([
     },
   },
   {
-    ignores: ["dist/**"],
+    ignores: ["dist/**", "coverage/**"],
   },
   {
     rules: {


### PR DESCRIPTION
## Summary

- Simplify VSCode Jest runner config for CLI package (use turbo instead of separate commands)
- Ignore coverage folders in ESLint base config
- Clean up CLI jest coverage collection patterns
- Use `eslint/config` defineConfig instead of typescript-eslint in apps/api

🤖 Generated with [Claude Code](https://claude.com/claude-code)