### PR TITLE
chore(eslint): ignore community templates directory

### DIFF
--- a/packages/eslint-config/base.mjs
+++ b/packages/eslint-config/base.mjs
@@ -58,5 +58,5 @@ export default defineConfig([
       },
     },
   },
-  globalIgnores(["examples/**"]),
+  globalIgnores(["examples/**", "community/templates/**"]),
 ]);


### PR DESCRIPTION
## Summary
- Add `community/templates/**` to ESLint global ignores

## Why
Templates in `community/templates/` are standalone Next.js projects meant to be cloned and used independently. They should not be linted by the monorepo's ESLint configuration.

The monorepo's ESLint config has `allowDefaultProject: ["*.mjs"]` which only matches root-level `.mjs` files. When adding a new template with its own `eslint.config.mjs` and `postcss.config.mjs`, the pre-commit hook fails because TypeScript's project service can't find these nested files.

## Test Plan
- [x] Create or modify files in `community/templates/` and verify `git commit` succeeds without ESLint parsing errors