### PR TITLE
feat(ui-registry): add keyboard navigation to ThreadDropdown

### DIFF
--- a/packages/ui-registry/src/components/thread-dropdown/thread-dropdown.test.tsx
+++ b/packages/ui-registry/src/components/thread-dropdown/thread-dropdown.test.tsx
@@ -2,6 +2,7 @@
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ThreadDropdown } from "./thread-dropdown";
 import { useTamboThread, useTamboThreadList } from "@tambo-ai/react";
 
@@ -40,5 +41,32 @@ describe("ThreadDropdown", () => {
   it("calls useTamboThreadList without arguments (contextKey comes from provider)", () => {
     render(<ThreadDropdown />);
     expect(mockUseTamboThreadList).toHaveBeenCalledWith();
+  });
+
+  describe("keyboard navigation", () => {
+    it("renders trigger as a button element for keyboard accessibility", () => {
+      render(<ThreadDropdown />);
+      const trigger = screen.getByRole("button", { name: /thread history/i });
+      expect(trigger.tagName).toBe("BUTTON");
+    });
+
+    it("opens dropdown with keyboard", async () => {
+      const user = userEvent.setup();
+      mockUseTamboThreadList.mockReturnValue({
+        data: { items: [{ id: "thread-1" }] },
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ThreadDropdown />);
+      const trigger = screen.getByRole("button", { name: /thread history/i });
+
+      trigger.focus();
+      await user.keyboard("{Enter}");
+
+      const newThreadItem = await screen.findByText("New Thread");
+      expect(newThreadItem).toBeInTheDocument();
+    });
   });
 });

--- a/packages/ui-registry/src/components/thread-dropdown/thread-dropdown.tsx
+++ b/packages/ui-registry/src/components/thread-dropdown/thread-dropdown.tsx
@@ -87,14 +87,13 @@ export const ThreadDropdown = React.forwardRef<
     <div className={cn("relative", className)} ref={ref} {...props}>
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
-          <div
-            role="button"
-            tabIndex={0}
+          <button
+            type="button"
             className="rounded-md px-1 flex items-center gap-2 text-sm border border-border bg-background hover:bg-accent hover:text-accent-foreground cursor-pointer transition-colors"
             aria-label="Thread History"
           >
             <ChevronDownIcon className="h-4 w-4" />
-          </div>
+          </button>
         </DropdownMenu.Trigger>
         <DropdownMenu.Portal>
           <DropdownMenu.Content
@@ -104,7 +103,7 @@ export const ThreadDropdown = React.forwardRef<
             sideOffset={5}
           >
             <DropdownMenu.Item
-              className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+              className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
               onSelect={(e: Event) => {
                 e.preventDefault();
                 void handleNewThread();
@@ -187,7 +186,7 @@ function ThreadListContent({
       {threads?.items.map((thread) => (
         <DropdownMenu.Item
           key={thread.id}
-          className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+          className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
           onSelect={(e: Event) => {
             e.preventDefault();
             void onSwitchThread(thread.id);


### PR DESCRIPTION
Fixes #1712

## Summary

Added keyboard navigation support to the ThreadDropdown component.

## Changes

- Changed dropdown trigger for proper keyboard accessibility
- Added focus styles to menu items for visual feedback during keyboard navigation
- Added tests to verify keyboard navigation functionality

## Testing

-  Can navigate and select items using keyboard only (Tab, Enter, Escape, Arrow keys)
-  Tests cover new functionality
-  `npm run check-types` passes
-  `npm run lint` passes  
-  `npm test` passes (thread-dropdown tests)