### PR TITLE
fix(web): fix port note typo in docker.env.example Fixes #1879

### DIFF
--- a/docker.env.example
+++ b/docker.env.example
@@ -28,7 +28,7 @@ EXTRACTION_OPENAI_API_KEY=your-extraction-openai-api-key
 FALLBACK_OPENAI_API_KEY=your-fallback-openai-api-key
 
 # Tambo API Configuration
-# NOTE: Use port 8261 for Docker deployments, port 8261 for local development
+# NOTE: Use port 3211 for Docker deployments, port 8261 for local development
 NEXT_PUBLIC_TAMBO_API_URL=http://localhost:3211
 NEXT_PUBLIC_TAMBO_API_KEY=your-tambo-api-key
 NEXT_PUBLIC_TAMBO_DASH_KEY=your-tambo-dash-key


### PR DESCRIPTION
Fixes #1879 

Updates the docker.env.example NOTE to reflect the correct ports: Docker 3211, local dev 8261.