### PR TITLE
ci(release-please): skip workflow for dependabot pushes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,9 @@ permissions:
 
 jobs:
   release-please:
+    # Skip for dependabot - secrets aren't available and dependency updates
+    # will be included in the next human-triggered release
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Skip the release-please workflow when triggered by dependabot pushes
- Dependabot-triggered push events don't have access to Actions secrets (only Dependabot secrets), causing the workflow to fail
- Dependency updates will be included in the next human-triggered release instead

## Test plan
- [ ] Verify workflow skips when a dependabot PR is merged
- [ ] Verify workflow runs normally for human-triggered pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)