### PR TITLE
fix(api): remove inline oneOf schema from component state endpoint

### DIFF
--- a/apps/api/src/v1/v1.controller.ts
+++ b/apps/api/src/v1/v1.controller.ts
@@ -15,15 +15,12 @@ import {
   UseGuards,
 } from "@nestjs/common";
 import {
-  ApiBody,
-  ApiExtraModels,
   ApiOperation,
   ApiParam,
   ApiProduces,
   ApiResponse,
   ApiSecurity,
   ApiTags,
-  getSchemaPath,
 } from "@nestjs/swagger";
 import { Request, Response } from "express";
 import { extractContextInfo } from "../common/utils/extract-context-info";
@@ -41,7 +38,6 @@ import {
   V1CreateThreadWithRunDto,
 } from "./dto/run.dto";
 import {
-  JsonPatchOperationDto,
   UpdateComponentStateDto,
   UpdateComponentStateResponseDto,
 } from "./dto/component-state.dto";
@@ -500,34 +496,6 @@ export class V1Controller {
 
   @Post("threads/:threadId/components/:componentId/state")
   @UseGuards(ThreadInProjectGuard)
-  @ApiExtraModels(JsonPatchOperationDto)
-  @ApiBody({
-    schema: {
-      oneOf: [
-        {
-          type: "object",
-          required: ["state"],
-          properties: {
-            state: {
-              type: "object",
-              additionalProperties: true,
-            },
-          },
-        },
-        {
-          type: "object",
-          required: ["patch"],
-          properties: {
-            patch: {
-              type: "array",
-              minItems: 1,
-              items: { $ref: getSchemaPath(JsonPatchOperationDto) },
-            },
-          },
-        },
-      ],
-    },
-  })
   @ApiOperation({
     summary: "Update component state",
     description:


### PR DESCRIPTION
## Summary
- Remove `@ApiBody` decorator with inline `oneOf` schema from the `updateComponentState` endpoint
- Schema is now inferred from `UpdateComponentStateDto` class
- Fixes OpenAPI spec validator warning about non-object request bodies causing generic "body" parameter names in generated code

## Details
The endpoint at `/v1/threads/{threadId}/components/{componentId}/state` had both a DTO type and an inline `@ApiBody` schema with `oneOf` to express that either `state` or `patch` must be provided. The `oneOf` at the top level isn't a simple object type, causing OpenAPI code generators to use a generic "body" parameter name.

The mutual exclusivity constraint is still enforced at runtime by the service (v1.service.ts).

## Test plan
- [ ] Verify OpenAPI spec no longer triggers the warning
- [ ] Verify generated client code uses appropriate parameter names
- [ ] Verify runtime validation still rejects requests with both/neither state and patch

🤖 Generated with [Claude Code](https://claude.ai/code)