### PR TITLE
fix(cli): add missing date-fns dependency

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@tambo-ai/react": "*",
+    "date-fns": "^4.1.0",
     "@tambo-ai/typescript-sdk": "^0.80.0",
     "@trpc/client": "^11.7.2",
     "@trpc/server": "^11.7.2",


### PR DESCRIPTION
## Summary
- Adds `date-fns` to CLI dependencies (was imported but not declared)
- Fixes `npx tambo@latest init` failing with `ERR_MODULE_NOT_FOUND`

## Test plan
- [ ] Run `npm install` from repo root
- [ ] Publish CLI and verify `npx tambo@latest init` works