### PR TITLE
fix(web): use typed array schema for agentHeaders in tool input

### DIFF
--- a/apps/web/lib/schemas/agent.ts
+++ b/apps/web/lib/schemas/agent.ts
@@ -7,13 +7,16 @@ import { z } from "zod/v3";
  * Used by both tRPC routers and tool definitions.
  */
 
-// Tool-compatible agent headers schema (must use object with explicit keys, not record)
-// This is a permissive schema for tool inputs; validation happens server-side
-const agentHeadersToolSchema = z
-  .unknown()
-  .describe(
-    "Custom headers for agent requests as key-value pairs (e.g., {Authorization: 'Bearer token', 'X-Custom': 'value'})",
-  );
+// Tool-compatible agent headers schema using array of key-value objects
+// Records (objects with dynamic keys) are not supported in tool schemas
+const agentHeadersToolSchema = z.array(
+  z.object({
+    name: z.string().describe("Header name (e.g., 'Authorization')"),
+    value: z.string().describe("Header value (e.g., 'Bearer token')"),
+  }),
+);
+
+export type AgentHeadersToolInput = z.infer<typeof agentHeadersToolSchema>;
 
 // Input schema for tRPC router (uses proper validation)
 export const updateProjectAgentSettingsInput = z.object({
@@ -45,7 +48,7 @@ export const updateProjectAgentSettingsInput = z.object({
     .describe("Custom headers for agent requests"),
 });
 
-// Input schema for tools (uses unknown for compatibility)
+// Input schema for tools (uses array format for headers since records are not supported)
 export const updateProjectAgentSettingsToolInput = z.object({
   projectId: z
     .string()

--- a/apps/web/lib/tambo/tools/agent-tools.ts
+++ b/apps/web/lib/tambo/tools/agent-tools.ts
@@ -1,9 +1,20 @@
 import {
-  updateProjectAgentSettingsInput as updateProjectAgentSettingsInputSchema,
+  type AgentHeadersToolInput,
   updateProjectAgentSettingsOutputSchema,
+  updateProjectAgentSettingsToolInput,
 } from "@/lib/schemas/agent";
 import { invalidateLlmSettingsCache, invalidateProjectCache } from "./helpers";
 import type { RegisterToolFn, ToolContext } from "./types";
+
+/**
+ * Converts an array of header objects to a record.
+ */
+function headersArrayToRecord(
+  headers: AgentHeadersToolInput | null | undefined,
+): Record<string, string> | null | undefined {
+  if (!headers) return headers;
+  return Object.fromEntries(headers.map(({ name, value }) => [name, value]));
+}
 
 /**
  * Register agent-specific settings management tools
@@ -36,9 +47,7 @@ export function registerAgentTools(
           agentProviderType,
           agentUrl,
           agentName,
-          // Cast from unknown (tool schema) to Record<string, string> (tRPC expects)
-          // Validation happens server-side
-          agentHeaders: agentHeaders,
+          agentHeaders: headersArrayToRecord(agentHeaders),
         });
 
       // Invalidate all caches that display agent settings (shown in LLM settings view)
@@ -50,7 +59,7 @@ export function registerAgentTools(
 
       return result;
     },
-    inputSchema: updateProjectAgentSettingsInputSchema,
+    inputSchema: updateProjectAgentSettingsToolInput,
     outputSchema: updateProjectAgentSettingsOutputSchema,
   });
 }


### PR DESCRIPTION
## Summary
- Fix `updateProjectAgentSettings` tool to use tool-compatible schema instead of tRPC schema
- Replace `z.unknown()` with typed array schema `z.array(z.object({ name, value }))` for `agentHeaders`
- Add `headersArrayToRecord()` helper to convert array format to record for tRPC

## Why
The react-sdk now validates that tool input schemas don't contain record types (objects with dynamic keys like `z.record()`). The `updateProjectAgentSettings` tool was importing the tRPC schema which uses `agentHeadersSchema` (a record type), causing a runtime error:

```
Record types (objects with dynamic keys) are not supported in inputSchema of tool "updateProjectAgentSettings"
```

## Test Plan
- [x] Run `npm run dev:cloud` and load the homepage
- [x] Verify no runtime errors about record types in tool schemas
- [x] Test updating agent settings via the Tambo assistant to confirm the tool still works