### PR TITLE
Replaced catch (error: any) with unknown

### DIFF
--- a/apps/api/src/oauth/oauth.controller.ts
+++ b/apps/api/src/oauth/oauth.controller.ts
@@ -1,19 +1,19 @@
 import {
-  BadRequestException,
-  Body,
-  Controller,
-  InternalServerErrorException,
-  Post,
-  Req,
-  UnauthorizedException,
-  UseGuards,
+    BadRequestException,
+    Body,
+    Controller,
+    InternalServerErrorException,
+    Post,
+    Req,
+    UnauthorizedException,
+    UseGuards,
 } from "@nestjs/common";
 import {
-  ApiConsumes,
-  ApiOperation,
-  ApiResponse,
-  ApiSecurity,
-  ApiTags,
+    ApiConsumes,
+    ApiOperation,
+    ApiResponse,
+    ApiSecurity,
+    ApiTags,
 } from "@nestjs/swagger";
 import * as Sentry from "@sentry/nestjs";
 import { OAuthValidationMode } from "@tambo-ai-cloud/core";
@@ -21,8 +21,8 @@ import { getDb, operations } from "@tambo-ai-cloud/db";
 import { type Request } from "express";
 import { SignJWT } from "jose";
 import {
-  OAuthTokenRequestDto,
-  OAuthTokenResponseDto,
+    OAuthTokenRequestDto,
+    OAuthTokenResponseDto,
 } from "../common/dto/oauth-token.dto";
 import { CorrelationLoggerService } from "../common/services/logger.service";
 import { validateSubjectToken } from "../common/utils/oauth";
@@ -178,10 +178,11 @@ export class OAuthController {
         expires_in: expiresIn,
         issued_token_type: "urn:ietf:params:oauth:token-type:access_token",
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const isError = error instanceof Error;
       this.logger.error(
-        `Error validating OAuth token: ${error.message}`,
-        error.stack,
+        `Error validating OAuth token: ${isError ? error.message : String(error)}`,
+        isError ? error.stack : undefined,
       );
 
       if (

--- a/apps/api/src/projects/guards/apikey.guard.ts
+++ b/apps/api/src/projects/guards/apikey.guard.ts
@@ -61,10 +61,11 @@ export class ApiKeyGuard implements CanActivate {
 
       this.logger.log(`Valid API key used for project ${projectId}`);
       return true;
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const isError = error instanceof Error;
       this.logger.error(
-        `Error validating API key: ${error.message}`,
-        error.stack,
+        `Error validating API key: ${isError ? error.message : String(error)}`,
+        isError ? error.stack : undefined,
       );
       return false;
     }
@@ -92,10 +93,11 @@ export class ApiKeyGuard implements CanActivate {
       await this.projectsService.updateApiKeyLastUsed(apiKeyId, new Date());
 
       return apiKeyId;
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const isError = error instanceof Error;
       this.logger.error(
-        `Error validating API key: ${error.message}`,
-        error.stack,
+        `Error validating API key: ${isError ? error.message : String(error)}`,
+        isError ? error.stack : undefined,
       );
       return null;
     }

--- a/apps/api/src/projects/guards/bearer-token.guard.ts
+++ b/apps/api/src/projects/guards/bearer-token.guard.ts
@@ -98,10 +98,11 @@ export class BearerTokenGuard implements CanActivate {
       );
 
       return true;
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const isError = error instanceof Error;
       this.logger.error(
-        `Error validating OAuth bearer token: ${error.message}`,
-        error.stack,
+        `Error validating OAuth bearer token: ${isError ? error.message : String(error)}`,
+        isError ? error.stack : undefined,
       );
       throw new UnauthorizedException("Invalid bearer token");
     }

--- a/apps/api/src/projects/guards/project-access-own.guard.ts
+++ b/apps/api/src/projects/guards/project-access-own.guard.ts
@@ -79,10 +79,11 @@ export class ProjectAccessOwnGuard implements CanActivate {
         `[${correlationId}] API key ${apiKey} accessed project ${projectId}`,
       );
       return true;
-    } catch (e: any) {
+    } catch (e: unknown) {
+      const isError = e instanceof Error;
       this.logger.error(
-        `[${correlationId}] Error verifying project access: API key ${apiKey}, project ${request.params.id}: ${e.message}`,
-        e.stack,
+        `[${correlationId}] Error verifying project access: API key ${apiKey}, project ${request.params.id}: ${isError ? e.message : String(e)}`,
+        isError ? e.stack : undefined,
       );
       return false;
     }

--- a/apps/api/src/threads/guards/thread-in-project-guard.ts
+++ b/apps/api/src/threads/guards/thread-in-project-guard.ts
@@ -48,10 +48,11 @@ export class ThreadInProjectGuard implements CanActivate {
         `Valid thread ${threadId} access for project ${projectId}`,
       );
       return true;
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const isError = error instanceof Error;
       this.logger.error(
-        `Error validating thread access: ${error.message}`,
-        error.stack,
+        `Error validating thread access: ${isError ? error.message : String(error)}`,
+        isError ? error.stack : undefined,
       );
       return false;
     }

