### PR TITLE
refactor(api): type-narrow StorageConfigService.hasStorageConfig #1770

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -67,6 +67,7 @@
     "resend": "^6.7.0",
     "rxjs": "7.8.1",
     "superjson": "^2.2.6",
+    "ts-essentials": "^10.1.1",
     "uuid": "^13.0.0"
   },
   "devDependencies": {

--- a/apps/api/src/common/services/storage-config.service.test.ts
+++ b/apps/api/src/common/services/storage-config.service.test.ts
@@ -1,0 +1,118 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+import * as backend from "@tambo-ai-cloud/backend";
+import { StorageConfigService } from "./storage-config.service";
+
+jest.mock("@tambo-ai-cloud/backend");
+
+describe("StorageConfigService", () => {
+  let isS3ConfiguredMock: jest.SpyInstance;
+  let createS3ClientMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isS3ConfiguredMock = jest
+      .spyOn(backend, "isS3Configured")
+      .mockReturnValue(false);
+    createS3ClientMock = jest
+      .spyOn(backend, "createS3Client")
+      .mockReturnValue({} as S3Client);
+  });
+
+  async function createService(
+    configValues: Record<string, string | undefined>,
+  ): Promise<StorageConfigService> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StorageConfigService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest
+              .fn()
+              .mockImplementation((key: string) => configValues[key]),
+          },
+        },
+      ],
+    }).compile();
+
+    return module.get<StorageConfigService>(StorageConfigService);
+  }
+
+  describe("bucket property", () => {
+    it("should trim whitespace from S3_BUCKET", async () => {
+      const service = await createService({ S3_BUCKET: "  my-bucket  " });
+      expect(service.bucket).toBe("my-bucket");
+    });
+
+    it("should be empty string when S3_BUCKET is whitespace only and hasStorageConfig returns false", async () => {
+      const service = await createService({ S3_BUCKET: "   " });
+      expect(service.bucket).toBe("");
+      expect(service.hasStorageConfig()).toBe(false);
+    });
+
+    it("should be empty string when S3_BUCKET is empty string and hasStorageConfig returns false", async () => {
+      const service = await createService({ S3_BUCKET: "" });
+      expect(service.bucket).toBe("");
+      expect(service.hasStorageConfig()).toBe(false);
+    });
+
+    it("should be empty string when S3_BUCKET is undefined and hasStorageConfig returns false", async () => {
+      const service = await createService({});
+      expect(service.bucket).toBe("");
+      expect(service.hasStorageConfig()).toBe(false);
+    });
+  });
+
+  describe("signingSecret property", () => {
+    it("should trim whitespace from API_KEY_SECRET", async () => {
+      const service = await createService({ API_KEY_SECRET: "  secret  " });
+      expect(service.signingSecret).toBe("secret");
+    });
+
+    it("should be empty string when API_KEY_SECRET is whitespace only and hasStorageConfig returns false", async () => {
+      const service = await createService({ API_KEY_SECRET: "   " });
+      expect(service.signingSecret).toBe("");
+      expect(service.hasStorageConfig()).toBe(false);
+    });
+  });
+
+  describe("s3Client configuration", () => {
+    it("should create s3Client and hasStorageConfig true when fully configured", async () => {
+      const mockS3Client = { custom: "client" } as any;
+      createS3ClientMock.mockReturnValue(mockS3Client);
+      isS3ConfiguredMock.mockReturnValue(true);
+
+      const service = await createService({
+        S3_ENDPOINT: "https://s3.example.com",
+        S3_REGION: "us-west-2",
+        S3_ACCESS_KEY_ID: "test-key-id",
+        S3_SECRET_ACCESS_KEY: "test-secret-key",
+        S3_BUCKET: "test-bucket",
+        API_KEY_SECRET: "test-secret",
+      });
+
+      expect(service.s3Client).toBe(mockS3Client);
+      expect(service.hasStorageConfig()).toBe(true);
+      expect(createS3ClientMock).toHaveBeenCalledWith({
+        endpoint: "https://s3.example.com",
+        region: "us-west-2",
+        accessKeyId: "test-key-id",
+        secretAccessKey: "test-secret-key",
+      });
+    });
+
+    it("should have undefined s3Client and hasStorageConfig false when S3 is not configured", async () => {
+      isS3ConfiguredMock.mockReturnValue(false);
+
+      const service = await createService({
+        S3_ENDPOINT: "https://s3.example.com",
+      });
+
+      expect(service.s3Client).toBeUndefined();
+      expect(service.hasStorageConfig()).toBe(false);
+      expect(createS3ClientMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/common/services/storage-config.service.ts
+++ b/apps/api/src/common/services/storage-config.service.ts
@@ -1,8 +1,8 @@
+import { S3Client } from "@aws-sdk/client-s3";
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { S3Client } from "@aws-sdk/client-s3";
 import { createS3Client, isS3Configured } from "@tambo-ai-cloud/backend";
-
+import { Merge } from "ts-essentials";
 /**
  * Centralized S3 storage configuration service.
  * Provides a single source of truth for S3 client initialization
@@ -22,9 +22,11 @@ export class StorageConfigService {
       secretAccessKey:
         this.configService.get<string>("S3_SECRET_ACCESS_KEY") ?? "",
     };
+    const bucket = this.configService.get<string>("S3_BUCKET") ?? "";
+    this.bucket = bucket.trim();
 
-    this.bucket = this.configService.get<string>("S3_BUCKET") ?? "user-files";
-    this.signingSecret = this.configService.get<string>("API_KEY_SECRET") ?? "";
+    const secret = this.configService.get<string>("API_KEY_SECRET");
+    this.signingSecret = secret?.trim() ?? "";
 
     if (isS3Configured(s3Config)) {
       this.s3Client = createS3Client(s3Config);
@@ -34,8 +36,16 @@ export class StorageConfigService {
   /**
    * Check if storage is fully configured for attachment operations.
    * Requires both S3 client and signing secret to be available.
+   * @returns true if storage is configured with S3 client, non-empty bucket, and signing secret
    */
-  hasStorageConfig(): boolean {
-    return this.s3Client !== undefined && this.signingSecret.length > 0;
+  hasStorageConfig(): this is Merge<
+    StorageConfigService,
+    { s3Client: S3Client }
+  > {
+    return (
+      this.s3Client !== undefined &&
+      this.bucket.length > 0 &&
+      this.signingSecret.length > 0
+    );
   }
 }

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -1363,7 +1363,7 @@ export class ThreadsService {
         const resourceFetchers = createResourceFetcherMap(mcpClients);
         if (this.storageConfig.hasStorageConfig()) {
           resourceFetchers["attachment"] = createAttachmentFetcher(
-            this.storageConfig.s3Client!,
+            this.storageConfig.s3Client,
             this.storageConfig.bucket,
             projectId,
             this.storageConfig.signingSecret,
@@ -1445,7 +1445,7 @@ export class ThreadsService {
       const resourceFetchers = createResourceFetcherMap(mcpClients);
       if (this.storageConfig.hasStorageConfig()) {
         resourceFetchers["attachment"] = createAttachmentFetcher(
-          this.storageConfig.s3Client!,
+          this.storageConfig.s3Client,
           this.storageConfig.bucket,
           projectId,
           this.storageConfig.signingSecret,

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "resend": "^6.7.0",
         "rxjs": "7.8.1",
         "superjson": "^2.2.6",
+        "ts-essentials": "^10.1.1",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
@@ -2709,9 +2710,9 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.28.tgz",
-      "integrity": "sha512-YD2p+3rBiuw6z6PNWCNOFpatIBGreuxbmhy92icxIHUtl8uf8G/AYPUcqbibsF51NRP49NZQwgghOCSL1zAmJg==",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.29.tgz",
+      "integrity": "sha512-1b7E9F/B5gex/1uCkhs+sGIbH0KsZOItHnNz3iY5ir+nc4ZUA6WOU5Cu2w1USlc+3UVbhf+H+iNLlxVjLe4VvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.1",
@@ -22564,12 +22565,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.122",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.122.tgz",
-      "integrity": "sha512-tbN8j7OQPuML9RQs7nN3l4WQnesZ7g255xgefIAaM7z6RT8eidXPD5/fflhHLIipq8X9ZgTc2pMqXXp0S6O9Qw==",
+      "version": "5.0.123",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.123.tgz",
+      "integrity": "sha512-V3Imb0tg0pHCa6a/VsoW/FZpT07mwUw/4Hj6nexJC1Nvf1eyKQJyaYVkl+YTLnA8cKQSUkoarKhXWbFy4CSgjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.28",
+        "@ai-sdk/gateway": "2.0.29",
         "@ai-sdk/provider": "2.0.1",
         "@ai-sdk/provider-utils": "3.0.20",
         "@opentelemetry/api": "1.9.0"
@@ -42436,6 +42437,20 @@
         "node": ">=6.10"
       }
     },
+    "node_modules/ts-essentials": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.1.1.tgz",
+      "integrity": "sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -45170,7 +45185,7 @@
         "@mastra/client-js": "^0.15.2",
         "@mastra/core": "^0.20.2",
         "@tambo-ai-cloud/core": "*",
-        "ai": "^5.0.122",
+        "ai": "^5.0.123",
         "ajv": "^8.17.1",
         "fast-json-patch": "^3.1.1",
         "gpt-tokenizer": "^3.2.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -41,7 +41,7 @@
     "@mastra/client-js": "^0.15.2",
     "@mastra/core": "^0.20.2",
     "@tambo-ai-cloud/core": "*",
-    "ai": "^5.0.122",
+    "ai": "^5.0.123",
     "ajv": "^8.17.1",
     "fast-json-patch": "^3.1.1",
     "gpt-tokenizer": "^3.2.0",


### PR DESCRIPTION
fixes #1770

> **Note**: This PR replaces #1784, which was closed to provide a clean commit history on the correct branch.

## Summary

Adds a TypeScript type predicate to `StorageConfigService.hasStorageConfig()` using `Merge` from `ts-essentials` to narrow `s3Client` from `S3Client | undefined` to `S3Client`. This ensures TypeScript understands when storage is fully configured and safe to use.

## Changes

-  `hasStorageConfig()` returns `this is Merge<StorageConfigService, { s3Client: S3Client }>` to narrow the type guard
-  Trims whitespace from `bucket` and `signingSecret` values
-  Empty bucket values fall back to `'user-files'`
- `hasStorageConfig()` checks `s3Client`, `bucket`, and `signingSecret` presence
- Added `ts-essentials` to `apps/api` for type utilities(for Merge utility)

## Test Coverage
- **StorageConfigService**: Bucket/secret trimming, fallback behavior, and `hasStorageConfig()` validation
- **ThreadsService**: Conditional `resourceFetchers.attachment` based on storage config availability
