### PR TITLE
fix(scrollable-message-container): memoize ScrollableMessageContainer JSX for better performance

### DIFF
--- a/packages/ui-registry/src/components/scrollable-message-container/scrollable-message-container.tsx
+++ b/packages/ui-registry/src/components/scrollable-message-container/scrollable-message-container.tsx
@@ -98,22 +98,25 @@ export const ScrollableMessageContainer = React.forwardRef<
     }
   }, [messagesContent, generationStage, shouldAutoscroll]);
 
-  return (
-    <div
-      ref={scrollContainerRef}
-      onScroll={handleScroll}
-      className={cn(
-        "flex-1 overflow-y-auto",
-        "[&::-webkit-scrollbar]:w-[6px]",
-        "[&::-webkit-scrollbar-thumb]:bg-muted-foreground/30",
-        "[&::-webkit-scrollbar:horizontal]:h-[4px]",
-        className,
-      )}
-      data-slot="scrollable-message-container"
-      {...props}
-    >
-      {children}
-    </div>
+  return useMemo(
+    () => (
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className={cn(
+          "flex-1 overflow-y-auto",
+          "[&::-webkit-scrollbar]:w-1.5",
+          "[&::-webkit-scrollbar-thumb]:bg-muted-foreground/30",
+          "[&::-webkit-scrollbar:horizontal]:h-1",
+          className,
+        )}
+        data-slot="scrollable-message-container"
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+    [scrollContainerRef, handleScroll, className, props, children],
   );
 });
 ScrollableMessageContainer.displayName = "ScrollableMessageContainer";


### PR DESCRIPTION
Wrap the entire JSX container in useMemo to prevent unnecessary re-renders when dependencies haven't changed.

This improves performance by avoiding recalculating the JSX tree on every render when props like className, children, or event handlers remain the same.

Related to #1706