### PR TITLE
fix(ci): workflow check was allowing failed jobs to pass

### DIFF
--- a/.github/workflows/workflow-check.yml
+++ b/.github/workflows/workflow-check.yml
@@ -27,23 +27,18 @@ jobs:
         shell: bash
         run: | # shell
           # Job Result
-          RESULT='success'
+          # `jq` is pre-installed on GitHub-hosted runners   
+          JOBS=$(jq -c '.[]' <<< "$JSON_NEEDS")
 
-          # `jq` is pre-installed on GitHub-hosted runners
-          jq -c '.[]' <<< "$JSON_NEEDS" | while read -r need; do
-            JOB_NAME=$(jq -r '.job_name' <<< "$need")
-            JOB_RESULT=$(jq -r '.result' <<< "$need")
-
-            # all needs results must be 'success' or 'skipped' for the overall result to be 'success'
+          while read -r job; do
+            JOB_RESULT=$(jq -r '.result' <<< "$job")
+            
+            # Fail immediately if any job is not 'success' or 'skipped'
             if [[ $JOB_RESULT != 'success' && $JOB_RESULT != 'skipped' ]]; then
-              RESULT='failure'
-              break
+              echo "::error title=Condition Failed::${ERROR_MESSAGE}"
+              exit 1
             fi
-          done
+          done <<< "$JOBS"
 
-          if [[ $RESULT == 'failure' ]]; then
-            echo "::error title=Condition Failed::${ERROR_MESSAGE}"
-            exit 1
-          else
-            exit 0
-          fi
+          # All jobs passed
+          exit 0


### PR DESCRIPTION
## Summary

- Fixed bug where workflow check job would pass even when dependent jobs failed
- The `while` loop was running in a subshell due to piping (`jq | while`), causing variable changes to be lost
- Simplified logic to store jq output in a variable first and fail immediately on any non-success/skipped result

## Test plan

- [x] Tested locally with sample JSON input containing a failed job - correctly exits 1
- [x] Verify in CI that failed jobs now properly fail the check

#### Result when cancelled/failed
<img width="1325" height="928" alt="Screenshot 2026-02-03 at 5 36 11 PM" src="https://github.com/user-attachments/assets/7d60efb4-f897-4758-b29d-3d3679012c06" />

#### Result when successful
<img width="1360" height="860" alt="Screenshot 2026-02-03 at 5 38 35 PM" src="https://github.com/user-attachments/assets/3eeffd48-db7a-4385-8d3d-2b1afe152bc5" />

