### PR TITLE
docs: add export/import pattern guidelines to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,8 @@ eval "$(mise activate)"   # Interactive shells only
 
 - Prefer named exports; allow multiple exports when they belong together (e.g., component + related types).
 - Avoid default exports.
-- Don't create generic index.ts barrels for internal modules; import directly from concrete files.
+- Don't create `index.ts` barrels for internal modules; import directly from source files. Exception: package entry points (e.g., `packages/core/src/index.ts`) are fine.
+- Don't re-export symbols for backwards compatibility. When moving a symbol, update all consumers to import from the new location.
 
 ## 3. TypeScript Standards
 
@@ -195,6 +196,13 @@ eval "$(mise activate)"   # Interactive shells only
 - **Avoid `reduce()`** - it's often confusing and can usually be replaced with simpler patterns.
   - Exception: when the mental model genuinely requires accumulation (e.g., summing numbers).
 - **Avoid complex method chaining** - break it into named intermediate steps for clarity.
+
+### Avoid RegEx When Possible
+
+- **Prefer string methods**: `str.includes()`, `str.startsWith()`, `str.split()`, and `str.replace()` are easier to read and maintain.
+- **Avoid global flag (`/g`)**: Creates stateful regex objects where `lastIndex` persists between calls, causing subtle bugs.
+- **Avoid multiline flag (`/m`)**: Platform differences in line endings (`\n` vs `\r\n`) cause inconsistent behavior.
+- **If regex is unavoidable**: Keep it simple, add a comment explaining the pattern, and test edge cases thoroughly.
 
 ## 4. Frontend Development (React + Next.js)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,18 +10,6 @@ Guidelines for Claude Code (claude.ai/code) when touching this repo.
 2. Use the workspace scripts it lists (see below for key commands).
 3. Defer to it whenever instructions collide; if something's still unclear, ask the user.
 
-## Avoid RegEx When Possible
-
-- **Prefer string methods**: Simple patterns like `str.includes()`, `str.startsWith()`, `str.split()`, and `str.replace()` are easier to read and maintain.
-- **Avoid global flag (`/g`)**: Creates stateful regex objects where `lastIndex` persists between calls, causing subtle bugs.
-- **Avoid multiline flag (`/m`)**: Line ending differences across platforms (`\n` vs `\r\n`) cause inconsistent behavior; multiline patterns are harder to reason about.
-- **If regex is unavoidable**: Keep it simple, add a comment explaining the pattern, and test edge cases thoroughly.
-
-## Export and Import Patterns
-
-- **No internal barrel files**: Don't create `index.ts` files that just re-export symbols from nearby files. Import directly from the source file. Exception: package entry points (e.g., `packages/core/src/index.ts`) are fine.
-- **No backwards-compatibility re-exports**: When moving a symbol from one file to another, update all consumers to import from the new location. Don't leave behind re-exports "for convenience."
-
 ## Key Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- Moves regex avoidance guidelines from CLAUDE.md to AGENTS.md (new "Avoid RegEx When Possible" subsection in TypeScript Standards)
- Expands the existing "Exports" subsection in AGENTS.md with:
  - Clarified barrel file guidance (no internal `index.ts` barrels, package entry points are fine)
  - No backwards-compatibility re-exports when moving symbols

## Test plan
- [ ] Review the updated sections in AGENTS.md for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)