### PR TITLE
CLI doesn't configure PostCSS/Vite plugin for Tailwind v4 in non-Next.js projects 

### DIFF
--- a/cli/src/commands/add/component.ts
+++ b/cli/src/commands/add/component.ts
@@ -98,6 +98,7 @@ export function cn(...inputs: ClassValue[]) {
     "postcss",
     "autoprefixer",
     "tailwind-merge",
+    "@tailwindcss/vite",
     "clsx",
   ]);
 

--- a/cli/src/commands/add/setupViteTailwindPlugin.ts
+++ b/cli/src/commands/add/setupViteTailwindPlugin.ts
@@ -1,0 +1,370 @@
+/**
+ * @param projectRoot The root directory of the project
+ */
+
+import chalk from "chalk";
+import fs from "fs";
+import path from "path";
+import {
+  Project,
+  ScriptKind,
+  SyntaxKind,
+  type ObjectLiteralExpression,
+} from "ts-morph";
+import { execFileSync } from "../../utils/interactive.js";
+import {
+  detectPackageManager,
+  formatPackageArgs,
+  getDevFlag,
+  getInstallCommand,
+} from "../../utils/package-manager.js";
+
+export async function setupViteTailwindPlugin(projectRoot: string) {
+  // Configuring how to install
+  const pm = detectPackageManager(projectRoot);
+  const installCmd = getInstallCommand(pm);
+  const devFlag = getDevFlag(pm);
+
+  const packageJsonPath = path.join(projectRoot, "package.json");
+  const packageRaw = fs.readFileSync(packageJsonPath, "utf-8");
+  const packageJson = JSON.parse(packageRaw);
+  const installedDeps = {
+    ...(packageJson.dependencies ?? {}),
+    ...(packageJson.devDependencies ?? {}),
+  };
+
+  // checking and installing "@tailwind/vite"
+  if (!installedDeps["@tailwindcss/vite"]) {
+    console.log(
+      ` Installing @tailwindcss/vite...  In the mean time don't forget to read our Docs https://docs.tambo.co`,
+    );
+
+    try {
+      const args = [
+        ...installCmd,
+        devFlag,
+        ...formatPackageArgs(pm, ["@tailwindcss/vite"]),
+      ];
+      execFileSync(pm, args, {
+        stdio: "inherit",
+        encoding: "utf-8",
+        allowNonInteractive: true,
+      });
+
+      console.log(`Installed @tailwindcss/vite`);
+    } catch (error) {
+      throw new Error(
+        `Failed to install @tailwindcss/vite: ${error}. Please install it manually with: ${pm} ${installCmd.join(" ")} ${devFlag} @tailwindcss/vite`,
+      );
+    }
+  }
+
+  // Locating the vite.config.ts file
+  const viteConfigPath = [
+    path.join(projectRoot, "vite.config.ts"),
+    path.join(projectRoot, "vite.config.js"),
+    path.join(projectRoot, "vite.config.mjs"),
+    path.join(projectRoot, "vite.config.cjs"),
+  ];
+  const existingConfigPath = viteConfigPath.find((p) => fs.existsSync(p));
+
+  // Now if that particular file exists
+  if (existingConfigPath) {
+    // Modify existing config
+    const configContent = fs.readFileSync(existingConfigPath, "utf-8");
+    const ext = path.extname(existingConfigPath);
+
+    if (ext === ".ts") {
+      // Use ts-morph for TypeScript files
+      await modifyViteConfigTS(existingConfigPath, configContent);
+    } else {
+      // Use string manipulation for JS/MJS files
+      const modified = modifyViteConfigJS(configContent, ext === ".mjs");
+      if (modified !== configContent) {
+        fs.writeFileSync(existingConfigPath, modified);
+        console.log(
+          `${chalk.green("✔")} Updated ${path.basename(existingConfigPath)}`,
+        );
+      }
+    }
+  } else {
+    // Create new vite.config.ts
+    const newConfigPath = path.join(projectRoot, "vite.config.ts");
+    const defaultConfig = `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(),
+   tailwindcss()],
+})`;
+    fs.writeFileSync(newConfigPath, defaultConfig);
+    console.log(`${chalk.green("✔")} Created vite.config.ts`);
+  }
+
+  console.log(` Vite Tailwind plugin setup complete`);
+}
+
+async function modifyViteConfigTS(
+  configPath: string,
+  configContent: string,
+): Promise<void> {
+  const project = new Project({
+    skipFileDependencyResolution: true,
+    compilerOptions: { allowJs: true },
+  });
+
+  const sourceFile = project.createSourceFile("vite.config.ts", configContent, {
+    scriptKind: ScriptKind.TS,
+  });
+
+  // Check if import already exists
+  const existingImport = sourceFile
+    .getImportDeclarations()
+    .find((imp) => imp.getModuleSpecifierValue() === "@tailwindcss/vite");
+
+  // Add import if it doesn't exist
+  if (!existingImport) {
+    // Find the last import or add at the top
+    const imports = sourceFile.getImportDeclarations();
+    const lastImport = imports[imports.length - 1];
+
+    if (lastImport) {
+      sourceFile.insertImportDeclaration(lastImport.getChildIndex() + 1, {
+        defaultImport: "tailwindcss",
+        moduleSpecifier: "@tailwindcss/vite",
+      });
+    } else {
+      // No imports, add at the top
+      sourceFile.insertImportDeclaration(0, {
+        defaultImport: "tailwindcss",
+        moduleSpecifier: "@tailwindcss/vite",
+      });
+    }
+  }
+
+  // Find the default export (can be export default or export default defineConfig(...))
+  // Try finding export default statements directly (more reliable for TypeScript)
+  const exportAssignment = sourceFile
+    .getStatements()
+    .find((stmt) => {
+      if (stmt.getKind() === SyntaxKind.ExportAssignment) {
+        const assignment = stmt.asKind(SyntaxKind.ExportAssignment);
+        return assignment && !assignment.isExportEquals();
+      }
+      return false;
+    })
+    ?.asKind(SyntaxKind.ExportAssignment);
+
+  let defaultExportDecl: unknown = null;
+
+  if (exportAssignment) {
+    defaultExportDecl = exportAssignment.getExpression();
+  }
+
+  // Fallback: try getExportedDeclarations if direct method didn't work
+  if (!defaultExportDecl) {
+    const exportedDecl = sourceFile
+      .getExportedDeclarations()
+      .get("default")?.[0];
+
+    if (exportedDecl) {
+      defaultExportDecl = exportedDecl;
+    }
+  }
+
+  if (
+    !defaultExportDecl ||
+    typeof defaultExportDecl !== "object" ||
+    !("getKindName" in defaultExportDecl) ||
+    !("asKind" in defaultExportDecl)
+  ) {
+    throw new Error(
+      `Could not find default export in vite.config.ts. Please ensure it has 'export default defineConfig({...})' or 'export default {...}'. File content:\n${configContent.substring(0, 200)}...`,
+    );
+  }
+
+  // Handle different export patterns:
+  let configObject: ObjectLiteralExpression | null = null;
+
+  const node = defaultExportDecl as {
+    getKindName: () => string;
+    asKind: (kind: SyntaxKind) => unknown;
+  };
+  const kindName = node.getKindName();
+  const asKind = node.asKind;
+
+  if (kindName === "CallExpression") {
+    // Case: export default defineConfig({ ... })
+    const callExpr = asKind(SyntaxKind.CallExpression) as {
+      getArguments: () => unknown[];
+    } | null;
+    const arg = callExpr?.getArguments()[0] as {
+      getKindName: () => string;
+      asKind: (kind: SyntaxKind) => unknown;
+    } | null;
+    if (arg?.getKindName() === "ObjectLiteralExpression") {
+      configObject = arg.asKind(
+        SyntaxKind.ObjectLiteralExpression,
+      ) as ObjectLiteralExpression | null;
+    }
+  } else if (kindName === "ObjectLiteralExpression") {
+    // Case: export default { ... }
+    configObject = asKind(
+      SyntaxKind.ObjectLiteralExpression,
+    ) as ObjectLiteralExpression | null;
+  } else if (kindName === "VariableDeclaration") {
+    // Case: const config = { ... }; export default config;
+    const varDecl = asKind(SyntaxKind.VariableDeclaration) as {
+      getInitializer: () => unknown;
+    } | null;
+    const initializer = varDecl?.getInitializer() as {
+      getKindName: () => string;
+      asKind: (kind: SyntaxKind) => unknown;
+    } | null;
+    if (initializer?.getKindName() === "ObjectLiteralExpression") {
+      configObject = initializer.asKind(
+        SyntaxKind.ObjectLiteralExpression,
+      ) as ObjectLiteralExpression | null;
+    }
+  }
+
+  if (!configObject) {
+    throw new Error(
+      "Could not parse vite.config.ts structure. Please ensure it exports a config object.",
+    );
+  }
+
+  // Check if plugins array exists
+  const properties = configObject.getProperties();
+  const pluginsProperty = properties.find((prop) => {
+    if (prop.getKind() === SyntaxKind.PropertyAssignment) {
+      const propAssignment = prop.asKind(SyntaxKind.PropertyAssignment);
+      return propAssignment?.getName() === "plugins";
+    }
+    return false;
+  });
+
+  if (!pluginsProperty) {
+    throw new Error(
+      "plugins property not found. Please add 'plugins: [react(), tailwindcss()]' manually.",
+    );
+  }
+
+  // Check if tailwindcss() is already in plugins array
+  const propAssignment = pluginsProperty.asKind(SyntaxKind.PropertyAssignment);
+  const pluginsValue = propAssignment?.getInitializer();
+  if (pluginsValue?.getKindName() === "ArrayLiteralExpression") {
+    const pluginsArray = pluginsValue.asKind(SyntaxKind.ArrayLiteralExpression);
+    const hasTailwind = pluginsArray
+      ?.getElements()
+      .some((elem: { getText: () => string }) => {
+        const text = elem.getText();
+        return text.includes("tailwindcss()");
+      });
+
+    if (!hasTailwind && pluginsArray) {
+      // Add tailwindcss() to the plugins array
+      const lastElement =
+        pluginsArray.getElements()[pluginsArray.getElements().length - 1];
+      if (lastElement) {
+        pluginsArray.insertElement(
+          pluginsArray.getElements().length,
+          "tailwindcss()",
+        );
+      } else {
+        pluginsArray.addElement("tailwindcss()");
+      }
+    }
+  }
+
+  // Write the modified file
+  const modifiedContent = sourceFile.getFullText();
+  fs.writeFileSync(configPath, modifiedContent);
+  console.log(`${chalk.green("✔")} Updated vite.config.ts`);
+}
+
+function modifyViteConfigJS(configContent: string, _isMJS: boolean): string {
+  // Check if import already exists
+  const hasImport = configContent.includes("@tailwindcss/vite");
+  const hasTailwindPlugin = configContent.includes("tailwindcss()");
+
+  if (hasImport && hasTailwindPlugin) {
+    // Already configured
+    return configContent;
+  }
+
+  let modified = configContent;
+
+  // Add import if missing
+  // Always use ES module import syntax for all JS files (Vite supports it)
+  if (!hasImport) {
+    const importStatement = `import tailwindcss from '@tailwindcss/vite'\n`;
+
+    // Try to find where to insert (after other imports or at the top)
+    const importRegex = /^(import|const|require).*$/m;
+    const lastImportMatch = [
+      ...modified.matchAll(new RegExp(importRegex.source, "gm")),
+    ].pop();
+
+    if (lastImportMatch) {
+      const insertIndex =
+        (lastImportMatch.index ?? 0) + lastImportMatch[0].length;
+      modified =
+        modified.slice(0, insertIndex) +
+        "\n" +
+        importStatement +
+        modified.slice(insertIndex);
+    } else {
+      // No imports found, add at the top
+      modified = importStatement + modified;
+    }
+  }
+
+  // Add to plugins array
+  if (!hasTailwindPlugin) {
+    // Look for plugins array pattern: plugins: [ ... ]
+    const pluginsArrayRegex = /plugins:\s*\[([^\]]*)\]/;
+    const match = pluginsArrayRegex.exec(modified);
+
+    if (match) {
+      // Plugins array exists, add tailwindcss()
+      const existingPlugins = match[1].trim();
+      const newPlugins = existingPlugins
+        ? `${existingPlugins}, tailwindcss()`
+        : "tailwindcss()";
+      modified = modified.replace(
+        pluginsArrayRegex,
+        `plugins: [${newPlugins}]`,
+      );
+    } else {
+      // No plugins array, need to add it
+      // Look for export default pattern
+      const exportDefaultRegex = /export\s+default\s+(\{[\s\S]*\})/;
+      const exportMatch = exportDefaultRegex.exec(modified);
+
+      if (exportMatch) {
+        // Insert plugins before the closing brace
+        const configObject = exportMatch[1];
+        const lastBraceIndex = configObject.lastIndexOf("}");
+        const beforeBrace = configObject.slice(0, lastBraceIndex);
+        const afterBrace = configObject.slice(lastBraceIndex);
+
+        const pluginsProperty = beforeBrace.trim().endsWith(",")
+          ? "\n  plugins: [tailwindcss()],"
+          : ",\n  plugins: [tailwindcss()]";
+
+        modified = modified.replace(
+          exportDefaultRegex,
+          `export default ${beforeBrace}${pluginsProperty}${afterBrace}`,
+        );
+      } else {
+        throw new Error(
+          "Could not find export default in vite.config. Please add plugins manually.",
+        );
+      }
+    }
+  }
+
+  return modified;
+}

