### PR TITLE
feat(ui): add aria-labels to dictation button

### DIFF
--- a/cli/src/registry/message-input/dictation-button.tsx
+++ b/cli/src/registry/message-input/dictation-button.tsx
@@ -51,6 +51,7 @@ export default function DictationButton() {
           <button
             type="button"
             onClick={handleStopRecording}
+            aria-label="Stop dictation"
             className="p-2 rounded-md cursor-pointer hover:bg-muted"
           >
             <Square className="h-4 w-4 text-red-500 fill-current animate-pulse" />
@@ -61,6 +62,7 @@ export default function DictationButton() {
           <button
             type="button"
             onClick={handleStartRecording}
+            aria-label="Start dictation"
             className="p-2 rounded-md cursor-pointer hover:bg-muted"
           >
             <Mic className="h-5 w-5" />

--- a/showcase/src/components/tambo/dictation-button.tsx
+++ b/showcase/src/components/tambo/dictation-button.tsx
@@ -61,6 +61,7 @@ export default function DictationButton() {
           <button
             type="button"
             onClick={handleStopRecording}
+            aria-label="Stop dictation"
             className="p-2 rounded-md cursor-pointer hover:bg-muted"
           >
             <Square className="h-4 w-4 text-red-500 fill-current animate-pulse" />
@@ -71,6 +72,7 @@ export default function DictationButton() {
           <button
             type="button"
             onClick={handleStartRecording}
+            aria-label="Start dictation"
             className="p-2 rounded-md cursor-pointer hover:bg-muted"
           >
             <Mic className="h-5 w-5" />


### PR DESCRIPTION
Adds descriptive aria-labels to the DictationButton so screen readers can correctly announce the button’s purpose based on its current state (start/stop dictation).

### Changes
- Added `aria-label="Start dictation"` when dictation is inactive
- Added `aria-label="Stop dictation"` when dictation is active

### Verification
- `npm run check-types` passes
- `npm run lint` passes
- Tests pass