### PR TITLE
fix(cli): add GenerationStage enum to components and Jest mock

### DIFF
--- a/cli/__tests__/__mocks__/@tambo-ai-react.ts
+++ b/cli/__tests__/__mocks__/@tambo-ai-react.ts
@@ -6,10 +6,21 @@
 import { jest } from "@jest/globals";
 import type { Mock } from "jest-mock";
 
+export enum GenerationStage {
+  IDLE = "IDLE",
+  CHOOSING_COMPONENT = "CHOOSING_COMPONENT",
+  FETCHING_CONTEXT = "FETCHING_CONTEXT",
+  HYDRATING_COMPONENT = "HYDRATING_COMPONENT",
+  STREAMING_RESPONSE = "STREAMING_RESPONSE",
+  COMPLETE = "COMPLETE",
+  ERROR = "ERROR",
+  CANCELLED = "CANCELLED",
+}
+
 export const useTambo: Mock = jest.fn().mockReturnValue({
   thread: {
     messages: [],
-    generationStage: "IDLE",
+    generationStage: GenerationStage.IDLE,
   },
 });
 

--- a/cli/__tests__/registry/scrollable-message-container/scrollable-message-container.test.tsx
+++ b/cli/__tests__/registry/scrollable-message-container/scrollable-message-container.test.tsx
@@ -1,9 +1,9 @@
 /// <reference types="@testing-library/jest-dom" />
-import { jest, describe, it, expect, beforeEach } from "@jest/globals";
-import React from "react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { GenerationStage, useTambo } from "@tambo-ai/react";
 import { render } from "@testing-library/react";
+import React from "react";
 import { ScrollableMessageContainer } from "../../../src/registry/scrollable-message-container/scrollable-message-container";
-import { useTambo } from "@tambo-ai/react";
 
 // @tambo-ai/react is mocked via moduleNameMapper in jest.config.ts
 
@@ -14,7 +14,7 @@ describe("ScrollableMessageContainer", () => {
     mockUseTambo.mockReturnValue({
       thread: {
         messages: [],
-        generationStage: "IDLE",
+        generationStage: GenerationStage.IDLE,
       },
     } as never);
   });

--- a/cli/src/registry/map/map.tsx
+++ b/cli/src/registry/map/map.tsx
@@ -8,7 +8,11 @@ import {
   type LayerProps,
   type LeafletContextInterface,
 } from "@react-leaflet/core";
-import { useTambo, useTamboCurrentMessage } from "@tambo-ai/react";
+import {
+  GenerationStage,
+  useTambo,
+  useTamboCurrentMessage,
+} from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
 import L, {
   type HeatLatLngTuple,
@@ -400,8 +404,8 @@ export const Map = React.forwardRef<HTMLDivElement, MapProps>(
     const generationStage = thread?.generationStage;
     const isGenerating =
       generationStage &&
-      generationStage !== "COMPLETE" &&
-      generationStage !== "ERROR";
+      generationStage !== GenerationStage.COMPLETE &&
+      generationStage !== GenerationStage.ERROR;
 
     const validMarkers = useValidMarkers(markers);
     const validHeatData = useValidHeatData(heatData);

--- a/cli/src/registry/message-suggestions/message-suggestions.tsx
+++ b/cli/src/registry/message-suggestions/message-suggestions.tsx
@@ -7,7 +7,11 @@ import {
 } from "@/components/tambo/suggestions-tooltip";
 import { cn } from "@/lib/utils";
 import type { Suggestion, TamboThread } from "@tambo-ai/react";
-import { useTambo, useTamboSuggestions } from "@tambo-ai/react";
+import {
+  GenerationStage,
+  useTambo,
+  useTamboSuggestions,
+} from "@tambo-ai/react";
 import { Loader2Icon } from "lucide-react";
 import * as React from "react";
 import { useEffect, useRef } from "react";
@@ -249,7 +253,8 @@ const MessageSuggestionsStatus = React.forwardRef<
         "p-2 rounded-md text-sm bg-transparent",
         !error &&
           !isGenerating &&
-          (!thread?.generationStage || thread.generationStage === "COMPLETE")
+          (!thread?.generationStage ||
+            thread.generationStage === GenerationStage.COMPLETE)
           ? "p-0 min-h-0 mb-0"
           : "",
         className,
@@ -286,7 +291,7 @@ function GenerationStageContent({
   generationStage?: string;
   isGenerating: boolean;
 }) {
-  if (generationStage && generationStage !== "COMPLETE") {
+  if (generationStage && generationStage !== GenerationStage.COMPLETE) {
     return <MessageGenerationStage />;
   }
   if (isGenerating) {

--- a/cli/src/registry/scrollable-message-container/scrollable-message-container.tsx
+++ b/cli/src/registry/scrollable-message-container/scrollable-message-container.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useTambo } from "@tambo-ai/react";
+import { GenerationStage, useTambo } from "@tambo-ai/react";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -50,7 +50,7 @@ export const ScrollableMessageContainer = React.forwardRef<
     }));
   }, [thread.messages]);
 
