### PR TITLE
docs(cli): add agent-friendly CLI implementation plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,3 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 react-sdk/dist/**
-
-/test


### PR DESCRIPTION
## Summary

Plan for making the Tambo CLI agent-friendly - commands return helpful guidance instead of hanging in CI/non-TTY environments.

**Plan document:** `plans/agent-friendly-cli.md`

## Key Design Decisions

| Decision | Choice | Why |
|----------|--------|-----|
| Framework | **Keep meow** | Lowest risk; evaluate alternatives post-launch |
| Non-interactive | **Return guidance text** | Don't hang - tell agents/CI what to do |
| Exit codes | **0/1/2 contract** | Scripts need predictable behavior |
| Claude Code | **Plugin marketplace** | Standard distribution via Skills |

## What's in the Plan

### Part 1: Non-Interactive Mode

- TTY detection with precedence rules (CI, TERM=dumb, piped output)
- Commands return guidance text instead of hanging
- Exit codes: 0=success, 1=error, 2=user action required

### Part 2: Command Updates

Commands that need updates:
- `init`: Return guidance when args missing, add `--yes`, `--project-name`, `--project-id`
- `add`: Ensure `--yes` skips confirmation
- `create-app`: Return guidance if template not specified
- `auth login`: Keep interactive only, add `--no-browser`

### Part 3: Claude Code Plugin

Lives in monorepo at `claude-plugin/` with 7 skills:
- `generative-components` - Component registration and streaming
- `mcp-integration` - MCP server setup
- `streaming-patterns` - Generation stages and loading states
- `component-state` - useTamboComponentState patterns
- `interactables` - withInteractable HOC
- `tools` - Tool registration with useTamboRegistry
- `cli` - CLI command reference

Installation: `/plugin marketplace add tambo-ai/tambo/claude-plugin` → `/plugin install tambo`

### Part 4: Testing

- Jest tests mock TTY and verify no prompts in non-interactive mode
- CI workflow with `timeout 30` ensures commands don't hang

## Test Plan

- [x] Plan covers all Tambo concepts
- [x] Plugin structure matches official Claude Code marketplace format
- [x] Framework evaluation documented
- [ ] Team review