### PR TITLE
chore(ci): fix release-please config

### DIFF
--- a/.github/workflows/release-please-sync-lockfile.yml
+++ b/.github/workflows/release-please-sync-lockfile.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   sync-lockfile:
     # Only run on PRs from release-please bot with "autorelease: pending" label
-    if: "${{ contains(github.event.pull_request.labels.*.name, 'autorelease: pending') && github.actor == 'release-please[bot]' }}"
+    if: "${{ contains(github.event.pull_request.labels.*.name, 'autorelease: pending') && github.actor == 'tambo-bot' }}"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -58,8 +58,8 @@ jobs:
       - name: Commit lockfile changes
         if: steps.check.outputs.changed == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "tambo-bot"
+          git config user.email "bots@tambo.co"
           git add package-lock.json
           git commit -m "chore: sync package-lock.json"
           git push origin "HEAD:${{ github.head_ref }}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,12 +5,7 @@
   "always-update": true,
   "bootstrap-sha": "afad6013a55f7614de2c2e5c9b090d271e821e01",
   "commit-search-depth": 50,
-  "plugins": [
-    {
-      "type": "node-workspace",
-      "updatePeerDependencies": true
-    }
-  ],
+  "plugins": ["node-workspace"],
   "packages": {
     "react-sdk": {
       "component": "react"


### PR DESCRIPTION
## Changes

1. Change the sync check to look for `tambo-bot` instead of `release-please[bot]`
2. Use the default `node-workspace` plugin configuration
	If this doesn't work, I'll just ditch the plugin and go back to the previous config.