### PR TITLE
fix(docs): update broken documentation links 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ const InteractableNote = withInteractable(Note, {
 });
 ```
 
-Docs: [generative components](https://docs.tambo.co/concepts/components/defining-tambo-components), [interactable components](https://docs.tambo.co/concepts/components/interactable-components)
+Docs: [generative components](https://docs.tambo.co/concepts/generative-interfaces/generative-components), [interactable components](https://docs.tambo.co/concepts/generative-interfaces/interactable-components)
 
 ### The Provider
 
@@ -127,7 +127,7 @@ Wrap your app with `TamboProvider`.
 
 For apps with signed-in users, pass a per-user `userToken` (OAuth access token) to `TamboProvider` to enable per-user auth and connect Tambo to your app's end-user identity. See [User Authentication](https://docs.tambo.co/concepts/user-authentication) for details.
 
-Docs: [provider options](https://docs.tambo.co/api-reference/tambo-provider)
+Docs: [provider options](https://docs.tambo.co/reference/react-sdk/providers)
 
 ### Hooks
 
@@ -170,7 +170,7 @@ if (!streamStatus.isSuccess) return <Spinner />;
 }
 ```
 
-Docs: [threads and messages](https://docs.tambo.co/concepts/message-threads), [streaming status](https://docs.tambo.co/concepts/streaming/component-streaming-status)
+Docs: [threads and messages](https://docs.tambo.co/concepts/conversation-storage), [streaming status](https://docs.tambo.co/concepts/generative-interfaces/component-state)
 
 <p align="center">
   <a href="https://docs.tambo.co/getting-started/quickstart">Full tutorial</a>
@@ -233,7 +233,7 @@ const tools: TamboTool[] = [
 </TamboProvider>;
 ```
 
-Docs: [local tools](https://docs.tambo.co/concepts/tools/adding-tools)
+Docs: [local tools](https://docs.tambo.co/guides/take-actions/register-tools)
 
 ### Context, Auth, and Suggestions
 
@@ -266,7 +266,7 @@ Docs: [additional context](https://docs.tambo.co/concepts/additional-context), [
 
 ### Supported LLM Providers
 
-OpenAI, Anthropic, Cerebras, Google Gemini, Mistral, and any OpenAI-compatible provider. [Full list](https://docs.tambo.co/models). Missing one? [Let us know](https://github.com/tambo-ai/tambo/issues).
+OpenAI, Anthropic, Cerebras, Google Gemini, Mistral, and any OpenAI-compatible provider. [Full list](https://docs.tambo.co/reference/llm-providers). Missing one? [Let us know](https://github.com/tambo-ai/tambo/issues).
 
 ## How Tambo Compares
 

--- a/react-sdk/README.md
+++ b/react-sdk/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="https://docs.tambo.co">Documentation</a> •
-  <a href="https://docs.tambo.co/api-reference">API Reference</a> •
+  <a href="https://docs.tambo.co/reference/react-sdk">API Reference</a> •
   <a href="https://discord.gg/dJNvPEHth6">Discord</a>
 </p>
 
@@ -159,7 +159,7 @@ const components: TamboComponent[] = [
 ];
 ```
 
-[→ Learn more about components](https://docs.tambo.co/concepts/components)
+[→ Learn more about components](https://docs.tambo.co/concepts/generative-interfaces)
 
 ### Provider Setup
 
@@ -176,7 +176,7 @@ Wrap your app with `TamboProvider` to enable AI capabilities:
 </TamboProvider>
 ```
 
-[→ See all provider options](https://docs.tambo.co/api-reference/tambo-provider)
+[→ See all provider options](https://docs.tambo.co/reference/react-sdk/providers)
 
 ### Hooks
 
@@ -189,7 +189,7 @@ Wrap your app with `TamboProvider` to enable AI capabilities:
 | `useTamboStreamStatus()`   | Monitor streaming status for progressive loading   |
 | `useTamboSuggestions()`    | Generate contextual suggestions                    |
 
-[→ API Reference](https://docs.tambo.co/api-reference)
+[→ API Reference](https://docs.tambo.co/reference/react-sdk)
 
 ## Key Features
 
@@ -211,7 +211,7 @@ const components: TamboComponent[] = [
 ];
 ```
 
-[→ Learn more about components](https://docs.tambo.co/concepts/components)
+[→ Learn more about components](https://docs.tambo.co/concepts/generative-interfaces)
 
 ### Interactable Components
 
@@ -234,7 +234,7 @@ const InteractableNote = withInteractable(Note, {
 <InteractableNote id="note-1" title="My Note" content="Content here" />;
 ```
 
-[→ Learn more about interactable components](https://docs.tambo.co/concepts/components/interactable-components)
+[→ Learn more about interactable components](https://docs.tambo.co/concepts/generative-interfaces/interactable-components)
 
 ### MCP Integration
 
@@ -298,7 +298,7 @@ const tools = [
 </TamboProvider>;
 ```
 
-[→ Learn more about tools](https://docs.tambo.co/concepts/tools/adding-tools)
+[→ Learn more about tools](https://docs.tambo.co/guides/take-actions/register-tools)
 
 #### Advanced: Transforming Tool Responses
 
@@ -426,7 +426,7 @@ registerResourceSource({
 
 Local resources appear in `useTamboMcpResourceList()` alongside MCP resources, with MCP resources always prefixed by their serverKey.
 
-[→ Learn more about resources](https://docs.tambo.co/concepts/resources)
+[→ Learn more about resources](https://docs.tambo.co/concepts/model-context-protocol/features#resources)
 
 ### Streaming Status
 
@@ -451,7 +451,7 @@ function LoadingComponent({ title, data }) {
 }
 ```
 
-[→ Learn more about streaming](https://docs.tambo.co/concepts/streaming/component-streaming-status)
+[→ Learn more about streaming](https://docs.tambo.co/concepts/generative-interfaces/component-state)
 
 ### Context, Auth, and Suggestions
 
@@ -484,7 +484,7 @@ suggestions.map((s) => (
 
 ### Supported LLM Providers
 
-OpenAI, Anthropic, Google Gemini, Mistral, Groq, and any OpenAI-compatible provider. [Full list](https://docs.tambo.co/models). Missing one? [Let us know](https://github.com/tambo-ai/tambo/issues).
+OpenAI, Anthropic, Google Gemini, Mistral, Groq, and any OpenAI-compatible provider. [Full list](https://docs.tambo.co/reference/llm-providers). Missing one? [Let us know](https://github.com/tambo-ai/tambo/issues).
 
 ## When to Use This SDK
 
@@ -519,8 +519,8 @@ TypeScript definitions included for both outputs.
 
 - [Full Documentation](https://docs.tambo.co)
 - [Getting Started Guide](https://docs.tambo.co/getting-started/quickstart)
-- [API Reference](https://docs.tambo.co/api-reference)
-- [Component Guides](https://docs.tambo.co/concepts/components)
+- [API Reference](https://docs.tambo.co/reference/react-sdk)
+- [Component Guides](https://docs.tambo.co/concepts/generative-interfaces)
 - [UI Library](https://ui.tambo.co)
 
 ## License

--- a/react-sdk/src/hooks/use-component-state.tsx
+++ b/react-sdk/src/hooks/use-component-state.tsx
@@ -31,7 +31,7 @@ type StateUpdateResult<T> = [currentState: T, setState: (newState: T) => void];
  * user edits take precedence over the original prop value.
  *
  * Pair with `useTamboStreamStatus` to disable inputs while streaming.
- * @see {@link https://docs.tambo.co/concepts/streaming/streaming-best-practices}
+ * @see {@link https://docs.tambo.co/concepts/generative-interfaces/component-state}
  */
 export function useTamboComponentState<S = undefined>(
   keyName: string,

--- a/react-sdk/src/hooks/use-streaming-props.tsx
+++ b/react-sdk/src/hooks/use-streaming-props.tsx
@@ -6,7 +6,7 @@ import { useEffect } from "react";
  * Low-level helper that merges streamed props into state.
  * @deprecated Use `useTamboComponentState` with `setFromProp` instead.
  * This hook will be removed in 1.0.0.
- * @see {@link https://docs.tambo.co/concepts/streaming/streaming-props}
+ * @see {@link https://docs.tambo.co/concepts/generative-interfaces/component-state}
  * @param currentState - Current state object
  * @param setState - State setter function
  * @param streamingProps - Props to merge into state when they change

--- a/react-sdk/src/hooks/use-tambo-stream-status.tsx
+++ b/react-sdk/src/hooks/use-tambo-stream-status.tsx
@@ -298,7 +298,7 @@ function deriveGlobalStreamStatus<Props extends Record<string, any>>(
  * Use `propStatus.<field>?.isSuccess` before treating a prop as complete.
  *
  * Pair with `useTamboComponentState` to disable inputs while streaming.
- * @see {@link https://docs.tambo.co/concepts/streaming/streaming-best-practices}
+ * @see {@link https://docs.tambo.co/concepts/generative-interfaces/component-state}
  * @template Props - Component props type
  * @returns `streamStatus` (overall) and `propStatus` (per-prop) flags
  * @throws {Error} When used during SSR/SSG

--- a/showcase/src/app/components/(message-primitives)/elicitation/page.tsx
+++ b/showcase/src/app/components/(message-primitives)/elicitation/page.tsx
@@ -269,7 +269,7 @@ export default function ElicitationPage() {
             from MCP servers. For detailed information about elicitation in MCP,
             see the{" "}
             <a
-              href="https://docs.tambo.co/concepts/model-context-protocol/features/elicitation"
+              href="https://docs.tambo.co/concepts/model-context-protocol/features#elicitations"
               className="text-primary-link hover:underline"
             >
               elicitation documentation


### PR DESCRIPTION
Updates some broken links pointing to removed docs.

Fixes: https://github.com/tambo-ai/tambo/issues/2130