--- a/cli/src/constants/packages.ts
+++ b/cli/src/constants/packages.ts
@@ -12,6 +12,7 @@ export const KNOWN_SAFE_PACKAGES = [
   "class-variance-authority",
   "framer-motion",
   "lucide-react",
+  "@tailwindcss/vite",
   "radix-ui",
   "@radix-ui/react-dialog",
   "@radix-ui/react-slot",

--- a/cli/src/utils/framework-detection.ts
+++ b/cli/src/utils/framework-detection.ts
@@ -54,13 +54,14 @@ const FRAMEWORKS: FrameworkDefinition[] = [
       hasPackage("next") ||
       hasAnyFile(["next.config.js", "next.config.ts", "next.config.mjs"]),
   },
-  // Future frameworks can be added here:
-  // {
-  //   name: "vite",
-  //   displayName: "Vite",
-  //   envPrefix: "VITE_",
-  //   detect: () => hasPackage("vite") || hasAnyFile(["vite.config.js", "vite.config.ts"]),
-  // },
+
+  {
+    name: "vite",
+    displayName: "Vite",
+    envPrefix: "VITE_",
+    detect: () =>
+      hasPackage("vite") || hasAnyFile(["vite.config.js", "vite.config.ts"]),
+  },
   // {
   //   name: "cra",
   //   displayName: "Create React App",

--- a/package-lock.json
+++ b/package-lock.json
@@ -314,6 +314,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.4.0.tgz",
       "integrity": "sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1319,6 +1320,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -2544,6 +2546,7 @@
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.43.tgz",
       "integrity": "sha512-150Y3TX+k83qvtmp4bTxmPW0Xu7to2y5vlhD8s5gof5/fxMdxybM1ieZazN7OIWU0nCK/hvhA+bVC7mmyby3gw==",
+      "peer": true,
       "dependencies": {
         "@ag-ui/core": "0.0.43",
         "@ag-ui/encoder": "0.0.43",
@@ -2570,6 +2573,7 @@
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.43.tgz",
       "integrity": "sha512-/T7kKwPAhtriFFiv3YxZ0yAzMHoY8a8I5UKzhPzwW934h92c6RJ54N93yb9PAqdX3XjCPId0C5gIBHb6QbeR3Q==",
+      "peer": true,
       "dependencies": {
         "rxjs": "7.8.1",
         "zod": "^3.22.4"
@@ -4908,6 +4912,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -6903,6 +6908,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6926,6 +6932,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8031,6 +8038,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
       "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -10807,6 +10815,7 @@
       "resolved": "https://registry.npmjs.org/@mastra/core/-/core-0.20.2.tgz",
       "integrity": "sha512-RbwuLwOVrcLbbjLFEBSlGTBA3mzGAy4bXp4JeXg2miJWDR/7WbXtxKIU+sTZGw5LpzlvvEFtj7JtHI1l+gKMVg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@a2a-js/sdk": "~0.2.4",
         "@ai-sdk/anthropic-v5": "npm:@ai-sdk/anthropic@2.0.23",
@@ -10981,6 +10990,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
       "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -12250,6 +12260,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
       "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
@@ -12599,6 +12610,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.12.tgz",
       "integrity": "sha512-v6U3O01YohHO+IE3EIFXuRuu3VJILWzyMmSYZXpyBbnp0hk0mFyHxK2w3dF4I5WnbwiRbWlEXdeXFvPQ7qaZzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -12658,6 +12670,7 @@
       "integrity": "sha512-97DzTYMf5RtGAVvX1cjwpKRiCUpkeQ9CCzSAenqkAhOmNVVFaApbhuw+xrDt13rsCa2hHVOYPrV4dBgOYMJjsA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -12718,6 +12731,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -13147,6 +13161,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -13181,6 +13196,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.3.0.tgz",
       "integrity": "sha512-hGcsT0qDP7Il1L+qT3JFpiGl1dCjF794Bb4yCRCYdr7XC0NwHtOF3ngF86Gk6TUnsakbyQsDQ0E/S4CU0F4d4g==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -13193,6 +13209,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
       "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -13429,7 +13446,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.208.0.tgz",
       "integrity": "sha512-jbzDw1q+BkwKFq9yxhjAJ9rjKldbt5AgIy1gmEIJjEV/WRxQ3B6HcLVkwbjJ3RcMif86BDNKR846KJ0tY0aOJA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/otlp-exporter-base": "0.208.0",
@@ -13449,7 +13465,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
       "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/otlp-transformer": "0.208.0"
@@ -13466,7 +13481,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
       "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.208.0",
         "@opentelemetry/core": "2.2.0",
@@ -13488,7 +13502,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
       "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.208.0",
         "@opentelemetry/core": "2.2.0",
@@ -13506,6 +13519,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
       "integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.208.0",
         "import-in-the-middle": "^2.0.0",
@@ -14563,6 +14577,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
       "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -14715,6 +14730,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
       "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/resources": "2.2.0",
@@ -14732,6 +14748,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
       "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -16691,6 +16708,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -18274,7 +18292,8 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.38.tgz",
       "integrity": "sha512-HpkxMmc2XmZKhvaKIZZThlHmx1L0I/V1hWK1NubtlFnr6ZqdiOpV72TKudZUNQjZNsyDBay72qFEhEvb+bcwcA==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@sindresorhus/base62": {
       "version": "1.0.0",
@@ -19134,6 +19153,7 @@
       "version": "1.12.38",
       "resolved": "https://registry.npmjs.org/@splinetool/runtime/-/runtime-1.12.38.tgz",
       "integrity": "sha512-Rgd4WdqCZ8PgMWjC/+BCoyNMJExa0je1qsHfio6FerwWVAqoy3/kAoAVjj3qLBOh2T6eAbfGoWR4rQTfe20JfA==",
+      "peer": true,
       "dependencies": {
         "on-change": "4.0.0",
         "semver-compare": "1.0.0"
@@ -19194,7 +19214,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -19361,6 +19382,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -19967,6 +19989,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.16.tgz",
       "integrity": "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.16"
       },
@@ -20011,6 +20034,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -20122,6 +20146,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.15.3.tgz",
       "integrity": "sha512-bmXydIHfm2rEtGju39FiQNfzkFx9CDvJe+xem1dgEZ2P6Dj7nQX9LnA1ZscW7TuzbBRkL5p3dwuBIi3f62A66A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -20344,6 +20369,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.15.3.tgz",
       "integrity": "sha512-n7y/MF9lAM5qlpuH5IR4/uq+kJPEJpe9NrEiH+NmkO/5KJ6cXzpJ6F4U17sMLf2SNCq+TWN9QK8QzoKxIn50VQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -20477,6 +20503,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.15.3.tgz",
       "integrity": "sha512-ycx/BgxR4rc9tf3ZyTdI98Z19yKLFfqM3UN+v42ChuIwkzyr9zyp7kG8dB9xN2lNqrD+5y/HyJobz/VJ7T90gA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -20491,6 +20518,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.15.3.tgz",
       "integrity": "sha512-Zm1BaU1TwFi3CQiisxjgnzzIus+q40bBKWLqXf6WEaus8Z6+vo1MT2pU52dBCMIRaW9XNDq3E5cmGtMc1AlveA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -20584,6 +20612,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.15.3.tgz",
       "integrity": "sha512-+CbaHhPfKUe+fNpUIQaOPhh6xI+xL5jbK1zw++U+CZIRrVAAmHRhO+D0O2HdiE1RK7596y8bRqMiB2CRHF7emA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -20624,6 +20653,7 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@trpc/server": "11.8.1",
         "typescript": ">=5.7.2"
@@ -20654,6 +20684,7 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": ">=5.7.2"
       }
@@ -21310,7 +21341,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -21475,6 +21507,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.5.tgz",
       "integrity": "sha512-HfF8+mYcHPcPypui3w3mvzuIErlNOh2OAG+BCeBZCEwyiD5ls2SiCwEyT47OELtf7M3nHxBdu0FsmzdKxkN52Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -21553,6 +21586,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -21563,6 +21597,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -21755,6 +21790,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -22259,6 +22295,7 @@
       "integrity": "sha512-GE7DmSr1C2UCWPiV0upRH6mv0cCPsqYGs819fb6srCS1tWhyXrkGGe+zxUiwzn/L1BOfADH4sNjY/YHCuP8phQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "valibot": "^1.2.0"
       }
@@ -22509,6 +22546,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -22572,6 +22610,7 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.123.tgz",
       "integrity": "sha512-V3Imb0tg0pHCa6a/VsoW/FZpT07mwUw/4Hj6nexJC1Nvf1eyKQJyaYVkl+YTLnA8cKQSUkoarKhXWbFy4CSgjw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "2.0.29",
         "@ai-sdk/provider": "2.0.1",
@@ -22656,6 +22695,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -23583,6 +23623,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -23855,6 +23896,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -23882,6 +23924,7 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -23927,13 +23970,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -24864,6 +24909,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.32.1.tgz",
       "integrity": "sha512-dbeqFTLYEwlFg7UGtcZhCCG/2WayX72zK3Sq323CEX29CY81tYfVhw1MIdduCtpstB0cTOhJswWlM/OEB3Xp+Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -25267,6 +25313,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -26203,7 +26250,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -26632,6 +26680,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -27598,6 +27647,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -28360,6 +28410,7 @@
       "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-15.8.5.tgz",
       "integrity": "sha512-hyJtKGuB2J/5y7tDfI1EnGMKlNbSXM5N5cpwvgCY0DcBJwFMDG/GpSpaVRzh3aWy67pAYDZFIwdtbKXBa/q5bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.6.2",
         "@orama/orama": "^3.1.14",
@@ -29520,6 +29571,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.10.6.tgz",
       "integrity": "sha512-BIdolzGpDO9MQ4nu3AUuDwHZZ+KViNm+EZ75Ae55eMXMqLVhDFqEMXxtUe9Qh8hjL+pIna/frs2j6Y2yD5Ua/g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -31121,6 +31173,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -33321,6 +33374,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -33406,6 +33460,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -33752,7 +33807,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/leaflet.heat": {
       "version": "0.2.0",
@@ -35049,6 +35105,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -36223,6 +36280,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
       "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
@@ -37404,6 +37462,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -37718,6 +37777,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -37957,6 +38017,7 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -38242,6 +38303,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -38271,6 +38333,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -38319,6 +38382,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
       "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -38443,7 +38507,8 @@
           "url": "https://github.com/sponsors/sxzz"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
@@ -38664,6 +38729,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -38685,6 +38751,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -38704,6 +38771,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.1.tgz",
       "integrity": "sha512-2KnjpgG2Rhbi+CIiIBQQ9Df6sMGH5ExNyFl4Hw9qO7pIqMBR8Bvu9RQyjl3JM4vehzCh9soiNUM/xYMswb2EiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -38728,7 +38796,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-leaflet": {
       "version": "4.2.1",
@@ -38812,6 +38881,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -39146,7 +39216,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -39161,7 +39232,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -39996,6 +40068,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.2.tgz",
       "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -40128,6 +40201,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -40306,6 +40380,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -40574,6 +40649,7 @@
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.19.0.tgz",
       "integrity": "sha512-77VJr3OR/VUZzPiStyRhADmO2jApMM0V2b1qf0RpfWya8Zr1PeZev5AEpPGAAKWdiYUtcZGBE4F5QvJml1PvWA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@shikijs/core": "3.19.0",
         "@shikijs/engine-javascript": "3.19.0",
@@ -41716,6 +41792,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -42799,7 +42876,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -43311,6 +43389,7 @@
       "integrity": "sha512-+HjKlP4OfYk+qzvWNETA3cUO5UuK6b5MSc2UJOKyvBceKucQoQGb2g7HlC2H1GHdkfKrk4YF1VPvROkhVZDDLQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "turbo": "bin/turbo"
       },
@@ -43567,6 +43646,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -43731,6 +43811,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -44445,6 +44526,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -44874,6 +44956,7 @@
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -45103,6 +45186,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -45415,6 +45499,7 @@
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }


### PR DESCRIPTION
This fixes issue #1817

# My approach 
I have gone with OPTION A   that is : 
Install ```@tailwindcss/vite```
Update ```vite.config.ts``` to include the plugin

# Changes I have made
1.  added the framework detection : Vite 
2.   ``` tailwind-setup.ts``` giving the user flexibity that :
-  by using ``` npx tambo full-send```  this command automatically install tailwind into the project >4.0.0 
-  No need to install external command when setup react using vite . As while setup vite there is a step in order to bring tailwindcss into the project . I thought this could be a good feature ! As the common flow is :  https://tailwindcss.com/docs/installation/using-vite

4.   created this file ``` cli\src\commands\add\setupViteTailwindPlugin.ts``` . This has the logic for creating : 
   -  Ensures that the @tailwindcss/vite plugin is installed (using the correct package manager for the project).
    -  Locates the Vite configuration file (vite.config.ts, .js, .mjs, or .cjs).
    -  If a Vite config file exists:
         - For TypeScript configs, parses and modifies the file using ts-morph, ensuring `tailwindcss` is imported and added to the `plugins` array.
         - For JavaScript configs, modifies the file contents via string manipulation to import `tailwindcss` and add it to the `plugins` array.
    4. If no config exists, generates a new vite.config.ts with React and Tailwind plugins preconfigured.
    
    
# Here is the Video demo for the same that it's working 
## 1.  Vite : React + Javascript : 
 -  import tailwindcss from '@tailwindcss/vite'
   - plugins: [react(), tailwindcss()]
  - Should show: "@import "tailwindcss" in App.css
  - In package.,json :
   "tailwindcss": "^4.x.x"
    "@tailwindcss/vite": "^4.x.x"
https://drive.google.com/file/d/18uMzqh8UTC-oShABBbEEjqTX_IlDsffW/view?usp=sharing


## 2. Vite : React + Typescript 
https://drive.google.com/file/d/1jB8C508BhLkFhNsbwbeiVYZn8HgTsm1c/view?usp=sharing
And here is the screenshot that the dependencies got isntalled after executing "npx tambo full-send"
<img width="959" height="599" alt="image" src="https://github.com/user-attachments/assets/ebb7047f-8436-4871-9ebc-1fcfee90a991" />

# As you can see in the above video : 
1. When configuring the project with Vite : React + Typescript , it shows this error : 
<img width="1888" height="468" alt="image" src="https://github.com/user-attachments/assets/a5962406-8ea1-4e45-a056-72ad1d639572" />

2. When google about this error it shows : 
When selecting React + TypeScript, if vite.config.ts exists but lacks a plugins property, the code threw an error instead of adding it. This caused setup to fail even though Tailwind packages were installed.

But if that's the case then my for react+javascript logic should not work! 
If you can come up with this solution I'm more than happy ! 
Also I asked this issue in the discord channel also  :https://discord.com/channels/1251581895414911016/1464967150773993645

# In short 
- User creates a new Vite application using "npm create vite@latest <name of the   folder >" 
- Executes "npx tambo full-send" with this no need to perform the step to install tailwind as this command installs tailwind css 
- selects javascript (everything works fine ) 
- selects typescript : dependenices gets installed but not overwritting the vite.config.ts file ! 

