### PR TITLE
docs(readme): Readme refresh with new tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/octo-white-background-rounded.png" width="150">
   <h1>Tambo AI</h1>
   <h3>Build agents that speak your UI</h3>
-  <p>An open-source generative UI toolkit for React. Connect your components—Tambo handles streaming, state management, and MCP.</p>
+  <p>The open-source generative UI toolkit for React. Connect your components—Tambo handles streaming, state management, and MCP.</p>
 </div>
 
 <p align="center">


### PR DESCRIPTION
Here's a summary of what was changed:

- [X] Added a ToC (although it's a bit long - I'd recommend cutting Pricing at the minimum to save 3 lines)
- [X] Reworked What is Tambo to be clearer w/ new tagline + value props
- [X] Reordered How it Works and removed two of the videos - it felt like they were getting in the way of progressing down the page
- [x] Before merging, I'll change all signup links to shortlinks

@michaelmagan lmk your thoughts!