### PR TITLE
docs(api): clarify userKey description in V1 API DTOs

### DIFF
--- a/apps/api/src/v1/dto/run.dto.ts
+++ b/apps/api/src/v1/dto/run.dto.ts
@@ -32,7 +32,8 @@ export class V1CreateRunDto {
   message!: V1InputMessageDto;
 
   @ApiProperty({
-    description: "Optional user key for thread organization",
+    description:
+      "Identifier for a user in your system. Required if no bearer token is provided.",
     required: false,
   })
   @IsOptional()

--- a/apps/api/src/v1/dto/thread.dto.ts
+++ b/apps/api/src/v1/dto/thread.dto.ts
@@ -184,7 +184,8 @@ export class V1ThreadWithMessagesDto extends V1ThreadDto {
 @ApiSchema({ name: "CreateThreadRequest" })
 export class V1CreateThreadDto {
   @ApiProperty({
-    description: "Optional user key for thread organization",
+    description:
+      "Identifier for a user in your system. Required if no bearer token is provided.",
     required: false,
   })
   @IsOptional()


### PR DESCRIPTION
## Summary
- Updates the `userKey` field description in V1 API request DTOs to clarify its purpose
- Specifies that `userKey` is an identifier for a user in the caller's system
- Notes that it is required when no bearer token is provided

## Test plan
- [x] Verified type checking passes
- [ ] Check OpenAPI spec reflects updated descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)