### PR TITLE
refactor(backend): remove unused chat_history logic from objectTemplate

### DIFF
--- a/packages/backend/src/util/template.test.ts
+++ b/packages/backend/src/util/template.test.ts
@@ -66,6 +66,25 @@ describe("objectTemplate - templates for nested objects", () => {
     expect(out).toEqual(["Hello user", "age is 1"]);
   });
 
+  it("formats array of objects correctly (e.g. ThreadMessage[])", () => {
+    const t = objectTemplate([
+      { role: "user", content: "Hello {name}" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+    const out = formatTemplate(t, { name: "Alice" });
+    expect(out).toEqual([
+      { role: "user", content: "Hello Alice" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+  });
+
+  it("treats previous chat_history special objects as normal objects", () => {
+    const t = objectTemplate([{ role: "chat_history", content: "{val}" }]);
+    const out = formatTemplate(t, { val: "expanded" });
+    // Should be treated as normal object, not expanded into array
+    expect(out).toEqual([{ role: "chat_history", content: "expanded" }]);
+  });
+
   it("throws if input is not object or string", () => {
     expect(() => objectTemplate(5 as unknown as object)).toThrow(
       "Can only generate object templates for objects or strings",

--- a/packages/backend/src/util/template.ts
+++ b/packages/backend/src/util/template.ts
@@ -11,8 +11,6 @@ const templateExpressionVarName = /{([a-zA-Z0-9_[\].]+)}/g;
  * to avoid substitutions, then replace it again with `{foo}` */
 const unescapeVariableExpression = /\\{([a-zA-Z0-9_[\].]+)\\}/g;
 // We have a special keyword that we use to expand out an array for a chat_history argument
-const CHAT_HISTORY = "chat_history";
-const ROLE_KEY = "role";
 
 type primitive = string | number | boolean | null | undefined;
 
@@ -180,12 +178,6 @@ export function objectTemplate<T>(objs: T): ObjectTemplate<T> {
     }
     if (Array.isArray(objs)) {
       return objs.flatMap((item) => {
-        // We have special handling for chat history, as we need to expand out
-        // the given variable
-        if (isChatHistory(item)) {
-          return handleChatHistory(item, parameters);
-        }
-
         return objectTemplate(item)[formatProp](parameters);
       }) as T;
     }
@@ -238,68 +230,4 @@ function objTemplateVariables(objs: unknown): readonly string[] {
       return objTemplateVariables(value);
     },
   );
-}
-
-/**
- * Defines the expected structure for a chat history placeholder.
- */
-interface ChatHistoryItem {
-  [ROLE_KEY]: typeof CHAT_HISTORY;
-  [key: string]: TemplateValue;
-}
-
-/**
- * Determines if this has a Chat History defined object.
- * It follows an expected/exact setup where the role is chat_history and the
- * content is just the chat_history variable.
- * @param obj
- * @returns true if it follows the chat history structure
- */
-function isChatHistory(objs: unknown): objs is ChatHistoryItem {
-  if (typeof objs !== "object" || objs === null || Array.isArray(objs)) {
-    return false;
-  }
-  const record = objs as Record<string, unknown>;
-  return record[ROLE_KEY] === CHAT_HISTORY;
-}
-
-function handleChatHistory(
-  item: ChatHistoryItem,
-  params: TemplateParameters,
-): ThreadMessage[] {
-  const varsInChatHistory = objTemplateVariables(item);
-
-  if (varsInChatHistory.length === 0) {
-    throw new Error(
-      `Expected to find a variable in the content of the chat_history role, but none was found`,
-    );
-  }
-
-  const allHistory = varsInChatHistory.flatMap((varName) => {
-    const value = params[varName];
-    if (value === undefined) {
-      throw new Error(
-        `No value was found in 'templateParams' for the variable '${varName}'. Ensure you have a corresponding entry in 'templateParams'.`,
-      );
-    }
-
-    if (!Array.isArray(value)) {
-      throw new Error(
-        `Expected value for variable '${varName}' to be an array of ThreadMessage, but got ${typeof value}`,
-      );
-    }
-
-    // Validate each element matches ThreadMessage structure
-    for (const msg of value) {
-      if (typeof msg !== "object" || msg === null || !("role" in msg)) {
-        throw new Error(
-          `Expected each element in '${varName}' to be a ThreadMessage, but found an invalid object.`,
-        );
-      }
-    }
-
-    return value as ThreadMessage[];
-  });
-
-  return allHistory;
 }


### PR DESCRIPTION
I checked the codebase and confirmed we are not using `{ role: "chat_history" }` placeholder logic anywhere in `objectTemplate`. Since we can pass `ThreadMessage[]` directly now, this special handling was just dead code.

I went ahead and removed the `chat_history` branch and the helper functions. I also added a couple of tests in `packages/backend/src/util/template.test.ts` just to make sure standard message arrays still format correctly without it.

Closes #1773

### PR Checklist

- [x] Conventional Commit title
- [x] Linked issue or context
- [x] Tests added/updated
- [ ] Docs updated (if user-facing)
- [ ] Screen recording attached (if visual change)
- [x] All checks pass locally
