### PR TITLE
refactor(cli): make registry components framework-agnostic

### DIFF
--- a/cli/src/registry/message/message.tsx
+++ b/cli/src/registry/message/message.tsx
@@ -282,6 +282,8 @@ const MessageImages = React.forwardRef<HTMLDivElement, MessageImagesProps>(
               alt={`Image ${index + 1}`}
               width={128}
               height={128}
+              loading="lazy"
+              decoding="async"
               className="w-full h-full object-cover"
             />
           </div>

--- a/showcase/src/components/tambo/message.tsx
+++ b/showcase/src/components/tambo/message.tsx
@@ -23,7 +23,6 @@ import type TamboAI from "@tambo-ai/typescript-sdk";
 import { cva, type VariantProps } from "class-variance-authority";
 import stringify from "json-stringify-pretty-compact";
 import { Check, ChevronDown, ExternalLink, Loader2, X } from "lucide-react";
-import Image from "next/image";
 import * as React from "react";
 import { useState } from "react";
 import { Streamdown } from "streamdown";
@@ -288,13 +287,14 @@ const MessageImages = React.forwardRef<HTMLDivElement, MessageImagesProps>(
             key={index}
             className="w-32 h-32 rounded-md overflow-hidden shadow-sm hover:shadow-md transition-shadow duration-200"
           >
-            <Image
+            <img
               src={imageUrl}
               alt={`Image ${index + 1}`}
               width={128}
               height={128}
+              loading="lazy"
+              decoding="async"
               className="w-full h-full object-cover"
-              unoptimized
             />
           </div>
         ))}


### PR DESCRIPTION
## Summary

Remove Next.js-specific code from component registry to support non-Next.js React frameworks (Vite, CRA, etc.):

- Replace `next/image` with standard `<img>` tags in `message.tsx` and `message-input.tsx`
- Replace `next/dynamic` with `React.lazy` + `Suspense` for DictationButton lazy loading

This enables Tambo components to work in any React application without requiring Next.js as a dependency.

## Changes

### `message.tsx`
- Removed `import Image from "next/image"`
- Changed `<Image>` component to standard `<img>` tag with equivalent styling

### `message-input.tsx`
- Removed `import dynamic from "next/dynamic"` and `import Image from "next/image"`
- Replaced `dynamic(() => import("./dictation-button"), { ssr: false })` with `React.lazy(() => import("./dictation-button"))` wrapped in `<React.Suspense>`
- Changed `<Image>` component to standard `<img>` tag with `absolute inset-0 w-full h-full` to replicate the `fill` prop behavior

## Audit Results

Searched entire registry for Next.js-specific imports:
- `next/image` - **Fixed** (was in 2 files)
- `next/dynamic` - **Fixed** (was in 1 file)
- `next/link` - None found
- `next/router` - None found
- `next/navigation` - None found

## Test plan

- [x] TypeScript type check passes (`npm run check-types`)
- [x] Lint passes (`npm run lint`)
- [x] All 155 tests pass (`npm test`)
- [ ] Manual testing with showcase app
- [ ] Verify images display correctly in message components

Relates to #1655

Note: PRs #1684 (package manager detection) and #1734 (framework detection for env vars) address other aspects of #1655. Together, these three PRs should provide comprehensive non-Next.js framework support.

---

TAM-914