--- a/apps/api/src/threads/threads.controller.ts
+++ b/apps/api/src/threads/threads.controller.ts
@@ -118,9 +118,9 @@ export class ThreadsController {
         count: threads.length,
         items: threads,
       };
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.logger.error(
-        `Error fetching threads for project ${projectId}: ${error.message}`,
+        `Error fetching threads for project ${projectId}: ${error instanceof Error ? error.message : String(error)}`,
       );
       throw error;
     }

--- a/react-sdk/src/providers/tambo-thread-input-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-input-provider.tsx
@@ -1,14 +1,14 @@
 "use client";
 import React, {
-  createContext,
-  PropsWithChildren,
-  useCallback,
-  useContext,
-  useState,
+    createContext,
+    PropsWithChildren,
+    useCallback,
+    useContext,
+    useState,
 } from "react";
 import {
-  useTamboMutation,
-  UseTamboMutationResult,
+    useTamboMutation,
+    UseTamboMutationResult,
 } from "../hooks/react-query-hooks";
 import { StagedImage, useMessageImages } from "../hooks/use-message-images";
 import { useTamboMcpServers } from "../mcp/tambo-mcp-provider";
@@ -16,8 +16,8 @@ import { ThreadInputError } from "../model/thread-input-error";
 import { validateInput } from "../model/validate-input";
 import { buildMessageContent } from "../util/message-builder";
 import {
-  extractResourceUris,
-  resolveResourceContents,
+    extractResourceUris,
+    resolveResourceContents,
 } from "../util/resource-content-resolver";
 import { useTamboInteractable } from "./tambo-interactable-provider";
 import { useTamboRegistry } from "./tambo-registry-provider";
@@ -157,10 +157,11 @@ export const TamboThreadInputProvider: React.FC<PropsWithChildren> = ({
           content: messageContent,
         });
         clearInteractableSelections();
-      } catch (error: any) {
+      } catch (error: unknown) {
         // Handle image-related errors with friendly messages
         if (imageState.images.length > 0) {
-          const errorMessage = error?.message?.toLowerCase() ?? "";
+          const errorMessage =
+            error instanceof Error ? error.message.toLowerCase() : "";
 
           // Backend not yet supporting image content type
           if (errorMessage.includes("unknown content part type: image")) {


### PR DESCRIPTION
# Refactor Error Handling to Use `unknown`
Solves Issue #1660 
## Description
This PR refactors error handling across the backend and React SDK to replace usage of `catch (error: any)` with `catch (error: unknown)`. This change reinforces TypeScript's type safety by enforcing strict type narrowing before accessing error properties.
## Changes
The following files have been updated to use `catch (error: unknown)` and `error instanceof Error`:
### API
- [apps/api/src/projects/guards/bearer-token.guard.ts](cci:7://file:///c:/Users/sajal/OneDrive/Documents/GitHub/tambo/apps/api/src/projects/guards/bearer-token.guard.ts:0:0-0:0)
- [apps/api/src/projects/guards/apikey.guard.ts](cci:7://file:///c:/Users/sajal/OneDrive/Documents/GitHub/tambo/apps/api/src/projects/guards/apikey.guard.ts:0:0-0:0)
- [apps/api/src/projects/guards/project-access-own.guard.ts](cci:7://file:///c:/Users/sajal/OneDrive/Documents/GitHub/tambo/apps/api/src/projects/guards/project-access-own.guard.ts:0:0-0:0)
- [apps/api/src/threads/guards/thread-in-project-guard.ts](cci:7://file:///c:/Users/sajal/OneDrive/Documents/GitHub/tambo/apps/api/src/threads/guards/thread-in-project-guard.ts:0:0-0:0)
- [apps/api/src/threads/threads.controller.ts](cci:7://file:///c:/Users/sajal/OneDrive/Documents/GitHub/tambo/apps/api/src/threads/threads.controller.ts:0:0-0:0)
- [apps/api/src/oauth/oauth.controller.ts](cci:7://file:///c:/Users/sajal/OneDrive/Documents/GitHub/tambo/apps/api/src/oauth/oauth.controller.ts:0:0-0:0)
### React SDK
- [react-sdk/src/providers/tambo-thread-input-provider.tsx](cci:7://file:///c:/Users/sajal/OneDrive/Documents/GitHub/tambo/react-sdk/src/providers/tambo-thread-input-provider.tsx:0:0-0:0)
## Details
- Replaced `catch (error: any)` with `catch (error: unknown)`.
- Implemented `error instanceof Error` checks to safely access `.message` and `.stack`.
- Added fallback for non-Error thrown objects (e.g., logging `String(error)`) to ensure logging and error messages remain robust and do not crash on non-standard errors.
## Motivation & Context
Using `any` in catch blocks bypasses TypeScript's type checking, leading to potential runtime errors if the thrown object doesn't match expectations. `unknown` forces developers to explicitly check types, making the code more resilient and self-documenting.
## Verification
- [x] Verified that all 7 modified files use strict error typing.
- [x] Manual review confirmed logical equivalence to previous behavior.
- [x] Logging format remains consistent for standard Error objects.
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have verified that no functional regressions were introduced