### PR TITLE
feat(api): add Swagger documentation for SSE event streams

### DIFF
--- a/apps/api/src/v1/dto/event.dto.ts
+++ b/apps/api/src/v1/dto/event.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiSchema } from "@nestjs/swagger";
+import { IsString, IsOptional, IsNumber } from "class-validator";
+
+/**
+ * Base AG-UI event structure.
+ *
+ * All events streamed via SSE conform to this base structure.
+ * The `type` field discriminates between different event types.
+ *
+ * Matches the BaseEvent interface from @ag-ui/core.
+ *
+ * Consumers should cast to specific event types based on the `type` field:
+ * - RUN_STARTED, RUN_FINISHED, RUN_ERROR
+ * - TEXT_MESSAGE_START, TEXT_MESSAGE_CONTENT, TEXT_MESSAGE_END
+ * - TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END
+ * - And others from the AG-UI protocol
+ */
+@ApiSchema({ name: "BaseEvent" })
+export class V1BaseEventDto {
+  @ApiProperty({
+    description:
+      "Event type discriminator (e.g., RUN_STARTED, TEXT_MESSAGE_CONTENT, TOOL_CALL_START)",
+    example: "TEXT_MESSAGE_CONTENT",
+  })
+  @IsString()
+  type!: string;
+
+  @ApiProperty({
+    description: "Unix timestamp (milliseconds) when event was generated",
+    required: false,
+    example: 1705334400000,
+  })
+  @IsOptional()
+  @IsNumber()
+  timestamp?: number;
+
+  /**
+   * Additional event-specific fields.
+   * Structure varies by event type.
+   */
+  [key: string]: unknown;
+}

--- a/apps/api/src/v1/v1.controller.ts
+++ b/apps/api/src/v1/v1.controller.ts
@@ -44,6 +44,7 @@ import {
   V1ListThreadsQueryDto,
   V1ListThreadsResponseDto,
 } from "./dto/thread.dto";
+import { V1BaseEventDto } from "./dto/event.dto";
 import { V1Service } from "./v1.service";
 
 @ApiTags("v1")
@@ -245,7 +246,9 @@ export class V1Controller {
   @ApiProduces("text/event-stream")
   @ApiResponse({
     status: 200,
-    description: "SSE stream of AG-UI events",
+    description:
+      "SSE stream of AG-UI events. Each event is sent as 'data: <json>\\n\\n' where <json> is a BaseEvent object.",
+    type: V1BaseEventDto,
     headers: {
       "X-Thread-Id": {
         description: "The created thread ID",
@@ -360,7 +363,9 @@ export class V1Controller {
   @ApiProduces("text/event-stream")
   @ApiResponse({
     status: 200,
-    description: "SSE stream of AG-UI events",
+    description:
+      "SSE stream of AG-UI events. Each event is sent as 'data: <json>\\n\\n' where <json> is a BaseEvent object.",
+    type: V1BaseEventDto,
     headers: {
       "X-Run-Id": {
         description: "The created run ID",


### PR DESCRIPTION
## Summary

Adds typesafe Swagger/OpenAPI documentation for the Server-Sent Events (SSE) endpoints in the V1 API.

## Changes

- Created `apps/api/src/v1/dto/event.dto.ts` with `V1BaseEventDto` 
- Updated `POST /v1/threads/runs` endpoint to reference BaseEvent type
- Updated `POST /v1/threads/:threadId/runs` endpoint to reference BaseEvent type

## What This Achieves

✅ OpenAPI spec now documents the BaseEvent structure  
✅ Swagger UI shows the event schema with type discriminator and timestamp  
✅ Zero implementation changes - only documentation improvements  
✅ Consumers can see the base event shape and cast based on `type` field  

## Implementation Details

The `V1BaseEventDto` includes:
- `type: string` - Event type discriminator (RUN_STARTED, TEXT_MESSAGE_CONTENT, etc.)
- `timestamp?: number` - Optional Unix timestamp in milliseconds  
- Index signature for additional event-specific fields

This follows the BaseEvent structure from `@ag-ui/core` and allows consumers to cast to specific event types as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)