### PR TITLE
ci(gha): add label automation workflow and config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
+    labels: [] # automation-labels.yml handles labeling
     ignore:
       - dependency-name: "actions/setup-node"
       - dependency-name: "actions/checkout"
@@ -24,6 +25,7 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
+    labels: [] # automation-labels.yml handles labeling
     # Let package releases bake for a bit before updating,
     # in case there is a bad release. However, always update
     # the latest version of the Tambo packages.
@@ -70,7 +72,6 @@ updates:
           - "typescript-eslint"
           - "eslint-plugin-*"
           - "eslint-config-*"
-          - "typescript-eslint"
       testing:
         patterns:
           - "jest"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,207 @@
+# GitHub labels configuration (see .github/workflows/automation-labels.yml)
+# Area labels - which part of the codebase
+- name: "area: api"
+  color: "26b5ce"
+  description: "Changes to the API (apps/api)"
+
+- name: "area: cli"
+  color: "26b5ce"
+  description: "Changes to the CLI package"
+
+- name: "area: db"
+  color: "26b5ce"
+  description: "Changes to the database package"
+
+- name: "area: documentation"
+  color: "26b5ce"
+  description: "Improvements or additions to documentation"
+
+- name: "area: github actions"
+  color: "26b5ce"
+  description: "Changes to GitHub Actions workflows"
+  from_name: "github_actions"
+
+- name: "area: linear"
+  color: "26b5ce"
+  description: "Issues related to Linear integration"
+
+- name: "area: react-sdk"
+  color: "26b5ce"
+  description: "Changes to the React SDK"
+
+- name: "area: showcase"
+  color: "26b5ce"
+  description: "Changes to the showcase app"
+
+- name: "area: ui"
+  color: "26b5ce"
+  description: "Changes to UI components"
+  from_name: "ui"
+
+- name: "area: web"
+  color: "26b5ce"
+  description: "Changes to the web app (apps/web)"
+
+- name: "area: community"
+  color: "26b5ce"
+  description: "Changes to community resources"
+
+- name: "area: core"
+  color: "26b5ce"
+  description: "Changes to the core package (packages/core)"
+
+- name: "area: backend"
+  color: "26b5ce"
+  description: "Changes to the backend package (packages/backend)"
+
+- name: "area: config"
+  color: "26b5ce"
+  description: "Changes to repository configuration files"
+
+# Type labels - what kind of change
+- name: "type: bug"
+  color: "d73a4a"
+  description: "Something isn't working"
+
+- name: "type: enhancement"
+  color: "a2eeef"
+  description: "New feature or request"
+
+- name: "type: question"
+  color: "d876e3"
+  description: "Further information is requested"
+
+# Change labels - conventional commit type
+- name: "change: feat"
+  color: "32e52f"
+  description: "New feature"
+
+- name: "change: fix"
+  color: "158c01"
+  description: "Bug fix"
+
+- name: "change: chore"
+  color: "ededed"
+  description: "Maintenance and chores"
+
+- name: "change: docs"
+  color: "0075ca"
+  description: "Documentation changes"
+
+- name: "change: refactor"
+  color: "fbca04"
+  description: "Code refactoring"
+
+- name: "change: test"
+  color: "bfd4f2"
+  description: "Test changes"
+
+- name: "change: ci"
+  color: "000000"
+  description: "CI/CD changes"
+
+- name: "change: perf"
+  color: "f9d0c4"
+  description: "Performance improvements"
+
+- name: "change: build"
+  color: "5319e7"
+  description: "Build system changes"
+
+- name: "change: style"
+  color: "c5def5"
+  description: "Code style changes"
+
+- name: "change: revert"
+  color: "d93f0b"
+  description: "Reverting changes"
+
+- name: "change: deps"
+  color: "0366d6"
+  description: "Dependency updates"
+
+# Status labels
+- name: "status: do not merge"
+  color: "e11d21"
+  description: "PR should not be merged"
+
+- name: "status: duplicate"
+  color: "cfd3d7"
+  description: "This issue or pull request already exists"
+
+- name: "status: invalid"
+  color: "e4e669"
+  description: "This doesn't seem right"
+
+- name: "status: revision required"
+  color: "e11d21"
+  description: "Changes requested"
+
+- name: "status: help wanted"
+  color: "008672"
+  description: "Needs assistance and is ready for work to be started/continued"
+  from_name: "help wanted"
+
+- name: "status: blocked"
+  color: "e11d21"
+  description: "This issue or pull request is blocked"
+
+- name: "status: in progress"
+  color: "cccccc"
+  description: "Work is currently being done"
+
+- name: "status: triage"
+  color: "fef2c0"
+  description: "Needs to be triaged by a maintainer"
+
+# Priority labels
+- name: "priority: 0"
+  color: "b60205"
+  description: "Critical priority"
+
+- name: "priority: 1"
+  color: "b60205"
+  description: "High priority"
+
+- name: "priority: 2"
+  color: "eab308"
+  description: "Medium priority"
+
+- name: "priority: 3"
+  color: "0e8a16"
+  description: "Normal priority"
+
+# Contributor labels
+- name: "contributor: ai"
+  color: "3bc8b6"
+  description: "AI-assisted contribution"
+
+- name: "contributor: bot"
+  color: "0366d6"
+  description: "Created by a bot"
+
+- name: "contributor: community"
+  color: "6f42c1"
+  description: "Created by a community member"
+
+- name: "contributor: external"
+  color: "6f42c1"
+  description: "Created by an external contributor"
+
+- name: "contributor: tambo-team"
+  color: "80ffce"
+  description: "Created by a Tambo team member"
+
+# Community labels
+- name: "good first issue"
+  color: "7057ff"
+  description: "Good for newcomers"
+
+# Release-please labels
+- name: "autorelease: pending"
+  color: "ededed"
+  description: "Release pending"
+
+- name: "autorelease: tagged"
+  color: "ededed"
+  description: "Release tagged"

