### PR TITLE
test(react-sdk): add tests for validate-component-name.ts-1657

### DIFF
--- a/react-sdk/src/util/validate-component-name.test.ts
+++ b/react-sdk/src/util/validate-component-name.test.ts
@@ -1,0 +1,40 @@
+import { assertValidName } from "./validate-component-name";
+describe("assertValidName", () => {
+  // Valid names
+  it("should not throw an error for a valid name with letters only", () => {
+    expect(() => assertValidName("MyComponent", "component")).not.toThrow();
+  });
+  it("should not throw an error for letters, numbers, underscore", () => {
+    expect(() => assertValidName("component_123", "component")).not.toThrow();
+  });
+  it("should not throw an error for letters, numbers, hyphen", () => {
+    expect(() => assertValidName("tool-456", "tool")).not.toThrow();
+  });
+  it("should not throw an error for mix of letters, numbers, underscores, hyphens", () => {
+    expect(() => assertValidName("A1_b-2C", "component")).not.toThrow();
+  });
+  it("should not throw an error with single underscore, and hyphen", () => {
+    expect(() => assertValidName("_", "tool")).not.toThrow();
+    expect(() => assertValidName("-", "tool")).not.toThrow();
+  });
+  // Invalid names
+  it("should throw an error for name with space", () => {
+    expect(() => assertValidName("My Component", "component")).toThrow(
+      `component "My Component" must only contain letters, numbers, underscores, and hyphens.`,
+    );
+  });
+  it("should throw an error for name with special characters", () => {
+    expect(() => assertValidName("tool@123", "tool")).toThrow(
+      `tool "tool@123" must only contain letters, numbers, underscores, and hyphens.`,
+    );
+    expect(() => assertValidName("component!$", "component")).toThrow(
+      `component "component!$" must only contain letters, numbers, underscores, and hyphens.`,
+    );
+  });
+  // Edge Cases
+  it("should throw an error for name with empty string", () => {
+    expect(() => assertValidName("", "component")).toThrow(
+      `component "" must only contain letters, numbers, underscores, and hyphens.`,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1657 

## Summary
The `react-sdk/src/util/validate-component-name.ts` file contains the `assertValidName` function, which currently has no unit tests. This PR adds comprehensive tests to ensure correct validation behavior.

## Files
- `react-sdk/src/util/validate-component-name.ts`  
- `react-sdk/src/util/validate-component-name.test.ts` (added)

## Changes
Added `validate-component-name.test.ts` covering:  
- **Valid names**: letters only, letters + numbers + underscore, letters + numbers + hyphen, mixed allowed characters, single underscore, single hyphen  
- **Invalid names**: names with spaces, names with special characters (`@`, `!$`), empty string  
- **Error messages**: ensures the thrown errors include the component type, invalid name, and a clear explanation of allowed characters

## Verification
- [x] Tests added to cover new functionality
- [x] `npm run check-types` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
