### PR TITLE
fix(react-sdk): replace any types with unknown in context helpers

### DIFF
--- a/react-sdk/src/context-helpers/context-helpers.test.ts
+++ b/react-sdk/src/context-helpers/context-helpers.test.ts
@@ -14,12 +14,19 @@ describe("Context Helpers (prebuilt functions)", () => {
       // Should not be null (error case)
       expect(context).not.toBeNull();
 
+      // Type guard: ensure context is an object
+      expect(typeof context).toBe("object");
+      if (typeof context !== "object" || context === null) {
+        throw new Error("Expected context to be a non-null object");
+      }
+
       // Shape: { timestamp: string }
       expect(context).toHaveProperty("timestamp");
-      expect(typeof context!.timestamp).toBe("string");
+      const contextObj = context as Record<string, unknown>;
+      expect(typeof contextObj.timestamp).toBe("string");
 
       // Verify timestamp string parses
-      expect(() => new Date(context!.timestamp as string)).not.toThrow();
+      expect(() => new Date(contextObj.timestamp as string)).not.toThrow();
     });
   });
 
@@ -33,12 +40,19 @@ describe("Context Helpers (prebuilt functions)", () => {
         return;
       }
 
+      // Type guard: ensure context is an object
+      expect(typeof context).toBe("object");
+      if (typeof context !== "object") {
+        throw new Error("Expected context to be an object");
+      }
+
       // Shape: { url: string, title: string }
       expect(context).toHaveProperty("url");
       expect(context).toHaveProperty("title");
 
-      expect(typeof context.url).toBe("string");
-      expect(typeof context.title).toBe("string");
+      const contextObj = context as Record<string, unknown>;
+      expect(typeof contextObj.url).toBe("string");
+      expect(typeof contextObj.title).toBe("string");
     });
   });
 });

--- a/react-sdk/src/context-helpers/current-interactables-context-helper.ts
+++ b/react-sdk/src/context-helpers/current-interactables-context-helper.ts
@@ -31,7 +31,7 @@ export const currentInteractablesContextHelper: ContextHelperFn = () => {
  * @returns A context helper function that returns component metadata or null if no components exist
  */
 export const createInteractablesContextHelper = (
-  components: any[],
+  components: unknown[],
 ): ContextHelperFn => {
   return () => {
     if (!Array.isArray(components) || components.length === 0) {
@@ -39,20 +39,38 @@ export const createInteractablesContextHelper = (
     }
 
     return {
-      components: components.map((component) => ({
-        id: component.id,
-        componentName: component.name,
-        description: component.description,
-        props: component.props,
-        propsSchema: component.propsSchema
-          ? "Available - use component-specific update tools"
-          : "Not specified",
-        state: component.state,
-        isSelectedForInteraction: component.isSelectedForInteraction ?? false,
-        stateSchema: component.stateSchema
-          ? "Available - use component-specific update tools"
-          : "Not specified",
-      })),
+      components: components.map((component) => {
+        // Type guard: ensure component is an object with the expected properties
+        if (typeof component !== "object" || component === null) {
+          return {
+            id: "unknown",
+            componentName: "unknown",
+            description: "invalid component",
+            props: undefined,
+            propsSchema: "Not specified",
+            state: undefined,
+            isSelectedForInteraction: false,
+            stateSchema: "Not specified",
+          };
+        }
+
+        const comp = component as Record<string, unknown>;
+        return {
+          id: String(comp.id ?? "unknown"),
+          componentName: String(comp.name ?? "unknown"),
+          description: String(comp.description ?? ""),
+          props: comp.props,
+          propsSchema: comp.propsSchema
+            ? "Available - use component-specific update tools"
+            : "Not specified",
+          state: comp.state,
+          isSelectedForInteraction:
+            (comp.isSelectedForInteraction as boolean | undefined) ?? false,
+          stateSchema: comp.stateSchema
+            ? "Available - use component-specific update tools"
+            : "Not specified",
+        };
+      }),
     };
   };
 };

--- a/react-sdk/src/context-helpers/registry.ts
+++ b/react-sdk/src/context-helpers/registry.ts
@@ -4,10 +4,10 @@
  */
 
 export type HelperFn = () =>
-  | any
+  | unknown
   | null
   | undefined
-  | Promise<any | null | undefined>;
+  | Promise<unknown | null | undefined>;
 
 /**
  * Resolve all helpers to AdditionalContext entries, skipping null/undefined and errors.
@@ -15,7 +15,7 @@ export type HelperFn = () =>
  */
 export async function resolveAdditionalContext(
   helpers: Record<string, HelperFn>,
-): Promise<{ name: string; context: any }[]> {
+): Promise<{ name: string; context: unknown }[]> {
   const entries = Object.entries(helpers);
   if (entries.length === 0) return [];
 
@@ -32,5 +32,5 @@ export async function resolveAdditionalContext(
     }),
   );
 
-  return results.filter(Boolean) as { name: string; context: any }[];
+  return results.filter(Boolean) as { name: string; context: unknown }[];
 }

--- a/react-sdk/src/context-helpers/types.ts
+++ b/react-sdk/src/context-helpers/types.ts
@@ -5,7 +5,7 @@ export interface AdditionalContext {
   /** The name of the context type */
   name: string;
   /** The context data */
-  context: any;
+  context: unknown;
 }
 
 /**
@@ -13,10 +13,10 @@ export interface AdditionalContext {
  * or null/undefined to skip including anything.
  */
 export type ContextHelperFn = () =>
-  | any
+  | unknown
   | null
   | undefined
-  | Promise<any | null | undefined>;
+  | Promise<unknown | null | undefined>;
 
 /**
  * A collection of context helpers keyed by their context name.


### PR DESCRIPTION
---

## Summary

Fixes #1710 

## Changes

* Refactored `react-sdk/src/context-helpers/current-interactables-context-helper.ts` for proper type narrowing
* Updated `react-sdk/src/context-helpers/types.ts` and `react-sdk/src/context-helpers/registry.ts` to use `unknown` instead of `any`
* Updated `react-sdk/src/context-helpers/context-helpers-provider.test.tsx` test

## Verification

* [x] Tests added/updated to cover new functionality.
* [x] `npm run check-types` passes.
* [x] `npm run lint` passes.
* [x] `npm test` passes.
