### PR TITLE
ci: split CI into parallel jobs and add coverage comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+permissions:
+  # Default to read-only; only the `test` job should request broader access.
+  contents: read
+
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
     env:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-
-    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v5.0.1
@@ -37,9 +40,98 @@ jobs:
       - name: Run Lint
         run: npm run lint
 
+      - name: Build React SDK types
+        run: npm -w @tambo-ai/react run build:cjs
+
+      - name: Run Type Check
+        run: npm run check-types
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      COVERAGE_FILES: |
+        React SDK, ./react-sdk/coverage/coverage-summary.json
+        CLI, ./cli/coverage/coverage-summary.json
+        Showcase, ./showcase/coverage/coverage-summary.json
+        Apps API, ./apps/api/coverage/coverage-summary.json
+        Apps Web, ./apps/web/coverage/coverage-summary.json
+        Packages Core, ./packages/core/coverage/coverage-summary.json
+        Packages Backend, ./packages/backend/coverage/coverage-summary.json
+        Packages UI Registry, ./packages/ui-registry/coverage/coverage-summary.json
+    permissions:
+      contents: read
+      pull-requests: write # Needed to post the coverage comment on PRs.
+
+    steps:
+      - uses: actions/checkout@v5.0.1
+
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        # This `frozen: false` is a workaround for the fact that release-please
+        # is not properly updating the lockfile for interdependencies. `npm ci`
+        # is run by setup-tools by default (when frozen=true) but this command
+        # will fail if more than one package has a version change. This is a bug
+        # in release-please, which should be updating the version numbers in release PR.
+        with:
+          frozen: false
+
       - name: Run Tests
-        # Have to use extra -- -- because of turbo wrapping
-        run: npm run test -- -- --coverage
+        id: test
+        continue-on-error: true
+        run: npm run test -- -- --coverage --coverageReporters=json-summary --coverageReporters=text
+
+      - name: Detect coverage
+        id: coverage
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Extract file paths from COVERAGE_FILES (format: "Name, ./path/to/file")
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            file="${line##*, }"
+            if [[ -f "$file" ]]; then
+              echo "has_coverage=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done <<< "$COVERAGE_FILES"
+
+          echo "has_coverage=false" >> "$GITHUB_OUTPUT"
+
+      - name: Jest Coverage Comment
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && steps.coverage.outputs.has_coverage == 'true'
+        continue-on-error: true
+        uses: MishaKav/jest-coverage-comment@174f9cbf582b7cc2a7a3acce14dcfc8362e9d37f # v1.0.29
+        with:
+          title: "Test Coverage Report"
+          multiple-files: ${{ env.COVERAGE_FILES }}
+          report-only-changed-files: true
+
+      - name: Fail if tests failed
+        if: steps.test.outcome == 'failure'
+        run: exit 1
+
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v5.0.1
+
+      - name: Setup tools
+        uses: ./.github/actions/setup-tools
+        # This `frozen: false` is a workaround for the fact that release-please
+        # is not properly updating the lockfile for interdependencies. `npm ci`
+        # is run by setup-tools by default (when frozen=true) but this command
+        # will fail if more than one package has a version change. This is a bug
+        # in release-please, which should be updating the version numbers in release PR.
+        with:
+          frozen: false
 
       - name: Build
         run: npm run build

--- a/.github/workflows/issue-comment-bot.yml
+++ b/.github/workflows/issue-comment-bot.yml
@@ -1,0 +1,77 @@
+name: Issue Comment Bot
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  respond:
+    # Only respond to issues (not PRs), open issues, unassigned issues,
+    # and comments asking to work on the issue
+    if: |
+      !github.event.issue.pull_request &&
+      github.event.issue.state == 'open' &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.comment.user.login != 'github-actions[bot]' &&
+      !github.event.issue.assignee &&
+      (
+        contains(github.event.comment.body, 'can i work on this') ||
+        contains(github.event.comment.body, 'Can I work on this') ||
+        contains(github.event.comment.body, 'can i take this') ||
+        contains(github.event.comment.body, 'Can I take this') ||
+        contains(github.event.comment.body, 'i would like to work on this') ||
+        contains(github.event.comment.body, 'I would like to work on this') ||
+        contains(github.event.comment.body, 'is this available') ||
+        contains(github.event.comment.body, 'Is this available')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Respond to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = "<!-- tambo-issue-comment-bot:do-not-remove -->";
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const per_page = 100;
+            let hasAlreadyResponded = false;
+
+            for (let page = 1; ; page += 1) {
+              const response = await github.rest.issues.listComments({
+                issue_number,
+                owner,
+                repo,
+                page,
+                per_page,
+                direction: "desc",
+                sort: "created",
+              });
+
+              hasAlreadyResponded = response.data.some(
+                (comment) => (comment.body ?? "").includes(marker),
+              );
+
+              if (hasAlreadyResponded || response.data.length < per_page) {
+                break;
+              }
+            }
+
+            if (hasAlreadyResponded) {
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              issue_number,
+              owner,
+              repo,
+              body: `${marker}
+
+Thanks for your interest!
+
+We encourage you to go ahead and open a pull request - no need to ask permission first. Feel free to ask questions on the PR if you get stuck.
+
+Check out our [Contributing Guide](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md) for setup instructions.`,
+            });


### PR DESCRIPTION
## Summary

- Split monolithic CI job into three parallel jobs: `lint`, `test`, `build`
- Add `check-types` to the lint job for comprehensive type checking
- Add coverage comment to PRs showing per-package coverage using `MishaKav/jest-coverage-comment`
- Create `issue-comment-bot.yml` to auto-respond to "can I work on this" comments

## Changes

### CI Pipeline (`ci.yml`)
The single `build` job is now split into three parallel jobs:

| Job | Steps |
|-----|-------|
| `lint` | prettier-check, lint, build React SDK types, check-types |
| `test` | test with coverage, post coverage comment |
| `build` | build with env vars |

### Coverage Comment
PRs will now receive a comment showing per-package coverage:
- Uses a pinned `jest-coverage-comment` ref (commit SHA with version comment)
- Only posts when at least one `coverage-summary.json` exists (avoids noisy failures when coverage isn't produced)
- Only shows changed files when `report-only-changed-files: true`
- Posts even when tests fail (to show what's broken)

### Issue Comment Bot (`issue-comment-bot.yml`)
Auto-responds to comments asking to work on issues:
- Triggers on phrases like "can I work on this", "can I take this", etc.
- Only responds to open issues without assignees
- Encourages contributors to open PRs directly

## Test Plan

- [ ] CI runs three parallel jobs successfully
- [ ] Coverage comment appears on PRs
- [ ] Issue comment bot responds to test comment on an issue

reviewChanges skipped: stricter coverage gating (requiring coverage for specific packages) — intent here is only to avoid coverage-comment failures when no coverage output exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)