### PR TITLE
fix(react-sdk): add .js extensions to ESM output for strict ESM compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21144,6 +21144,16 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
+    "node_modules/@topoconfig/extends": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@topoconfig/extends/-/extends-0.16.2.tgz",
+      "integrity": "sha512-sTF+qpWakr5jf1Hn/kkFSi833xPW15s/loMAiKSYSSVv4vDonxf6hwCGzMXjLq+7HZoaK6BgaV72wXr1eY7FcQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "xtends": "target/esm/cli.mjs"
+      }
+    },
     "node_modules/@trpc/client": {
       "version": "11.9.0",
       "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.9.0.tgz",
@@ -26175,6 +26185,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/depseek": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/depseek/-/depseek-0.4.3.tgz",
+      "integrity": "sha512-0Ex/Uoz9Y9oipbqvgSc7FoV2q4GTDGORkg8TGgM9Pd3RyvRzrDYScKplWiqHU7WqckbKN5kukqD0opEayu2bXg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -43186,6 +43203,72 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/tsc-esm-fix": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tsc-esm-fix/-/tsc-esm-fix-3.1.2.tgz",
+      "integrity": "sha512-1/OpZssMcEp2ae6DyZV+yvDviofuCdDf7dEWEaBvm/ac8vtS04lFyl0LVs8LQE56vjKHytgzVjPIL9udM4QuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@topoconfig/extends": "^0.16.2",
+        "depseek": "^0.4.1",
+        "fast-glob": "^3.3.2",
+        "fs-extra": "^11.2.0",
+        "json5": "^2.2.3",
+        "type-flag": "^3.0.0"
+      },
+      "bin": {
+        "tsc-esm-fix": "target/esm/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/tsc-esm-fix/node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/tsc-esm-fix/node_modules/fs-extra": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tsc-esm-fix/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -43976,6 +44059,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/type-flag/-/type-flag-3.0.0.tgz",
+      "integrity": "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/type-flag?sponsor=1"
       }
     },
     "node_modules/type-is": {
@@ -45999,6 +46092,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "ts-jest": "^29.4.6",
+        "tsc-esm-fix": "^3.1.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.54.0",
         "zod": "^3.25.76 || ^4",

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:esm": "tsc -p tsconfig.esm.json && tsc-esm-fix --target=esm",
     "check-types": "tsc --noEmit",
     "dev": "concurrently \"npm run dev:cjs\" \"npm run dev:esm\"",
     "dev:cjs": "tsc -p tsconfig.cjs.json --watch",
@@ -122,6 +122,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "ts-jest": "^29.4.6",
+    "tsc-esm-fix": "^3.1.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
     "zod": "^3.25.76 || ^4",


### PR DESCRIPTION
## Summary
- Add `tsc-esm-fix` as dev dependency to automatically add `.js` extensions to ESM output
- Update `build:esm` script to run `tsc-esm-fix` after `tsc`

This fixes compatibility with strict ESM environments like Astro SSR and Node.js ESM mode. Source files remain unchanged - only the compiled ESM output gets the extensions added.

## Test plan
- [x] All 990 tests pass
- [x] ESM output has `.js` extensions on all relative imports
- [ ] Test in Astro SSR environment

Fixes TAM-1025