### PR TITLE
fix: add back AdvanceThreadDto so it is codegened

### DIFF
--- a/apps/api/src/threads/threads.controller.test.ts
+++ b/apps/api/src/threads/threads.controller.test.ts
@@ -255,9 +255,9 @@ describe("ThreadsController - Stream Routes Error Propagation", () => {
       const request = { url: `/threads/${threadId}/advance` } as Request;
 
       // Act & Assert - The deprecated endpoint should throw EndpointDeprecatedException
-      await expect(controller.advanceThread(threadId, request)).rejects.toThrow(
-        EndpointDeprecatedException,
-      );
+      await expect(
+        controller.advanceThread(threadId, request, {} as any),
+      ).rejects.toThrow(EndpointDeprecatedException);
 
       // Verify the service was never called
       expect(threadsService.advanceThread).not.toHaveBeenCalled();
@@ -270,7 +270,7 @@ describe("ThreadsController - Stream Routes Error Propagation", () => {
 
       // Act & Assert
       const error = await controller
-        .advanceThread(threadId, request)
+        .advanceThread(threadId, request, {} as any)
         .catch((caughtError) => caughtError);
 
       expectEndpointDeprecatedProblem(error, {

--- a/apps/api/src/threads/threads.controller.ts
+++ b/apps/api/src/threads/threads.controller.ts
@@ -398,6 +398,7 @@ export class ThreadsController {
   async advanceThread(
     @Param("id") _threadId: string,
     @Req() request: Request,
+    @Body() _advanceRequestDto: AdvanceThreadDto,
   ): Promise<AdvanceThreadResponseDto> {
     throw new EndpointDeprecatedException({
       detail:


### PR DESCRIPTION
this kinda broke the stainless build when I removed it in #1648 