### PR TITLE
fix(api): expose discriminated unions in OpenAPI schema for v1 DTOs

### DIFF
--- a/apps/api/src/v1/dto/content.dto.ts
+++ b/apps/api/src/v1/dto/content.dto.ts
@@ -1,4 +1,9 @@
-import { ApiProperty, ApiSchema } from "@nestjs/swagger";
+import {
+  ApiProperty,
+  ApiSchema,
+  ApiExtraModels,
+  getSchemaPath,
+} from "@nestjs/swagger";
 import {
   ValidateNested,
   IsArray,
@@ -107,6 +112,7 @@ export class V1ToolUseContentDto {
  * Tool result content block - represents the result of a tool call.
  */
 @ApiSchema({ name: "ToolResultContent" })
+@ApiExtraModels(V1TextContentDto, V1ResourceContentDto)
 export class V1ToolResultContentDto {
   @ApiProperty({
     description: "Content block type identifier",
@@ -126,7 +132,20 @@ export class V1ToolResultContentDto {
 
   @ApiProperty({
     description: "Result content (text or resource blocks)",
-    type: [Object],
+    type: "array",
+    items: {
+      oneOf: [
+        { $ref: getSchemaPath(V1TextContentDto) },
+        { $ref: getSchemaPath(V1ResourceContentDto) },
+      ],
+      discriminator: {
+        propertyName: "type",
+        mapping: {
+          text: getSchemaPath(V1TextContentDto),
+          resource: getSchemaPath(V1ResourceContentDto),
+        },
+      },
+    },
   })
   @IsArray()
   @ValidateNested({ each: true })


### PR DESCRIPTION
## Summary

- Fixed OpenAPI schema generation for discriminated union content blocks in v1 API DTOs
- Added explicit `oneOf` + `discriminator` metadata to `@ApiProperty` decorators
- Added `@ApiExtraModels` to ensure Swagger knows about all content type DTOs
- Applied fix to all three discriminated unions in v1 DTOs:
  - `V1MessageDto.content` (all 5 content types)
  - `V1InputMessageDto.content` (3 input-only types)
  - `V1ToolResultContentDto.content` (2 result types)

## Problem

NestJS Swagger cannot introspect `class-transformer` discriminators, causing discriminated union properties to appear as generic `{ type: "object" }` in the OpenAPI schema. This masked the actual content block types available to API clients.

## Solution

Used explicit OpenAPI schema definitions with `oneOf`, `discriminator.propertyName`, and `discriminator.mapping` to properly document the discriminated union structure. Runtime validation via `@Type()` discriminator remains unchanged.

## Test plan

- [x] Type checking passes (`npm run check-types -w apps/api`)
- [x] All v1 tests pass (177 tests)
- [x] Linting passes with no errors
- [ ] Verify OpenAPI schema at `/api` shows proper discriminated unions for content blocks
- [ ] Generate client SDK and verify discriminated union types are properly typed

🤖 Generated with [Claude Code](https://claude.com/claude-code)