### PR TITLE
fix: Allow multiple messages in response stream

### DIFF
--- a/react-sdk/src/providers/tambo-thread-provider.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.tsx
@@ -945,6 +945,9 @@ export const TamboThreadProvider: React.FC<
               }
             }
 
+            // Capture previous message ID before updating finalMessage
+            const previousMessageId = finalMessage.id;
+
             if (chunk.responseMessageDto.component?.componentName) {
               finalMessage = renderComponentIntoMessage(
                 chunk.responseMessageDto,
@@ -956,7 +959,7 @@ export const TamboThreadProvider: React.FC<
 
             // if we start getting a new message mid-stream, put the previous one on screen
             const isNewMessage =
-              chunk.responseMessageDto.id !== finalMessage.id;
+              chunk.responseMessageDto.id !== previousMessageId;
             if (isNewMessage) {
               await addThreadMessage(finalMessage, false);
             } else {


### PR DESCRIPTION
Fixes a bug where a response stream containing multiple messages (because of a server-side tool invocation) would not render messages after the first.
Fix is to check each chunk to see if we have a new message id, and add it to the local thread.