### PR TITLE
test(react-sdk): add test for is-promise.ts

### DIFF
--- a/react-sdk/src/util/is-promise.test.ts
+++ b/react-sdk/src/util/is-promise.test.ts
@@ -1,0 +1,56 @@
+import { isPromise } from "../util/is-promise";
+
+describe("isPromise", () => {
+  it("should return true for real Promise instances", () => {
+    expect(isPromise(Promise.resolve(1))).toBe(true);
+    expect(isPromise(new Promise(() => {}))).toBe(true);
+  });
+
+  it("should return true for custom thenables", () => {
+    const thenable = {
+      then: () => {},
+    };
+
+    expect(isPromise(thenable)).toBe(true);
+  });
+
+  it("should return true for function with a then method", () => {
+    const fn = () => {};
+    fn.then = () => {};
+
+    expect(isPromise(fn)).toBe(true);
+  });
+
+  it("should return false for null", () => {
+    expect(isPromise(null)).toBe(false);
+  });
+
+  it("should return false for primitive values", () => {
+    expect(isPromise(0)).toBe(false);
+    expect(isPromise("text")).toBe(false);
+    expect(isPromise(true)).toBe(false);
+    expect(isPromise(undefined)).toBe(false);
+    expect(isPromise(Symbol("sym"))).toBe(false);
+    expect(isPromise(10n)).toBe(false);
+  });
+
+  it("should return false for object without then method", () => {
+    expect(isPromise({})).toBe(false);
+    expect(isPromise({ status: "active" })).toBe(false);
+  });
+
+  it("should return false when then exists but is not a function", () => {
+    expect(isPromise({ then: 123 })).toBe(false);
+    expect(isPromise({ then: "not-a-function" })).toBe(false);
+  });
+
+  it("should handle Promise-like object created via Promise.resolve", () => {
+    const value = Promise.resolve("ok");
+    expect(isPromise(value)).toBe(true);
+  });
+
+  it("should not throw for unexpected input types", () => {
+    expect(() => isPromise(Object.create(null))).not.toThrow();
+    expect(isPromise(Object.create(null))).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #1658

## Summary
The `react-sdk/src/util/is-promise.ts` file currently has a simple type guard but no unit tests. This PR adds comprehensive tests to ensure correct behavior.

## Changes
- Added `react-sdk/src/util/is-promise.test.ts`
- Tests cover:
  - Real Promises
  - Custom thenables (objects with a `.then` method)
  - Null and undefined values
  - Primitives (numbers, strings, booleans)
  - Plain objects 
  - Functions with a `.then` method

## Verification
- `npm run check-types` passes
- `npm run lint` passes
- `npm test` passes
- All test cases for `isPromise` return expected results

## Checklist
- [x] Tests added to cover new functionality
- [x] `npm run check-types` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
