### PR TITLE
fix(api): restore e2e tests and add them to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
         # Have to use extra -- -- because of turbo wrapping
         run: npm run test -- -- --coverage
 
+      - name: Run E2E Tests
+        run: npm run test:e2e -w @tambo-ai-cloud/api
+
       - name: Build
         run: npm run build
         env:

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -2,6 +2,7 @@ import { INestApplication } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import request from "supertest";
 import { AppModule } from "./../src/app.module";
+import { AudioService } from "./../src/audio/audio.service";
 
 describe("AppController (e2e)", () => {
   let app: INestApplication;
@@ -9,16 +10,27 @@ describe("AppController (e2e)", () => {
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(AudioService)
+      .useValue({
+        // Mock AudioService to avoid requiring OpenAI credentials
+      })
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
   });
 
   it("/ (GET)", () => {
     return request(app.getHttpServer())
       .get("/")
       .expect(200)
-      .expect("Hello World!");
+      .expect("Welcome to the Tambo AI API!");
   });
 });

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -1,12 +1,26 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.(t|j)s$": [
+      "ts-jest",
+      {
+        "useESM": true,
+        "tsconfig": {
+          "module": "esnext"
+        }
+      }
+    ]
   },
+  "extensionsToTreatAsEsm": [".ts"],
   "moduleNameMapper": {
-    "^@tambo-ai-cloud/(.*)$": "<rootDir>/../../../packages/$1/src"
-  }
+    "^src/(.*)$": "<rootDir>/src/$1",
+    "^@tambo-ai-cloud/(.*)$": "<rootDir>/../../packages/$1/src"
+  },
+  "transformIgnorePatterns": [
+    "node_modules/(?!(superjson|is-what|copy-anything|uuid)/)"
+  ],
+  "testTimeout": 10000
 }


### PR DESCRIPTION
## What does this PR do?

This PR restores the API end-to-end (e2e) test setup that broke after the monorepo restructure and ensures the tests are executed as part of the CI workflow.

Specifically, it:
- Fixes the Jest e2e configuration to work correctly in the updated monorepo layout
- Adds a basic API e2e test that boots the NestJS app successfully
- Mocks external dependencies (e.g. AudioService) so tests do not require credentials
- Adds an explicit CI step to run API e2e tests

---

## Why is this needed?

API e2e tests were no longer running locally or in CI after the repo restructure (#1347), causing them to bit-rot.  
This PR ensures e2e coverage is restored and continuously validated going forward.

---

## How was this tested?

- [x] `npm run test:e2e -w @tambo-ai-cloud/api` passes locally
- [x] CI workflow includes a dedicated e2e test step
- [x] CI runs e2e tests successfully without external secrets

---

## Checklist

- [x] e2e tests pass locally
- [x] e2e tests added to CI workflows
- [x] CI passes with e2e tests enabled
- [x] No external credentials required for tests
- [x] Follows CONTRIBUTING.md guidelines

---

## Related Issue

Closes #1847