### PR TITLE
fix(web): store Google auth name and image in user metadata

### DIFF
--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -3,7 +3,7 @@ import { DefaultSession } from "next-auth";
 declare module "next-auth" {
   interface User {
     id: string;
-    idToken: string;
+    idToken?: string;
   }
   interface Session extends DefaultSession {
     user: DefaultSession["user"] & {


### PR DESCRIPTION
## Summary
- Add explicit profile callback to Google provider to ensure name and image are properly mapped from the OAuth response
- Fix `createUser` in the adapter to store both name and image (as `avatar_url`) in `raw_user_meta_data`
- Fix `updateUser` to preserve existing metadata using atomic JSONB merge instead of overwriting
- Skip unnecessary DB writes when no metadata or email updates are provided
- Make `User.idToken` optional since profile callback doesn't have access to it

## Why
We need access to Google user names for downstream workflows and integrations. Unlike GitHub (which has a public API to fetch user data from provider ID), Google doesn't expose a public endpoint for this. The `access_token` expires in 1 hour, so it can't be used for historical records. The name data exists in the `id_token` JWT stored in `identities.identity_data`, but many external tools don't support JWT decoding.

Rather than requiring external tooling to parse JWTs, this should be handled at the source: store the name fields from Google's profile response directly in `auth.users.raw_user_meta_data` during login.

## What this means for users
- **New users**: Name and avatar are stored in `auth.users.raw_user_meta_data` on first login
- **Existing users who log in again**: Name and avatar get populated on next login
- **Existing users who never log in again**: Would need a one-time backfill migration (data exists in `identities.identity_data.id_token`)

## Problem
The name from Google OAuth wasn't being reliably stored because:
1. No explicit profile callback meant relying on NextAuth defaults
2. `createUser` only stored `name`, not `image`
3. `updateUser` would overwrite all metadata with an empty object if name wasn't provided in the update

## Test plan
- [ ] Sign in with Google and verify `name` is stored in `auth.users.raw_user_meta_data`
- [ ] Verify `avatar_url` is also stored in the same metadata
- [ ] Verify subsequent logins don't wipe the existing metadata
- [ ] Verify no unnecessary DB writes occur when updateUser is called without changes