### PR TITLE
fix(api): remove projectId from V1 public API thread DTO

### DIFF
--- a/apps/api/src/v1/__tests__/v1-conversions.test.ts
+++ b/apps/api/src/v1/__tests__/v1-conversions.test.ts
@@ -57,7 +57,6 @@ describe("v1-conversions", () => {
       const result = threadToDto(baseThread);
 
       expect(result.id).toBe("thr_123");
-      expect(result.projectId).toBe("prj_123");
       expect(result.contextKey).toBe("user_456");
       expect(result.runStatus).toBe(V1RunStatus.IDLE);
       expect(result.metadata).toEqual({ key: "value" });

--- a/apps/api/src/v1/__tests__/v1.service.test.ts
+++ b/apps/api/src/v1/__tests__/v1.service.test.ts
@@ -359,7 +359,6 @@ describe("V1Service", () => {
         metadata: undefined,
       });
       expect(result.id).toBe("thr_123");
-      expect(result.projectId).toBe("prj_123");
     });
 
     it("should create a thread with context key and metadata", async () => {

--- a/apps/api/src/v1/dto/thread.dto.ts
+++ b/apps/api/src/v1/dto/thread.dto.ts
@@ -54,13 +54,6 @@ export class V1ThreadDto {
   id!: string;
 
   @ApiProperty({
-    description: "Project this thread belongs to",
-    example: "prj_xyz789",
-  })
-  @IsString()
-  projectId!: string;
-
-  @ApiProperty({
     description: "Optional context key for thread organization",
     required: false,
   })

--- a/apps/api/src/v1/v1-conversions.ts
+++ b/apps/api/src/v1/v1-conversions.ts
@@ -48,7 +48,6 @@ export function roleToV1(role: string): V1MessageRole {
 export function threadToDto(thread: DbThread): V1ThreadDto {
   return {
     id: thread.id,
-    projectId: thread.projectId,
     contextKey: thread.contextKey ?? undefined,
     runStatus: thread.runStatus,
     currentRunId: thread.currentRunId ?? undefined,


### PR DESCRIPTION
## Summary
- Remove `projectId` field from `V1ThreadDto` - it's an internal implementation detail that should not be exposed in public API responses
- Update thread conversion function to not include `projectId` in output
- Update tests to remove assertions on `projectId`

## Test plan
- [x] All 130 v1 API tests pass
- [x] Verified no other DTOs in `apps/api/src/v1/dto/` expose `projectId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)