### PR TITLE
docs(claude): add guidance against overusing RegEx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,13 @@ Guidelines for Claude Code (claude.ai/code) when touching this repo.
 2. Use the workspace scripts it lists (see below for key commands).
 3. Defer to it whenever instructions collide; if something's still unclear, ask the user.
 
+## Avoid RegEx When Possible
+
+- **Prefer string methods**: Simple patterns like `str.includes()`, `str.startsWith()`, `str.split()`, and `str.replace()` are easier to read and maintain.
+- **Avoid global flag (`/g`)**: Creates stateful regex objects where `lastIndex` persists between calls, causing subtle bugs.
+- **Avoid multiline flag (`/m`)**: Line ending differences across platforms (`\n` vs `\r\n`) cause inconsistent behavior; multiline patterns are harder to reason about.
+- **If regex is unavoidable**: Keep it simple, add a comment explaining the pattern, and test edge cases thoroughly.
+
 ## Key Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- Add section to CLAUDE.md discouraging RegEx overuse
- Warn about global flag (`/g`) creating stateful regex with `lastIndex` bugs
- Warn about multiline flag (`/m`) and cross-platform line ending inconsistencies
- Recommend string methods for simple patterns

## Test plan
- [x] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)