### PR TITLE
fix(cli): allow git clone in non-interactive mode

### DIFF
--- a/cli/src/commands/create-app.ts
+++ b/cli/src/commands/create-app.ts
@@ -213,7 +213,7 @@ export async function handleCreateApp(
         `git clone --depth 1 ${selectedTemplate.repository} ${
           appName === "." ? "." : appName
         }`,
-        { stdio: "ignore" },
+        { stdio: "ignore", allowNonInteractive: true },
       );
       cloneSpinner.succeed(
         `${selectedTemplate.name} template downloaded successfully`,


### PR DESCRIPTION
## Summary
- Fixes `tambo create-app` failing silently in non-interactive environments (CI/CD, scripts, automated testing)

## Problem
The CLI's `execSync` wrapper blocks commands in non-TTY environments unless `allowNonInteractive: true` is passed. The git clone call was missing this flag, causing it to throw a `NonInteractiveError` that got caught and re-thrown as a generic "Failed to clone template repository" error.

## Solution
Add `allowNonInteractive: true` to the git clone `execSync` call since the user has already explicitly provided the `--template` flag.

## Test plan
- [x] Tested `tambo create-app test-app --template=standard` in non-interactive shell
- [x] Verified app is created with all files and dependencies installed