### PR TITLE
fix(ui-registry): fix stale closure in dictation transcription

### DIFF
--- a/packages/ui-registry/src/components/message-input/dictation-button.tsx
+++ b/packages/ui-registry/src/components/message-input/dictation-button.tsx
@@ -15,7 +15,7 @@ export default function DictationButton() {
     transcript,
     transcriptionError,
   } = useTamboVoice();
-  const { value, setValue } = useTamboThreadInput();
+  const { setValue } = useTamboThreadInput();
   const [lastProcessedTranscript, setLastProcessedTranscript] =
     useState<string>("");
 
@@ -31,9 +31,9 @@ export default function DictationButton() {
   useEffect(() => {
     if (transcript && transcript !== lastProcessedTranscript) {
       setLastProcessedTranscript(transcript);
-      setValue(value + " " + transcript);
+      setValue((prev) => prev + " " + transcript);
     }
-  }, [transcript, lastProcessedTranscript, value, setValue]);
+  }, [transcript, lastProcessedTranscript, setValue]);
 
   if (isTranscribing) {
     return (


### PR DESCRIPTION
Fixes #1703

## Summary

Fixes stale closure bug in dictation button where rapid transcript updates could cause duplicate or missing text.

## Problem

The dictation button was capturing a stale `value` in the `useEffect` closure. When the transcription service sent rapid updates, each update would append to the same old captured value instead of the latest input value, causing:
- Duplicate text
- Missing transcript segments

Changed from direct state access to functional state update:
- **Before:** `setValue(value + " " + transcript)` - captures stale `value`
- **After:** `setValue((prev) => prev + " " + transcript)` - always gets latest value

Also removed `value` from the dependency array since it's no longer referenced in the effect.

## Verification

- `npm run lint` passes
- `npm run check-types` passes  
- `npm test` passes (react-sdk tests)
- SDK already supports functional updates`