-  const generationStage = thread?.generationStage ?? "IDLE";
+  const generationStage = thread?.generationStage ?? GenerationStage.IDLE;
 
   // Handle scroll events to detect user scrolling
   const handleScroll = () => {
@@ -84,7 +84,7 @@ export const ScrollableMessageContainer = React.forwardRef<
         }
       };
 
-      if (generationStage === "STREAMING_RESPONSE") {
+      if (generationStage === GenerationStage.STREAMING_RESPONSE) {
         // During streaming, scroll immediately
         requestAnimationFrame(scroll);
       } else {

--- a/showcase/src/components/tambo/map.tsx
+++ b/showcase/src/components/tambo/map.tsx
@@ -18,7 +18,11 @@ import {
   type LayerProps,
   type LeafletContextInterface,
 } from "@react-leaflet/core";
-import { useTambo, useTamboCurrentMessage } from "@tambo-ai/react";
+import {
+  GenerationStage,
+  useTambo,
+  useTamboCurrentMessage,
+} from "@tambo-ai/react";
 import { cva, type VariantProps } from "class-variance-authority";
 import L, {
   type HeatLatLngTuple,
@@ -410,8 +414,8 @@ export const Map = React.forwardRef<HTMLDivElement, MapProps>(
     const generationStage = thread?.generationStage;
     const isGenerating =
       generationStage &&
-      generationStage !== "COMPLETE" &&
-      generationStage !== "ERROR";
+      generationStage !== GenerationStage.COMPLETE &&
+      generationStage !== GenerationStage.ERROR;
 
     const validMarkers = useValidMarkers(markers);
     const validHeatData = useValidHeatData(heatData);

--- a/showcase/src/components/tambo/message-suggestions.tsx
+++ b/showcase/src/components/tambo/message-suggestions.tsx
@@ -17,7 +17,11 @@ import {
 } from "@/components/tambo/suggestions-tooltip";
 import { cn } from "@/lib/utils";
 import type { Suggestion, TamboThread } from "@tambo-ai/react";
-import { useTambo, useTamboSuggestions } from "@tambo-ai/react";
+import {
+  GenerationStage,
+  useTambo,
+  useTamboSuggestions,
+} from "@tambo-ai/react";
 import { Loader2Icon } from "lucide-react";
 import * as React from "react";
 import { useEffect, useRef } from "react";
@@ -259,7 +263,8 @@ const MessageSuggestionsStatus = React.forwardRef<
         "p-2 rounded-md text-sm bg-transparent",
         !error &&
           !isGenerating &&
-          (!thread?.generationStage || thread.generationStage === "COMPLETE")
+          (!thread?.generationStage ||
+            thread.generationStage === GenerationStage.COMPLETE)
           ? "p-0 min-h-0 mb-0"
           : "",
         className,
@@ -296,7 +301,7 @@ function GenerationStageContent({
   generationStage?: string;
   isGenerating: boolean;
 }) {
-  if (generationStage && generationStage !== "COMPLETE") {
+  if (generationStage && generationStage !== GenerationStage.COMPLETE) {
     return <MessageGenerationStage />;
   }
   if (isGenerating) {

--- a/showcase/src/components/tambo/scrollable-message-container.tsx
+++ b/showcase/src/components/tambo/scrollable-message-container.tsx
@@ -11,7 +11,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { useTambo } from "@tambo-ai/react";
+import { GenerationStage, useTambo } from "@tambo-ai/react";
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -60,7 +60,7 @@ export const ScrollableMessageContainer = React.forwardRef<
     }));
   }, [thread.messages]);
 
-  const generationStage = thread?.generationStage ?? "IDLE";
+  const generationStage = thread?.generationStage ?? GenerationStage.IDLE;
 
   // Handle scroll events to detect user scrolling
   const handleScroll = () => {
@@ -94,7 +94,7 @@ export const ScrollableMessageContainer = React.forwardRef<
         }
       };
 
-      if (generationStage === "STREAMING_RESPONSE") {
+      if (generationStage === GenerationStage.STREAMING_RESPONSE) {
         // During streaming, scroll immediately
         requestAnimationFrame(scroll);
       } else {


### PR DESCRIPTION
Closes #1704 

Replaces magic strings with GenerationStage enum values in components and tests.

