### PR TITLE
fix(web): prevent optional env vars from failing validation when empty

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -58,7 +58,7 @@ GITHUB_TOKEN=
 
 ## Nextauth login stuff
 # Run `openssl rand -hex 8` to generate a random secret
-NEXTAUTH_SECRET=YOUR_NEXTAUTH_SECRET_HERE 
+NEXTAUTH_SECRET=YOUR_NEXTAUTH_SECRET_HERE
 NEXTAUTH_URL=http://localhost:8260
 # When set, redirects /login and /api/auth/* from this host to NEXT_PUBLIC_APP_URL
 # e.g. AUTH_REDIRECT_FROM_HOST=tambo.co with NEXT_PUBLIC_APP_URL=https://console.tambo.co

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -45,11 +45,14 @@ export const env = createEnv({
     EMAIL_FROM_DEFAULT: z.string().transform(allowEmptyString).optional(),
 
     // Whitelabeling (server-side copies; optional so can be omitted)
-    TAMBO_WHITELABEL_ORG_NAME: z.string().min(1).optional().or(z.literal("")),
+    TAMBO_WHITELABEL_ORG_NAME: z
+      .string()
+      .transform(allowEmptyString)
+      .optional(),
     TAMBO_WHITELABEL_ORG_LOGO: z.string().url().optional().or(z.literal("")),
     // Restrict logins to a specific verified email domain when self-hosting.
     // When unset, any verified email is allowed.
-    ALLOWED_LOGIN_DOMAIN: z.string().optional().or(z.literal("")),
+    ALLOWED_LOGIN_DOMAIN: z.string().transform(allowEmptyString).optional(),
     // When set, redirects auth routes from this host to NEXT_PUBLIC_APP_URL.
     // Used to redirect tambo.co/login -> console.tambo.co/login
     AUTH_REDIRECT_FROM_HOST: z.string().optional(),
@@ -76,9 +79,8 @@ export const env = createEnv({
     // Whitelabeling vars
     NEXT_PUBLIC_TAMBO_WHITELABEL_ORG_NAME: z
       .string()
-      .min(1)
-      .optional()
-      .or(z.literal("")),
+      .transform(allowEmptyString)
+      .optional(),
     NEXT_PUBLIC_TAMBO_WHITELABEL_ORG_LOGO: z
       .string()
       .url()


### PR DESCRIPTION
## Proposed Changes

- Fixes #1819 

## Problem

First-time developers copying `.env.example` to `.env.local` encounter Zod validation errors 

This occurs because some environment variables are marked as **optional** while still using `.min(1)`:

- `.optional()` allows the value to be `undefined`
- `.min(1)` explicitly disallows empty strings (`""`)

When a variable exists in `.env` but is left empty (`VAR=`), it is parsed as an empty string rather than `undefined`. As a result, validation fails even though the variable is intended to be optional.

Since optional environment variables in `.env.example` are commonly left empty, this breaks local setup for new contributors.

---

## Solution

Empty strings are transformed to `undefined` for optional environment variables before validation, preserving strict validation for non-empty values.

### Before
```ts
INTERNAL_SLACK_USER_ID: z.string().min(1).optional(),
SLACK_OAUTH_TOKEN: z.string().min(1).optional(),

### After
```ts
INTERNAL_SLACK_USER_ID: z.string().transform(allowEmptyString).optional(),
SLACK_OAUTH_TOKEN: z.string().transform(allowEmptyString).optional(),


