### PR TITLE
fix: update migrate-db flow to trigger on CI complete

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   workflow_run:
-    workflows: ["Build (Cloud)"]
+    workflows: ["CI"]
     branches: [main]
     types:
       - completed
@@ -14,8 +14,8 @@ on:
 jobs:
   deploy-migrations:
     name: Deploy Database Migrations
-    # Skip if the actor is dependabot
-    if: github.actor != 'dependabot[bot]'
+    # Skip if the actor is dependabot, or if the triggering workflow failed
+    if: github.actor != 'dependabot[bot]' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
`migrate-db` workflow was triggering on "Build (Cloud)" workflow completion, which does not exist, so migration has not been running. Updates flow to run on completion of CI workflow.