### PR TITLE
fix: Add Tailwind v4 + Vite/Remix/Astro PostCSS toolchain support 

### DIFF
--- a/cli/src/utils/framework-detection.ts
+++ b/cli/src/utils/framework-detection.ts
@@ -54,19 +54,26 @@ const FRAMEWORKS: FrameworkDefinition[] = [
       hasPackage("next") ||
       hasAnyFile(["next.config.js", "next.config.ts", "next.config.mjs"]),
   },
-  // Future frameworks can be added here:
-  // {
-  //   name: "vite",
-  //   displayName: "Vite",
-  //   envPrefix: "VITE_",
-  //   detect: () => hasPackage("vite") || hasAnyFile(["vite.config.js", "vite.config.ts"]),
-  // },
-  // {
-  //   name: "cra",
-  //   displayName: "Create React App",
-  //   envPrefix: "REACT_APP_",
-  //   detect: () => hasPackage("react-scripts"),
-  // },
+  {
+    name: "vite",
+    displayName: "Vite",
+    envPrefix: "VITE_",
+    detect: () =>
+      hasPackage("vite") ||
+      hasAnyFile(["vite.config.js", "vite.config.ts", "vite.config.mjs"]),
+  },
+  {
+    name: "remix",
+    displayName: "Remix",
+    envPrefix: null,
+    detect: () => hasPackage("@remix-run/react"),
+  },
+  {
+    name: "astro",
+    displayName: "Astro",
+    envPrefix: null,
+    detect: () => hasPackage("astro") || hasAnyFile(["astro.config.mjs"]),
+  },
 ];
 
 /**


### PR DESCRIPTION
- Enable Vite, Remix, and Astro framework detection
- Auto-install @tailwindcss/vite plugin when Tailwind v4 is detected
- Auto-configure vite.config files with Tailwind plugin
- Fix broken styles issue in Vite projects using Tailwind v4

Resolves issue where npx tambo init/full-send would set up globals.css with v4 syntax but not configure the PostCSS toolchain needed to process it. Now automatically installs @tailwindcss/vite and updates vite.config when Tailwind v4 + Vite/Remix/Astro is detected.