### PR TITLE
fix: prevent duplicate headers and resolve Windows setup blockers

### DIFF
--- a/apps/web/lib/schemas/agent.ts
+++ b/apps/web/lib/schemas/agent.ts
@@ -9,12 +9,23 @@ import { z } from "zod/v3";
 
 // Tool-compatible agent headers schema using array of key-value objects
 // Records (objects with dynamic keys) are not supported in tool schemas
-const agentHeadersToolSchema = z.array(
-  z.object({
-    name: z.string().describe("Header name (e.g., 'Authorization')"),
-    value: z.string().describe("Header value (e.g., 'Bearer token')"),
-  }),
-);
+const agentHeadersToolSchema = z
+  .array(
+    z.object({
+      name: z.string().describe("Header name (e.g., 'Authorization')"),
+      value: z.string().describe("Header value (e.g., 'Bearer token')"),
+    }),
+  )
+  // REFINE BLOCK TO PREVENT DUPLICATES
+  .refine(
+    (items) => {
+      const keys = items.map((i) => i.name);
+      return new Set(keys).size === keys.length;
+    },
+    {
+      message: "Duplicate header names are not allowed",
+    },
+  );
 
 export type AgentHeadersToolInput = z.infer<typeof agentHeadersToolSchema>;
 


### PR DESCRIPTION
**Summary**
This PR is a follow-up to the conversation in issue #1917. As discussed with @lachieh, the current implementation of headersArrayToRecord (added in #1957) allows duplicate header names where the "last one wins," potentially leading to silent data loss or unexpected API behavior.

**1. Feature: Unique Header Validation**

- Added a Zod refinement to the Agent Header schema in apps/web/lib/schemas/agent.ts.
- Users are now prevented from entering duplicate header names at the schema level, ensuring the Object.fromEntries conversion remains predictable and safe.

**2. Fix: Windows Development Environment & Dependencies**

- To test and build these changes on Windows, several environment blockers were resolved:
- Windows Script Support: Integrated cross-env into apps/api and apps/web scripts to handle NODE_OPTIONS and SKIP_ENV_VALIDATION.
- Dependency Resolution: Fixed a Mastra type conflict via dependency deduplication and added missing valibot dependency required by the React SDK.


**Test & Quality Check**

- Verified that npm run dev:cloud now starts correctly on Windows.
- Passed check-types and lint specifically for the @tambo-ai-cloud/web package.
- Note on failing checks: I observed pre-existing type errors in the tambo (CLI) tests and thread-in-project-guard.ts in the API. I verified these failures persist on the main branch and are unrelated to the changes in this PR.

**Final update**: I have added cross-env to the ui-registry and tambo CLI test scripts to ensure they can run on Windows. I've verified that the React SDK tests pass (927/927) and the API build is now successful. The remaining failures in the CLI tests are pre-existing issues found on the main branch.