--- a/.github/workflows/automation-labels.yml
+++ b/.github/workflows/automation-labels.yml
@@ -1,0 +1,294 @@
+name: Automation / Labels
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+  issues:
+    types: [opened]
+
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/automation-labels.yml"
+
+jobs:
+  meta:
+    name: "Meta"
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      author: ${{ steps.author.outputs.author }}
+      status: ${{ steps.status.outputs.status }}
+      areas: ${{ steps.files_changed.outputs.changed_keys || '[]' }}
+      change_type: ${{ steps.change_type.outputs.change_type }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Mise
+        uses: jdx/mise-action@v3.5.1
+
+      - name: Determine Author
+        id: author
+        env:
+          AUTHOR_LOGIN: "${{ github.event.sender.login }}"
+          AUTHOR_TYPE: "${{ github.event.sender.type }}"
+          TAMBO_TEAM_MEMBERS: |- # json
+            [
+              "alecf",
+              "akhileshrangani4",
+              "lachieh",
+              "MichaelMilstead",
+              "michaelmagan"
+            ]
+          KNOWN_AI_ACTORS: |- # json
+            [
+              "charliecreates[bot]",
+              "CharlieHelps"
+            ]
+        run: | # shell
+          AUTHOR="external"
+
+          if jq -e ". | index(\"${AUTHOR_LOGIN}\")" <<< "${TAMBO_TEAM_MEMBERS}" > /dev/null; then
+            AUTHOR="tambo-team"
+          elif jq -e ". | index(\"${AUTHOR_LOGIN}\")" <<< "${KNOWN_AI_ACTORS}" > /dev/null; then
+            AUTHOR="ai"
+          elif [[ "$AUTHOR_TYPE" == "Bot" || "${AUTHOR_LOGIN}" == *"[bot]"* ]]; then
+            AUTHOR="bot"
+          fi
+
+          echo "author=${AUTHOR}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check Status
+        id: status
+        env:
+          EXISTING_LABELS: ${{ toJson(github.event.issue.labels || github.event.pull_request.labels || '[]') }}
+        run: | # shell
+          ISSUE_STATUS="triage"
+
+          # Only apply one status label
+          if jq -e '.[] | select(.name | startswith("status: "))' <<< "${EXISTING_LABELS}" > /dev/null; then
+            ALL_STATUS_LABELS="$(jq -r '.[] | select(.name | startswith("status: ")) | .name' <<< "${EXISTING_LABELS}")"
+            FIRST_STATUS_LABEL=$(echo "${ALL_STATUS_LABELS}" | head -n 1)
+            ISSUE_STATUS="$(echo "${FIRST_STATUS_LABEL}" | sed 's/status: //')"
+          fi
+
+          echo "status=${ISSUE_STATUS}" >> "${GITHUB_OUTPUT}"
+
+      - name: Determine Change Type
+        id: change_type
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: "${{ github.event.pull_request.title }}"
+        run: | # shell
+          # Extract conventional commit type from PR title (e.g., "feat(scope): description" -> "feat")
+          CHANGE_TYPE=""
+          if [[ "${PR_TITLE}" =~ ^(feat|fix|chore|docs|refactor|test|ci|perf|build|style|revert|deps)(\(.+\))?!?:.*$ ]]; then
+            CHANGE_TYPE="${BASH_REMATCH[1]}"
+          fi
+          echo "change_type=${CHANGE_TYPE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Determine Areas
+        id: files_changed
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@v47
+        with:
+          json: true
+          escape_json: false
+          files_yaml: |- # yaml
+            api:
+              - "apps/api/**"
+            web:
+              - "apps/web/**"
+            showcase:
+              - "showcase/**"
+            cli:
+              - "cli/**"
+            community:
+              - "community/**"
+            db:
+              - "packages/db/**"
+            core:
+              - "packages/core/**"
+            backend:
+              - "packages/backend/**"
+            react-sdk:
+              - "react-sdk/**"
+            config:
+              - "packages/eslint-config/**"
+              - "packages/typescript-config/**"
+              - "turbo.json"
+              - ".nvmrc"
+              - ".node-version"
+              - "mise.toml"
+              - ".prettier*"
+              - "*.config.{js,cjs,mjs,ts,cts,mts,json}"
+            documentation:
+              - "docs/**"
+              - "devdocs/**"
+              - "**/*.md"
+              - "**/README.*"
+            github_actions:
+              - ".github/workflows/**"
+              - ".github/actions/**"
+            labels:
+              - ".github/labels.yml"
+              - ".github/workflows/automation-labels.yml"
+
+  sync-labels:
+    name: "Sync Labels"
+    needs: [meta]
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' || github.event_name == 'issues') && (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      added_labels: ${{ steps.determine_labels.outputs.added_labels || '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Mise
+        uses: jdx/mise-action@v3.5.1
+
+      - name: Determine Labels
+        id: determine_labels
+        env:
+          EXISTING_LABELS: "${{ toJson(github.event.issue.labels || github.event.pull_request.labels || '[]') }}"
+          DATA_AREAS: "${{ needs.meta.outputs.areas }}"
+          DATA_STATUS: "${{ needs.meta.outputs.status }}"
+          DATA_AUTHOR: "${{ needs.meta.outputs.author }}"
+          DATA_CHANGE: "${{ needs.meta.outputs.change_type }}"
+        run: | # shell
+          # Determine Labels
+
+          # object of labels to add/remove
+          # {"label name": true (add) / false (remove)}
+          LABEL_CHANGES="{}"
+
+          remove_label() {
+            local LABEL_TO_REMOVE="$1"
+            LABEL_CHANGES=$(jq --arg key "$LABEL_TO_REMOVE" '. + {($key): false}' <<< "${LABEL_CHANGES}")
+          }
+
+          add_label() {
+            local LABEL_TO_ADD="$1"
+            LABEL_CHANGES=$(jq --arg key "$LABEL_TO_ADD" '. + {($key): true}' <<< "${LABEL_CHANGES}")
+          }
+
+          remove_all_by_prefix() {
+            local PREFIX="$1"
+            for LABEL in $(jq -r '.[] | .name' <<< "${EXISTING_LABELS}"); do
+              if [[ "${LABEL}" == ${PREFIX}* ]]; then
+                remove_label "$LABEL"
+              fi
+            done
+          }
+
+          label_prefix_exists() {
+            local PREFIX="$1"
+            if jq -e --arg prefix "$PREFIX" '.[] | select(.name | startswith($prefix))' <<< "${EXISTING_LABELS}" > /dev/null; then
+              return 0
+            else
+              return 1
+            fi
+          }
+
+          # Areas
+          remove_all_by_prefix "area: "
+          for AREA in $(jq -r '.[]' <<< "${DATA_AREAS}"); do
+            # skip "labels"
+            if [[ "${AREA}" == "labels" ]]; then continue; fi
+            LABEL_KEY="area: ${AREA}"
+            add_label "$LABEL_KEY"
+          done
+
+          # Status
+          remove_all_by_prefix "status: "
+          if [[ -n "${DATA_STATUS}" ]]; then
+            LABEL_KEY="status: ${DATA_STATUS}"
+            add_label "$LABEL_KEY"
+          fi
+
+          # Contributor
+          if label_prefix_exists "contributor: "; then
+            LABEL_KEY="contributor: ${DATA_AUTHOR}"
+            add_label "$LABEL_KEY"
+          fi
+
+          # Change Type
+          if [[ -n "${DATA_CHANGE}" ]]; then
+            remove_all_by_prefix "change: "
+            LABEL_KEY="change: ${DATA_CHANGE}"
+            add_label "$LABEL_KEY"
+          fi
+
+          echo "added_labels=$(jq -c '.' <<< "${LABEL_CHANGES}")" >> "${GITHUB_OUTPUT}"
+
+      - name: Apply Label Changes
+        env:
+          PR_OR_ISSUE_NUMBER: ${{ github.event.number }}
+          GH_SUBCOMMAND: ${{ github.event_name == 'pull_request' && 'pr' || 'issue' }}
+          LABEL_CHANGES: |-
+            ${{ steps.determine_labels.outputs.added_labels || '{}' }}
+        run: | # shell
+          # Apply Label Changes
+          set +e;
+
+          while IFS= read -r LABEL; do
+            SHOULD_ADD=$(jq -r --arg key "$LABEL" '.[$key]' <<< "${LABEL_CHANGES}")
+            ACTION=$([[ "${SHOULD_ADD}" == "true" ]] && echo "--add-label" || echo "--remove-label")
+
+            echo "$([[ "${SHOULD_ADD}" == "true" ]] && echo "to be added" || echo "to be removed") '$LABEL' to $GH_SUBCOMMAND: #$PR_OR_ISSUE_NUMBER"
+
+            RESULT=$(gh $GH_SUBCOMMAND edit "$PR_OR_ISSUE_NUMBER" $ACTION "$LABEL"  2>&1)
+            if [[ $? -ne 0 ]]; then
+              echo "::error title=Failed to sync labels: labels::Failed to sync label '$LABEL'. Error: $RESULT"
+            fi
+          done < <(jq -r 'keys[]' <<< "${LABEL_CHANGES}")
+
+  repo-labels:
+    name: "Repository Labels"
+    runs-on: ubuntu-latest
+    needs: [meta]
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && contains(fromJson(needs.meta.outputs.areas || '[]'), 'labels')) }}
+    permissions:
+      contents: read # to fetch repository content
+      issues: write # to create and update labels
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Update Labels
+        uses: crazy-max/ghaction-github-labeler@v5.3.0
+        with:
+          dry-run: ${{ github.event_name == 'pull_request' }}
+          skip-delete: true
+          yaml-file: .github/labels.yml
+
+  do-not-merge:
+    name: "Do Not Merge"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Check
+        env:
+          DO_NOT_MERGE: "${{contains(github.event.pull_request.labels.*.name, 'status: do not merge')}}"
+        run: | # shell
+          if [[ "${DO_NOT_MERGE}" == "true" ]]; then
+            echo "##[error]Cannot merge when 'status: do not merge' label is present. Remove the label to proceed."
+            exit 1
+          else
+            echo "No 'status: do not merge' label found. Passing check."
+          fi

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,7 @@
 [tools]
 cspell = "9.4.0"
+gh = "2.83.2"
+jq = "1.8.1"
 shellcheck = "0.11.0"
 
 [tools."npm:corepack"]


### PR DESCRIPTION
## Summary
- Adds automated label management workflow that applies labels to PRs and issues based on:
  - **Area labels** (`area: api`, `area: web`, etc.) based on changed files
  - **Change type labels** (`change: feat`, `change: fix`, etc.) extracted from conventional commit PR titles
  - **Contributor labels** (`contributor: tambo-team`, `contributor: external`, etc.) based on author
  - **Status labels** (defaults to `status: triage` for new issues/PRs)
- Adds comprehensive `labels.yml` config defining all repository labels with consistent naming and colors
- Syncs repository labels from config on push to main or when label files change
- Adds "Do Not Merge" check that blocks PRs with the `status: do not merge` label
- Updates dependabot config to skip default labeling (now handled by automation)
- Adds `gh` and `jq` to mise.toml for workflow scripts

## Test plan
- [ ] Verify workflow triggers on PR open and label changes
- [ ] Verify area labels are correctly applied based on changed files
- [ ] Verify change type labels are extracted from PR titles
- [ ] Verify contributor detection works for team members vs external contributors
- [ ] Verify "Do Not Merge" check blocks appropriately labeled PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)