### PR TITLE
fix(showcase): remove console.log debug statements from template

### DIFF
--- a/showcase/src/app/template.tsx
+++ b/showcase/src/app/template.tsx
@@ -46,7 +46,6 @@ export default function Template({
                   ]}
                   contextKey={userContextKey}
                   listResources={async (search = "X") => {
-                    console.log("listResources", search);
                     return [
                       {
                         uri: `generic-registry-resource/${search}`,
@@ -57,7 +56,6 @@ export default function Template({
                     ];
                   }}
                   getResource={async (uri) => {
-                    console.log("getResource", uri);
                     return {
                       contents: [
                         {


### PR DESCRIPTION
## Summary
Removes two debug `console.log()` statements from the showcase template that were polluting the browser console with unnecessary output.

## Changes
- Removed `console.log("listResources", search)` from line 49
- Removed `console.log("getResource", uri)` from line 60

## Verification
- ✅ Code follows project ESLint standards
- ✅ Showcase functionality unchanged
- ✅ Fixes #2144

## Testing
The showcase app should work identically - the console.log statements only affected output, not behavior.