### PR TITLE
ci: adjust release-please setting for dependencies

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/refs/heads/main/schemas/config.json",
-  "always-link-local": true,
+  "always-link-local": false,
   "separate-pull-requests": true,
   "always-update": true,
   "bootstrap-sha": "afad6013a55f7614de2c2e5c9b090d271e821e01",


### PR DESCRIPTION
Adjust the `always-link-local` setting to prevent local, unreleased changes from affecting dependent project versions.