### PR TITLE
docs: update all port references from 3000/3001 to new ports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,5 +48,5 @@ jobs:
           API_KEY_SECRET: "dummy-api-key-secret"
           PROVIDER_KEY_SECRET: "dummy-provider-key-secret"
           NEXTAUTH_SECRET: "dummy-nextauth-secret"
-          NEXTAUTH_URL: "http://localhost:3000"
+          NEXTAUTH_URL: "http://localhost:8260"
           SKIP_ENV_VALIDATION: "true"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,13 @@ This is a Turborepo monorepo containing both the Tambo AI framework packages and
   - Built as ESM module with executable binary
 
 - **showcase/** - Demo application (`@tambo-ai/showcase`)
+  - Runs on port 8262
   - Next.js app demonstrating all Tambo components and patterns
   - Components auto-synced from CLI registry - edit CLI registry, not showcase components directly
   - Serves as both documentation and testing ground
 
 - **docs/** - Documentation site (`@tambo-ai/docs`)
+  - Runs on port 8263
   - Built with Fumadocs, includes comprehensive guides and API reference
   - This package contains ui components that originated from the cli/ package.
     Any changes to the components should be made in the cli/ package first, and
@@ -42,8 +44,8 @@ This is a Turborepo monorepo containing both the Tambo AI framework packages and
 
 ### Tambo Cloud Platform
 
-- **apps/web** - Next.js app (UI)
-- **apps/api** - NestJS app (OpenAPI server)
+- **apps/web** - Next.js app (UI) - runs on port 8260
+- **apps/api** - NestJS app (OpenAPI server) - runs on port 8261
 - **packages/db** - Drizzle ORM schema + migrations + DB helpers
 - **packages/core** - Shared pure utilities (no DB access)
 - **packages/backend** - LLM/agent-side helpers
@@ -282,7 +284,7 @@ npm run db:studio -w packages/db    # Open Drizzle Studio
 
 ```bash
 # Development (two different apps!)
-npm run dev:cloud        # Start Tambo Cloud (web + API) - ports 3000/3001
+npm run dev:cloud        # Start Tambo Cloud (web + API) - ports 8260 + 8261
 npm run dev              # Start React SDK (showcase + docs)
 
 # Quality checks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Guidelines for Claude Code (claude.ai/code) when touching this repo.
 
 ```bash
 # Development (two different apps)
-npm run dev:cloud        # Start Tambo Cloud (web + API) - ports 3000/3001
+npm run dev:cloud        # Start Tambo Cloud (web + API) - ports 8260 + 8261
 npm run dev              # Start React SDK (showcase + docs)
 
 # Quality checks (run before commits)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,8 @@ For Tambo Cloud (web dashboard + API):
 npm run dev:cloud
 ```
 
-- **Web App**: http://localhost:3000
-- **API**: http://localhost:3001
+- **Web App**: http://localhost:8260
+- **API**: http://localhost:8261
 
 For the React SDK framework (showcase + docs):
 
@@ -100,10 +100,10 @@ npm run dev
 ### 6. Get a Local API Key
 
 1. Start the dev servers: `npm run dev:cloud`
-2. Visit http://localhost:3000/dashboard and sign in
+2. Visit http://localhost:8260/dashboard and sign in
 3. Create a project and generate an API key
 4. Add to `apps/web/.env.local`: `NEXT_PUBLIC_TAMBO_API_KEY=your_key`
-5. Verify with http://localhost:3000/internal/smoketest
+5. Verify with http://localhost:8260/internal/smoketest
 
 ## Common Commands
 
@@ -133,7 +133,7 @@ npm run db:studio -w packages/db    # Open Drizzle Studio
 | `API_KEY_SECRET`      | `apps/api/.env`, `apps/web/.env.local`                     | API key encryption secret    |
 | `PROVIDER_KEY_SECRET` | `apps/api/.env`, `apps/web/.env.local`                     | Provider key encryption      |
 | `NEXTAUTH_SECRET`     | `apps/web/.env.local`                                      | NextAuth.js session secret   |
-| `NEXTAUTH_URL`        | `apps/web/.env.local`                                      | http://localhost:3000        |
+| `NEXTAUTH_URL`        | `apps/web/.env.local`                                      | http://localhost:8260        |
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ import { MCPTransport } from "@tambo-ai/react/mcp";
 const mcpServers = [
   {
     name: "filesystem",
-    url: "http://localhost:3001/mcp",
+    url: "http://localhost:8261/mcp",
     transport: MCPTransport.HTTP,
   },
 ];

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,7 +69,7 @@ In general, the process is as follows for any repo:
   1. Grab the OpenAPI spec from your local build:
 
      ```
-     curl http://localhost:3001/api-json | jq -S . | pbcopy
+     curl http://localhost:8261/api-json | jq -S . | pbcopy
      ```
 
      (On Mac, `pbcopy` is used to copy the output to the clipboard)

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -7,7 +7,7 @@ NestJS service powering the Tambo Cloud backend (projects, threads, registry syn
 1. Copy `.env.example` to `.env` (see root `turbo.json` for the full env list).
 2. `npm install`
 3. `npm run dev`
-4. Swagger is available at [http://localhost:3000/api](http://localhost:3000/api)
+4. Swagger is available at [http://localhost:8261/api](http://localhost:8261/api)
 
 ## Commands
 

--- a/apps/api/src/common/systemTools.test.ts
+++ b/apps/api/src/common/systemTools.test.ts
@@ -90,7 +90,7 @@ describe("systemTools", () => {
     jest.clearAllMocks();
 
     // Set env variables
-    process.env.VERCEL_URL = "http://localhost:3000";
+    process.env.VERCEL_URL = "http://localhost:8260";
 
     // Create a mock db with a query property
     mockDb = {

--- a/apps/api/src/common/systemTools.ts
+++ b/apps/api/src/common/systemTools.ts
@@ -332,7 +332,7 @@ async function getAuthProvider(
   }
 
   const authProvider = new OAuthLocalProvider(db, context.id, {
-    baseUrl: env.VERCEL_URL ?? "http://localhost:3000",
+    baseUrl: env.VERCEL_URL ?? "http://localhost:8260",
     serverUrl: mcpServer.url,
     clientInformation: client.sessionInfo.clientInformation,
     sessionId: client.sessionId,

--- a/apps/web/app/blog/AGENTS.md
+++ b/apps/web/app/blog/AGENTS.md
@@ -212,7 +212,7 @@ export function Example() {
 ## Development Commands
 
 ```bash
-npm run dev              # Start dev server (localhost:3000)
+npm run dev              # Start dev server (localhost:8260)
 npm run build            # Build for production
 npm run lint             # Check code quality
 npm run check-types      # TypeScript type checking

--- a/docker.env.example
+++ b/docker.env.example
@@ -28,7 +28,7 @@ EXTRACTION_OPENAI_API_KEY=your-extraction-openai-api-key
 FALLBACK_OPENAI_API_KEY=your-fallback-openai-api-key
 
 # Tambo API Configuration
-# NOTE: Use port 3211 for Docker deployments, port 3001 for local development
+# NOTE: Use port 8261 for Docker deployments, port 8261 for local development
 NEXT_PUBLIC_TAMBO_API_URL=http://localhost:3211
 NEXT_PUBLIC_TAMBO_API_KEY=your-tambo-api-key
 NEXT_PUBLIC_TAMBO_DASH_KEY=your-tambo-dash-key

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ To run the documentation site locally:
 npm run dev
 ```
 
-Open http://localhost:3000 to view the documentation.
+Open http://localhost:8263 to view the documentation.
 
 ## Structure
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -205,7 +205,7 @@ import { MCPTransport } from "@tambo-ai/react/mcp";
 const mcpServers = [
   {
     name: "filesystem",
-    url: "http://localhost:3001/mcp",
+    url: "http://localhost:8261/mcp",
     transport: MCPTransport.HTTP,
   },
 ];

--- a/react-sdk/README.md
+++ b/react-sdk/README.md
@@ -246,7 +246,7 @@ import { MCPTransport } from "@tambo-ai/react/mcp";
 const mcpServers = [
   {
     name: "filesystem",
-    url: "http://localhost:3001/mcp",
+    url: "http://localhost:8261/mcp",
     transport: MCPTransport.HTTP,
   },
 ];

--- a/scripts/cloud/smoke-mcp.sh
+++ b/scripts/cloud/smoke-mcp.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # Default to the new /mcp route; allow override via environment variable
 # Usage: TARGET_URL="https://mcp.tambo.co/mcp" ./scripts/cloud/smoke-mcp.sh
-TARGET_URL="${TARGET_URL:-http://localhost:3000/mcp}"
+TARGET_URL="${TARGET_URL:-http://localhost:8261/mcp}"
 
 info "[smoke] Hitting $TARGET_URL ..."
 


### PR DESCRIPTION
## Summary

- Updates all documentation, config files, and code to use the new port scheme:
  - **apps/web**: 3000 → 8260
  - **apps/api**: 3001 → 8261
  - **showcase**: 8262
  - **docs**: 8263
- Fixes remaining stale port references that were missed in the initial port migration

## Files Updated

**Documentation:**
- AGENTS.md, CLAUDE.md, CONTRIBUTING.md, README.md, RELEASING.md
- apps/api/README.md, apps/web/app/blog/AGENTS.md, docs/README.md
- react-sdk/README.md, docs/content/docs/index.mdx

**Config & Code:**
- .github/workflows/ci.yml (NEXTAUTH_URL)
- apps/api/src/common/systemTools.ts (OAuth fallback URL)
- apps/api/src/common/systemTools.test.ts
- scripts/cloud/smoke-mcp.sh
- docker.env.example

## Not Changed (Intentional)

References to `localhost:3000` in these files are correct as they refer to **user's apps** (which run on default port 3000), not Tambo infrastructure:
- cli/src/commands/init.ts
- docs/content/docs/getting-started/quickstart.mdx
- apps/web/components/sections/code-examples.tsx
- apps/web/components/sections/component-library-demo.tsx

## Test plan

- [ ] Verify CI passes with updated NEXTAUTH_URL
- [ ] Verify smoke-mcp.sh script works with new port
- [ ] Documentation URLs are correct in all READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)