### PR TITLE
chore(web): Comment out optional env vars in .env.example to prevent validation errors

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -13,8 +13,8 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres # Default l
 
 ## OpenAI
 # Ask for a key from Magan if you need one!
-EXTRACTION_OPENAI_API_KEY= # Get from OpenAI. Used in component extraction service.
-OPENAIAPI_KEY=             # Get from OpenAI. Used in component generation and hydration.
+# EXTRACTION_OPENAI_API_KEY= # Get from OpenAI. Used in component extraction service.
+# OPENAIAPI_KEY=             # Get from OpenAI. Used in component generation and hydration.
 
 ## Provider Keys
 PROVIDER_KEY_SECRET=API_KEY_SECRET_FOR_LOCAL_DEVELOPMENT_ONLY
@@ -23,13 +23,13 @@ API_KEY_SECRET=API_KEY_SECRET_FOR_LOCAL_DEVELOPMENT_ONLY
 PORT=8261 # Default local API port
 
 ## Email
-RESEND_API_KEY=
+# RESEND_API_KEY=
 
 ## Free Tier API Keys
-FALLBACK_OPENAI_API_KEY=  # use your dev key here
+# FALLBACK_OPENAI_API_KEY=  # use your dev key here
 
 # Sentry
-SENTRY_DSN=
+# SENTRY_DSN=
 
 ## S3 Storage (file uploads)
 # Local Development: Run `docker compose --env-file docker.env up minio -d`

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -18,35 +18,35 @@ API_KEY_SECRET=API_KEY_SECRET_FOR_LOCAL_DEVELOPMENT_ONLY
 # Get these from Magan
 # The bot token must include the `conversations.connect:write` scope
 # so the app can set `external_limited: false` when inviting guests.
-SLACK_OAUTH_TOKEN=
-SLACK_TEAM_ID=
-INTERNAL_SLACK_USER_ID=
-NEXT_PUBLIC_SLACK_CLIENT_ID=
-SLACK_CLIENT_SECRET=
+# SLACK_OAUTH_TOKEN=
+# SLACK_TEAM_ID=
+# INTERNAL_SLACK_USER_ID=
+# NEXT_PUBLIC_SLACK_CLIENT_ID=
+# SLACK_CLIENT_SECRET=
 
 ## Email Configuration
 #get from Magan
-RESEND_API_KEY=
-RESEND_AUDIENCE_ID=
+# RESEND_API_KEY=
+# RESEND_AUDIENCE_ID=
 DISALLOWED_EMAIL_DOMAINS=gmail.com,yahoo.com,hotmail.com,outlook.com,aol.com,icloud.com,protonmail.com,zoho.com,yandex.com,fastmail.com,gmx.com,mail.com,tutanota.com,hey.com,inbox.com,mail.ru,outlook.com,protonmail.com,tutanota.com,zoho.com,gmx.com,mail.com,mail.ru,yandex.com,fastmail.com,hey.com,inbox.com
 # When self-hosting, you can restrict logins to a single verified email domain.
 # If set (e.g. "foo.com") only users with verified emails ending in *@foo.com
 # will be able to sign in. Leave unset to allow any verified domain.
-ALLOWED_LOGIN_DOMAIN=
+# ALLOWED_LOGIN_DOMAIN=
 
 ## PostHog Configuration
 #get from Magan
-NEXT_PUBLIC_POSTHOG_KEY=
-NEXT_PUBLIC_POSTHOG_HOST=
+# NEXT_PUBLIC_POSTHOG_KEY=
+# NEXT_PUBLIC_POSTHOG_HOST=
 
 ## Hydra Smoketest Setup
 NEXT_PUBLIC_TAMBO_API_URL=http://localhost:8261
 # Get this after you setup your local environment
-NEXT_PUBLIC_TAMBO_API_KEY=
+# NEXT_PUBLIC_TAMBO_API_KEY=
 
 ## Weather API Key
 # Go here: https://www.weatherapi.com/
-WEATHER_API_KEY=
+# WEATHER_API_KEY=
 
 ## Allow Local MCP Servers
 # Set to true if you want to allow local MCP servers
@@ -54,7 +54,7 @@ ALLOW_LOCAL_MCP_SERVERS=false
 
 
 ## Github
-GITHUB_TOKEN=
+# GITHUB_TOKEN=
 
 ## Nextauth login stuff
 # Run `openssl rand -hex 8` to generate a random secret
@@ -64,18 +64,18 @@ NEXTAUTH_URL=http://localhost:8260
 # e.g. AUTH_REDIRECT_FROM_HOST=tambo.co with NEXT_PUBLIC_APP_URL=https://console.tambo.co
 # will redirect tambo.co/login -> console.tambo.co/login
 # If no port is specified, also matches :443 and :80 variants to handle Host headers with ports
-AUTH_REDIRECT_FROM_HOST=
+# AUTH_REDIRECT_FROM_HOST=
 # Get these from a developer. You must use the "developer" clients here, not
 # "production" clients, so that they support localhost-based redirects
-GITHUB_CLIENT_ID=...
-GITHUB_CLIENT_SECRET=...
-GOOGLE_CLIENT_ID=...
-GOOGLE_CLIENT_SECRET=...
+# GITHUB_CLIENT_ID=...
+# GITHUB_CLIENT_SECRET=...
+# GOOGLE_CLIENT_ID=...
+# GOOGLE_CLIENT_SECRET=...
 
 # Sentry configuration
-NEXT_PUBLIC_SENTRY_DSN=
-NEXT_PUBLIC_SENTRY_ORG=
-NEXT_PUBLIC_SENTRY_PROJECT=
+# NEXT_PUBLIC_SENTRY_DSN=
+# NEXT_PUBLIC_SENTRY_ORG=
+# NEXT_PUBLIC_SENTRY_PROJECT=
 # The SENTRY_AUTH_TOKEN variable is picked up by the Sentry Build Plugin.
 # It's used for authentication when uploading source maps.
-SENTRY_AUTH_TOKEN=
+# SENTRY_AUTH_TOKEN=


### PR DESCRIPTION
This PR aims to fix #1819 

changes made:
 commented out env variables with no default value in `tambo/apps/web/.env.example` and `apps/api/.env.example`