### PR TITLE
docs: validate Groq Llama-3.1-8B

### DIFF
--- a/docs/content/docs/reference/providers/groq.mdx
+++ b/docs/content/docs/reference/providers/groq.mdx
@@ -103,7 +103,7 @@ Not yet validated on common Tambo tasks. With 70B parameters, this model offers 
 
 #### llama-3.1-8b-instant
 
-**Status:** Untested
+**Status:** Tested
 
 **API Name:** `llama-3.1-8b-instant`
 
@@ -125,7 +125,19 @@ Llama 3.1 8B on Groq delivers fast, high-quality responses for real-time tasks. 
 
 **Notes:**
 
-Not yet validated on common Tambo tasks. This is the most cost-effective option in Groq's lineup while maintaining good performance for well-defined tasks.
+This model has been tested with Tambo component generation tasks and shows issues with JSON escaping in component attributes and component tag syntax. While it's the most cost-effective option in Groq's lineup, it will require careful validation and potentially post-processing for component generation use cases. See below for details.
+
+**Known Shortcomings:**
+
+Based on testing with component generation tasks, the following issues have been observed:
+
+- **JSON Escaping in Component Attributes**: The fields attribute contains unescaped JSON strings. This will cause parsing errors because quotes aren't escaped. (e.g., `fields="[{"id":"text_field","type":"text",...}]"`)
+
+- **Verbose Explanatory Text**: The model tends to include unnecessary explanatory text before and after component tags (e.g., "The form component is now displayed below" or "Your form now includes an email input field"). While not breaking, this adds noise to responses.
+
+- **Invalid Component Syntax**: Uses non-standard XML-like syntax that won't render properly. (e.g., `<show_component_FormComponent ... ></show_component_FormComponent>`)
+
+- **Streaming Error**: The model throws error while streaming sometimes.
 
 ## Configuration
 

--- a/packages/core/src/llms/models/groq.ts
+++ b/packages/core/src/llms/models/groq.ts
@@ -41,7 +41,7 @@ export const groqModels: Partial<LlmModelConfig<GroqModelId>> = {
   "llama-3.1-8b-instant": {
     apiName: "llama-3.1-8b-instant",
     displayName: "Llama 3.1 8B Instant",
-    status: "untested",
+    status: "tested",
     notes:
       "Llama 3.1 8B on Groq delivers fast, high-quality responses for real-time tasks. Supports function calling, JSON output, and 128K context at low cost.",
     docLink: "https://console.groq.com/docs/model/llama-3.1-8b-instant",


### PR DESCRIPTION
Closes #1789

This PR validates the Groq-hosted llama-3.1-8b-instant model in Tambo.

Tested the model using the Tambo showcase app and documented the shortcomings of the response:
  - JSON escaping issues in component attributes (unescaped quotes).
  - Verbose explanatory text in responses which adds noise.
  - Non-standard invalid XML-like syntax that won't render.
  - Streaming error (Often but not all the time)
  
Updated documentation to reflect testing results and known shortcomings.
Updated model status from "untested" to "tested" in the Groq model registry.

**Note:** llama-3.1-8b-instant model was not added in hosted tambo cloud, so this is tested by running the cloud (Both API + FE) in local. This model is tested against gpt-5 model in local which was working fine (This comparison is done only to show the diff in response format). Video verification is attached for both for better comparison.

**Verdict:** Some extra post-processing might be needed to handle Groq llama-3.1-8b-instant response.

Groq llama-3.1-8b-instant model response in local - 

https://github.com/user-attachments/assets/734f0c63-0057-468f-98dd-45793b1e6a80


OpenAI gpt-5 model response in local - 

https://github.com/user-attachments/assets/9b7b253d-e40f-4df6-ba45-0c71a4900403


