### PR TITLE
fix(backend): use OpenAI API key from env for suggestions

### DIFF
--- a/packages/backend/src/services/suggestion/suggestion.service.ts
+++ b/packages/backend/src/services/suggestion/suggestion.service.ts
@@ -56,12 +56,19 @@ export async function generateSuggestions(
   }
 
   // Create a suggestion-specific LLMClient which ensures faster response times by using a lighter model for suggestions
+  // Use the OpenAI API key from environment variable (suggestions always use OpenAI)
+  const openaiApiKey =
+    process.env.OPENAI_API_KEY ?? process.env.FALLBACK_OPENAI_API_KEY;
+  if (!openaiApiKey) {
+    throw new Error(
+      "OpenAI API key required for suggestions. Set OPENAI_API_KEY or FALLBACK_OPENAI_API_KEY.",
+    );
+  }
   const client = llmClient as unknown as {
-    apiKey: string | undefined;
     userId: string;
   };
   const suggestionLlmClient = new AISdkClient(
-    client.apiKey,
+    openaiApiKey,
     SUGGESTION_MODEL,
     SUGGESTION_PROVIDER,
     llmClient.chainId,


### PR DESCRIPTION
## Summary
- Suggestions always use OpenAI (gpt-4.1-mini) but were incorrectly using the user's configured provider API key
- This caused suggestions to silently fail for users using non-OpenAI providers (Anthropic, Groq, Gemini, etc.)
- Now reads `OPENAI_API_KEY` or `FALLBACK_OPENAI_API_KEY` from environment and fails explicitly if neither is set

## Test plan
- [x] Test suggestions work with OpenAI provider configured
- [x] Test suggestions work with non-OpenAI provider configured (e.g., Anthropic)
- [x] Verify error is thrown if neither `OPENAI_API_KEY` nor `FALLBACK_OPENAI_API_KEY` is set