### PR TITLE
fix(api): add ApiExtraModels to DTOs for OpenAPI schema generation

### DIFF
--- a/apps/api/src/v1/dto/content.dto.ts
+++ b/apps/api/src/v1/dto/content.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiSchema } from "@nestjs/swagger";
+import { ApiExtraModels, ApiProperty, ApiSchema } from "@nestjs/swagger";
 import {
   ValidateNested,
   IsBoolean,
@@ -107,6 +107,7 @@ export class V1ToolUseContentDto {
  * Tool result content block - represents the result of a tool call.
  */
 @ApiSchema({ name: "ToolResultContent" })
+@ApiExtraModels(V1TextContentDto, V1ResourceContentDto)
 export class V1ToolResultContentDto {
   @ApiProperty({
     description: "Content block type identifier",

--- a/apps/api/src/v1/dto/message.dto.ts
+++ b/apps/api/src/v1/dto/message.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiSchema } from "@nestjs/swagger";
+import { ApiExtraModels, ApiProperty, ApiSchema } from "@nestjs/swagger";
 import {
   IsString,
   IsOptional,
@@ -26,6 +26,13 @@ export type V1MessageRole = "user" | "assistant" | "system";
  * Represents a message in a thread.
  */
 @ApiSchema({ name: "Message" })
+@ApiExtraModels(
+  V1TextContentDto,
+  V1ResourceContentDto,
+  V1ToolUseContentDto,
+  V1ToolResultContentDto,
+  V1ComponentContentDto,
+)
 export class V1MessageDto {
   @ApiProperty({
     description: "Unique identifier for this message",
@@ -87,6 +94,7 @@ export type V1InputContent =
  * Only "user" role is allowed for input messages.
  */
 @ApiSchema({ name: "InputMessage" })
+@ApiExtraModels(V1TextContentDto, V1ResourceContentDto, V1ToolResultContentDto)
 export class V1InputMessageDto {
   @ApiProperty({
     description: "Message role - must be 'user' for input messages",


### PR DESCRIPTION
## Summary
- Fixed missing schema references in OpenAPI spec (`TextContent`, `ToolResultContent`, etc.)
- Added explicit `@ApiExtraModels` decorators to `V1MessageDto`, `V1InputMessageDto`, and `V1ToolResultContentDto`
- The `@ApiDiscriminatedUnion` decorator was using `@ApiExtraModels` inside `applyDecorators` on properties, but it's a class decorator and doesn't properly register schemas when applied that way

## Test plan
- [x] Regenerate OpenAPI spec and validate with external tool
- [x] Verify `TextContent` and `ToolResultContent` schemas are now included in `components/schemas`

🤖 Generated with [Claude Code](https://claude.com/claude-code)