### PR TITLE
fix(ui): add missing exports to various component index files

### DIFF
--- a/packages/ui-registry/src/components/form/index.tsx
+++ b/packages/ui-registry/src/components/form/index.tsx
@@ -1,1 +1,7 @@
-export { FormComponent, type FormProps } from "./form";
+export {
+  FormComponent,
+  formFieldSchema,
+  formSchema,
+  type FormField,
+  type FormProps,
+} from "./form";

--- a/packages/ui-registry/src/components/graph/index.tsx
+++ b/packages/ui-registry/src/components/graph/index.tsx
@@ -1,1 +1,7 @@
-export { Graph, type GraphDataType, type GraphProps } from "./graph";
+export {
+  Graph,
+  graphDataSchema,
+  graphSchema,
+  type GraphDataType,
+  type GraphProps,
+} from "./graph";

--- a/packages/ui-registry/src/components/input-fields/index.tsx
+++ b/packages/ui-registry/src/components/input-fields/index.tsx
@@ -1,1 +1,7 @@
-export { InputFields, type InputFieldsProps } from "./input-fields";
+export {
+  fieldSchema,
+  InputFields,
+  inputFieldsSchema,
+  type Field,
+  type InputFieldsProps,
+} from "./input-fields";

--- a/packages/ui-registry/src/components/map/index.tsx
+++ b/packages/ui-registry/src/components/map/index.tsx
@@ -1,1 +1,9 @@
-export { Map, type MapProps } from "./map";
+export {
+  heatDataSchema,
+  Map,
+  mapSchema,
+  markerSchema,
+  type HeatData,
+  type MapProps,
+  type MarkerData,
+} from "./map";

--- a/packages/ui-registry/src/components/message-input/index.tsx
+++ b/packages/ui-registry/src/components/message-input/index.tsx
@@ -14,4 +14,8 @@ export {
   MessageInputToolbar,
   messageInputVariants,
 } from "./message-input";
-export type { PromptItem, ResourceItem } from "./text-editor";
+export type {
+  MessageInputTextareaProps,
+  ResourceProvider,
+} from "./message-input";
+export type { PromptItem, ResourceItem, TamboEditor } from "./text-editor";

--- a/packages/ui-registry/src/components/message-thread-full/index.tsx
+++ b/packages/ui-registry/src/components/message-thread-full/index.tsx
@@ -1,1 +1,2 @@
 export { MessageThreadFull } from "./message-thread-full";
+export { ThreadContainer, useThreadContainerContext } from "./thread-container";


### PR DESCRIPTION
A number of components that were migrated into the new ui-registry package miss some of the exports from that particular component folder. This PR updates those components missing their exports to include them.