### PR TITLE
feat(docs): add SEO and GEO optimization

### DIFF
--- a/docs/next-sitemap.config.js
+++ b/docs/next-sitemap.config.js
@@ -109,16 +109,35 @@ const enumerated = enumerateRoutes();
 module.exports = {
   siteUrl,
   generateRobotsTxt: false,
-  exclude: ["/_next/*", "/api/*"],
+  // Exclude non-page routes and duplicates
+  exclude: [
+    "/_next/*",
+    "/api/*",
+    "/llms.txt",
+    "/llms-full.txt",
+    "/robots.txt",
+    "/llms.mdx",
+    "/llms.mdx/*",
+  ],
   changefreq: "weekly",
   priority: 0.8,
   transform: async (config, path) => {
+    // Skip paths that shouldn't be in sitemap
+    if (
+      path.includes("/llms.mdx") ||
+      path === "/llms.txt" ||
+      path === "/llms-full.txt" ||
+      path === "/robots.txt"
+    ) {
+      return null;
+    }
     const found = enumerated.find((e) => e.url === path);
     return {
       loc: `${siteUrl}${path}`,
       changefreq: "weekly",
       priority: path === "/" ? 1.0 : 0.8,
-      lastmod: found?.lastmod ?? new Date(0).toISOString(),
+      // Use current date as fallback instead of epoch
+      lastmod: found?.lastmod ?? new Date().toISOString(),
       alternateRefs: [],
     };
   },

--- a/docs/next-sitemap.config.js
+++ b/docs/next-sitemap.config.js
@@ -109,6 +109,8 @@ const excludedSitemapExactPathList = [
   "/llms.txt",
   "/llms-full.txt",
   "/robots.txt",
+  // We use `/llms.mdx/*` as a routable prefix via `next.config.mjs` rewrites.
+  // It serves a Markdown rendering of pages and should not be indexed.
   "/llms.mdx",
 ];
 
@@ -122,7 +124,12 @@ const excludedSitemapGlobs = [
 const excludedSitemapExactPaths = new Set(excludedSitemapExactPathList);
 
 const isExcludedSitemapPath = (path) =>
-  excludedSitemapExactPaths.has(path) || path.startsWith("/llms.mdx/");
+  excludedSitemapExactPaths.has(path) ||
+  path.startsWith("/llms.mdx/") ||
+  path.startsWith("/_next/") ||
+  path === "/_next" ||
+  path.startsWith("/api/") ||
+  path === "/api";
 
 // Enumerate routes once at config load for deterministic, build-time-only sitemap generation
 const enumerated = enumerateRoutes();

--- a/docs/next-sitemap.config.js
+++ b/docs/next-sitemap.config.js
@@ -104,12 +104,27 @@ function enumerateRoutes() {
     .map(([url, lastmod]) => ({ url, lastmod }));
 }
 
-const excludedPaths = new Set(["/llms.txt", "/llms-full.txt", "/robots.txt"]);
-const isExcludedSitemapPath = (path) =>
-  excludedPaths.has(path) ||
-  path === "/llms.mdx" ||
-  path.startsWith("/llms.mdx/");
+const excludedSitemapGlobs = [
+  "/_next/*",
+  "/api/*",
+  "/llms.txt",
+  "/llms-full.txt",
+  "/robots.txt",
+  "/llms.mdx",
+  "/llms.mdx/*",
+];
 
+const excludedSitemapExactPaths = new Set([
+  "/llms.txt",
+  "/llms-full.txt",
+  "/robots.txt",
+  "/llms.mdx",
+]);
+
+const isExcludedSitemapPath = (path) =>
+  excludedSitemapExactPaths.has(path) || path.startsWith("/llms.mdx/");
+
+// Enumerate routes once at config load for deterministic, build-time-only sitemap generation
 const enumerated = enumerateRoutes();
 const enumeratedByUrl = new Map(enumerated.map((e) => [e.url, e.lastmod]));
 
@@ -117,15 +132,7 @@ module.exports = {
   siteUrl,
   generateRobotsTxt: false,
   // Exclude non-page routes and duplicates
-  exclude: [
-    "/_next/*",
-    "/api/*",
-    "/llms.txt",
-    "/llms-full.txt",
-    "/robots.txt",
-    "/llms.mdx",
-    "/llms.mdx/*",
-  ],
+  exclude: excludedSitemapGlobs,
   changefreq: "weekly",
   priority: 0.8,
   transform: async (_config, path) => {

--- a/docs/next-sitemap.config.js
+++ b/docs/next-sitemap.config.js
@@ -60,7 +60,7 @@ function getLastModForFile(filePath) {
     const stats = statSync(filePath);
     return stats.mtime.toISOString();
   } catch {
-    return;
+    return undefined;
   }
 }
 
@@ -104,22 +104,21 @@ function enumerateRoutes() {
     .map(([url, lastmod]) => ({ url, lastmod }));
 }
 
-const excludedSitemapGlobs = [
-  "/_next/*",
-  "/api/*",
+const excludedSitemapExactPathList = [
   "/llms.txt",
   "/llms-full.txt",
   "/robots.txt",
   "/llms.mdx",
-  "/llms.mdx/*",
 ];
 
-const excludedSitemapExactPaths = new Set([
-  "/llms.txt",
-  "/llms-full.txt",
-  "/robots.txt",
-  "/llms.mdx",
-]);
+const excludedSitemapGlobPatterns = ["/_next/*", "/api/*", "/llms.mdx/*"];
+
+const excludedSitemapGlobs = [
+  ...excludedSitemapGlobPatterns,
+  ...excludedSitemapExactPathList,
+];
+
+const excludedSitemapExactPaths = new Set(excludedSitemapExactPathList);
 
 const isExcludedSitemapPath = (path) =>
   excludedSitemapExactPaths.has(path) || path.startsWith("/llms.mdx/");

--- a/docs/next-sitemap.config.js
+++ b/docs/next-sitemap.config.js
@@ -60,6 +60,7 @@ function getLastModForFile(filePath) {
     const stats = statSync(filePath);
     return stats.mtime.toISOString();
   } catch {
+    // Intentionally omit `lastmod` when we can't determine a stable value.
     return undefined;
   }
 }
@@ -144,7 +145,7 @@ module.exports = {
       loc: `${siteUrl}${path}`,
       changefreq: "weekly",
       priority: path === "/" ? 1.0 : 0.8,
-      ...(lastmod ? { lastmod } : {}),
+      ...(lastmod != null ? { lastmod } : {}),
       alternateRefs: [],
     };
   },
@@ -154,7 +155,7 @@ module.exports = {
       .filter((e) => !isExcludedSitemapPath(e.url))
       .map((e) => ({
         loc: `${siteUrl}${e.url}`,
-        ...(e.lastmod ? { lastmod: e.lastmod } : {}),
+        ...(e.lastmod != null ? { lastmod: e.lastmod } : {}),
       })),
   // include ensures index and known root routes are emitted
   include: enumerated

--- a/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -11,10 +11,21 @@ import {
   DocsPage,
   DocsTitle,
 } from "fumadocs-ui/page";
+import { statSync } from "node:fs";
+import { join } from "node:path";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
+
+const getDocPageLastModified = (contentPath: string): string | undefined => {
+  try {
+    const filePath = join(process.cwd(), "content", "docs", contentPath);
+    return statSync(filePath).mtime.toISOString();
+  } catch {
+    return;
+  }
+};
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -31,6 +42,7 @@ export default async function Page(props: {
     title: page.data.title,
     description: page.data.description ?? "",
     url: `${siteUrl}${page.url}`,
+    dateModified: getDocPageLastModified(page.path),
   });
 
   return (
@@ -81,7 +93,7 @@ export async function generateMetadata(props: {
     title: page.data.title,
     description: page.data.description,
     alternates: {
-      canonical: page.url,
+      canonical: pageUrl,
     },
     openGraph: {
       title: page.data.title,

--- a/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -18,11 +18,20 @@ import { Suspense } from "react";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
 
+const docLastModifiedCache = new Map<string, string | undefined>();
+
 const getDocPageLastModified = (contentPath: string): string | undefined => {
+  if (docLastModifiedCache.has(contentPath)) {
+    return docLastModifiedCache.get(contentPath);
+  }
+
   try {
     const filePath = join(process.cwd(), "content", "docs", contentPath);
-    return statSync(filePath).mtime.toISOString();
+    const lastModified = statSync(filePath).mtime.toISOString();
+    docLastModifiedCache.set(contentPath, lastModified);
+    return lastModified;
   } catch {
+    docLastModifiedCache.set(contentPath, undefined);
     return;
   }
 };

--- a/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -20,6 +20,8 @@ const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
 
 export const runtime = "nodejs";
 
+// Best-effort cache (per Node.js process) to avoid re-statting the same MDX file.
+// This is used only for structured data metadata and doesn't need to be real-time.
 const docLastModifiedCache = new Map<string, string>();
 
 const getDocPageLastModified = (contentPath: string): string | undefined => {

--- a/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -1,4 +1,5 @@
 import { LLMCopyButton, OpenDropdown } from "@/components/ai-actions";
+import { createDocPageSchema, PageJsonLd } from "@/components/json-ld";
 import { MessageThreadCollapsible } from "@/components/tambo/message-thread-collapsible";
 import { getLLMText } from "@/lib/get-llm-text";
 import { source } from "@/lib/source";
@@ -13,6 +14,8 @@ import {
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
+
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
 }) {
@@ -23,31 +26,41 @@ export default async function Page(props: {
   const MDXContent = page.data.body;
   const llmContent = await getLLMText(page);
 
+  // Generate TechArticle schema for each doc page
+  const pageSchema = createDocPageSchema({
+    title: page.data.title,
+    description: page.data.description ?? "",
+    url: `${siteUrl}${page.url}`,
+  });
+
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
-      <Suspense fallback={<div>Loading...</div>}>
-        <MessageThreadCollapsible className="tambo-theme" />
-      </Suspense>
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription>{page.data.description}</DocsDescription>
+    <>
+      <PageJsonLd schema={pageSchema} />
+      <DocsPage toc={page.data.toc} full={page.data.full}>
+        <Suspense fallback={<div>Loading...</div>}>
+          <MessageThreadCollapsible className="tambo-theme" />
+        </Suspense>
+        <DocsTitle>{page.data.title}</DocsTitle>
+        <DocsDescription>{page.data.description}</DocsDescription>
 
-      <div className="flex items-center gap-2 mb-6 pb-4 border-b border-fd-border">
-        <LLMCopyButton content={llmContent} />
-        <OpenDropdown
-          markdownUrl={`${process.env.NEXT_PUBLIC_DOCS_URL || "https://docs.tambo.co"}${page.url}`}
-          githubUrl={`https://github.com/tambo-ai/tambo/blob/main/docs/content/docs/${page.path}`}
-        />
-      </div>
+        <div className="flex items-center gap-2 mb-6 pb-4 border-b border-fd-border">
+          <LLMCopyButton content={llmContent} />
+          <OpenDropdown
+            markdownUrl={`${process.env.NEXT_PUBLIC_DOCS_URL || "https://docs.tambo.co"}${page.url}`}
+            githubUrl={`https://github.com/tambo-ai/tambo/blob/main/docs/content/docs/${page.path}`}
+          />
+        </div>
 
-      <DocsBody>
-        <MDXContent
-          components={getMDXComponents({
-            // this allows you to link to other pages with relative file paths
-            a: createRelativeLink(source, page),
-          })}
-        />
-      </DocsBody>
-    </DocsPage>
+        <DocsBody>
+          <MDXContent
+            components={getMDXComponents({
+              // this allows you to link to other pages with relative file paths
+              a: createRelativeLink(source, page),
+            })}
+          />
+        </DocsBody>
+      </DocsPage>
+    </>
   );
 }
 
@@ -62,8 +75,36 @@ export async function generateMetadata(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
+  const pageUrl = `${siteUrl}${page.url}`;
+
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: page.url,
+    },
+    openGraph: {
+      title: page.data.title,
+      description: page.data.description,
+      url: pageUrl,
+      siteName: "Tambo AI Docs",
+      type: "article",
+      locale: "en_US",
+      images: [
+        {
+          url: "/logo/lockup/Tambo-Lockup.png",
+          width: 1200,
+          height: 630,
+          alt: `${page.data.title} - Tambo AI Documentation`,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: page.data.title,
+      description: page.data.description,
+      site: "@tamborino",
+      images: ["/logo/lockup/Tambo-Lockup.png"],
+    },
   };
 }

--- a/docs/src/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/src/app/(docs)/[[...slug]]/page.tsx
@@ -18,12 +18,13 @@ import { Suspense } from "react";
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
 
-const docLastModifiedCache = new Map<string, string | undefined>();
+export const runtime = "nodejs";
+
+const docLastModifiedCache = new Map<string, string>();
 
 const getDocPageLastModified = (contentPath: string): string | undefined => {
-  if (docLastModifiedCache.has(contentPath)) {
-    return docLastModifiedCache.get(contentPath);
-  }
+  const cached = docLastModifiedCache.get(contentPath);
+  if (cached) return cached;
 
   try {
     const filePath = join(process.cwd(), "content", "docs", contentPath);
@@ -31,7 +32,6 @@ const getDocPageLastModified = (contentPath: string): string | undefined => {
     docLastModifiedCache.set(contentPath, lastModified);
     return lastModified;
   } catch {
-    docLastModifiedCache.set(contentPath, undefined);
     return;
   }
 };

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import "@/app/global.css";
+import { GlobalJsonLd } from "@/components/json-ld";
 import { WebVitalsReporter } from "@/components/web-vitals";
 import { cn } from "@/lib/utils";
 import {
@@ -13,6 +14,7 @@ import { Inter } from "next/font/google";
 import { Suspense } from "react";
 
 const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
+const logoUrl = new URL("/logo/lockup/Tambo-Lockup.png", baseUrl).toString();
 const docsDescription =
   "Tambo is an open-source generative UI toolkit for React. Register your components—the agent renders them based on user messages.";
 
@@ -23,17 +25,47 @@ export const metadata: Metadata = {
     template: "%s | Tambo Docs",
   },
   description: docsDescription,
+  keywords: [
+    "Tambo",
+    "generative UI",
+    "React SDK",
+    "AI components",
+    "Model Context Protocol",
+    "MCP",
+    "streaming components",
+    "AI-powered interfaces",
+    "React hooks",
+    "component rendering",
+  ],
+  authors: [{ name: "Tambo AI", url: "https://tambo.co" }],
+  creator: "Tambo AI",
+  publisher: "Tambo AI",
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
     title: "Tambo Docs",
     description: docsDescription,
     url: baseUrl,
     siteName: "Tambo Docs",
     type: "website",
+    locale: "en_US",
+    images: [
+      {
+        url: logoUrl,
+        width: 1200,
+        height: 630,
+        alt: "Tambo AI - Generative UI SDK for React",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "Tambo Docs",
     description: docsDescription,
+    site: "@tamborino",
+    creator: "@tamborino",
+    images: [logoUrl],
   },
   robots: {
     index: true,
@@ -46,6 +78,7 @@ export const metadata: Metadata = {
       "max-snippet": -1,
     },
   },
+  category: "technology",
 };
 
 const inter = Inter({
@@ -59,6 +92,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       className={cn(inter.className, "tambo-theme")}
       suppressHydrationWarning
     >
+      <head>
+        <GlobalJsonLd />
+      </head>
       <body className="flex flex-col min-h-screen">
         <TamboRootProvider>
           <Suspense>

--- a/docs/src/app/robots.ts
+++ b/docs/src/app/robots.ts
@@ -4,11 +4,60 @@ const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-      disallow: ["/api/"],
-    },
+    rules: [
+      // Default rule for all bots
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/"],
+      },
+      // Explicitly allow OpenAI's GPTBot (used for ChatGPT training and browsing)
+      {
+        userAgent: "GPTBot",
+        allow: "/",
+      },
+      // Explicitly allow ChatGPT's browsing feature
+      {
+        userAgent: "ChatGPT-User",
+        allow: "/",
+      },
+      // Explicitly allow Perplexity AI
+      {
+        userAgent: "PerplexityBot",
+        allow: "/",
+      },
+      // Explicitly allow Claude/Anthropic
+      {
+        userAgent: "ClaudeBot",
+        allow: "/",
+      },
+      {
+        userAgent: "anthropic-ai",
+        allow: "/",
+      },
+      // Explicitly allow Google's AI bot
+      {
+        userAgent: "Google-Extended",
+        allow: "/",
+      },
+      // Explicitly allow Bing/Microsoft Copilot
+      {
+        userAgent: "Bingbot",
+        allow: "/",
+      },
+      // Explicitly allow Meta AI
+      {
+        userAgent: "Meta-ExternalAgent",
+        allow: "/",
+      },
+      // Explicitly allow Cohere
+      {
+        userAgent: "cohere-ai",
+        allow: "/",
+      },
+    ],
     sitemap: `${baseUrl}/sitemap.xml`,
+    // Point AI crawlers to the LLM-optimized content
+    host: baseUrl,
   };
 }

--- a/docs/src/components/json-ld.tsx
+++ b/docs/src/components/json-ld.tsx
@@ -1,0 +1,215 @@
+import Script from "next/script";
+
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
+const mainSiteUrl = "https://tambo.co";
+
+/**
+ * Organization schema for Tambo AI brand identity.
+ */
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Tambo AI",
+  url: mainSiteUrl,
+  logo: `${mainSiteUrl}/logo.png`,
+  description:
+    "Tambo is a generative UI SDK for React that lets AI dynamically render components based on natural language conversations.",
+  sameAs: [
+    "https://github.com/tambo-ai/tambo",
+    "https://x.com/tamaborino",
+    "https://discord.gg/wMprBWYfbb",
+  ],
+  foundingDate: "2024",
+  knowsAbout: [
+    "Generative UI",
+    "React SDK",
+    "Model Context Protocol",
+    "AI-powered interfaces",
+    "Component rendering",
+  ],
+};
+
+/**
+ * SoftwareApplication schema for the Tambo React SDK.
+ */
+const softwareSchema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Tambo React SDK",
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "Any",
+  description:
+    "Open-source React SDK for building generative UI applications. Register components once, let AI render them dynamically based on user messages.",
+  url: mainSiteUrl,
+  downloadUrl: "https://www.npmjs.com/package/@tambo-ai/react",
+  softwareVersion: "1.0",
+  author: {
+    "@type": "Organization",
+    name: "Tambo AI",
+  },
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  programmingLanguage: ["TypeScript", "JavaScript"],
+  runtimePlatform: "Node.js",
+  keywords: [
+    "generative UI",
+    "React",
+    "AI",
+    "MCP",
+    "Model Context Protocol",
+    "component rendering",
+    "streaming",
+    "tools",
+  ],
+};
+
+/**
+ * WebSite schema with search action for the documentation site.
+ */
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Tambo AI Documentation",
+  url: baseUrl,
+  description:
+    "Official documentation for Tambo - the generative UI SDK for React with MCP-native tools, streaming components, and AI-powered interfaces.",
+  publisher: {
+    "@type": "Organization",
+    name: "Tambo AI",
+  },
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${baseUrl}?q={search_term_string}`,
+    },
+    "query-input": "required name=search_term_string",
+  },
+};
+
+/**
+ * TechArticle schema for documentation pages.
+ */
+export function createDocPageSchema({
+  title,
+  description,
+  url,
+  dateModified,
+}: {
+  title: string;
+  description: string;
+  url: string;
+  dateModified?: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: title,
+    description,
+    url,
+    dateModified: dateModified ?? new Date().toISOString(),
+    author: {
+      "@type": "Organization",
+      name: "Tambo AI",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Tambo AI",
+      logo: {
+        "@type": "ImageObject",
+        url: `${mainSiteUrl}/logo.png`,
+      },
+    },
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": url,
+    },
+  };
+}
+
+/**
+ * FAQPage schema for pages with Q&A content.
+ */
+export function createFAQSchema(
+  faqs: Array<{ question: string; answer: string }>,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: faq.answer,
+      },
+    })),
+  };
+}
+
+/**
+ * HowTo schema for tutorial/guide pages.
+ */
+export function createHowToSchema({
+  name,
+  description,
+  steps,
+  totalTime,
+}: {
+  name: string;
+  description: string;
+  steps: Array<{ name: string; text: string }>;
+  totalTime?: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name,
+    description,
+    totalTime: totalTime ?? "PT10M",
+    step: steps.map((step, index) => ({
+      "@type": "HowToStep",
+      position: index + 1,
+      name: step.name,
+      text: step.text,
+    })),
+  };
+}
+
+/**
+ * Renders global JSON-LD schemas for the entire site.
+ * Place this in the root layout.
+ */
+export function GlobalJsonLd() {
+  const schemas = [organizationSchema, softwareSchema, websiteSchema];
+
+  return (
+    <Script
+      id="global-json-ld"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(schemas),
+      }}
+      strategy="afterInteractive"
+    />
+  );
+}
+
+/**
+ * Renders page-specific JSON-LD schema.
+ */
+export function PageJsonLd({ schema }: { schema: object | object[] }) {
+  return (
+    <Script
+      id="page-json-ld"
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(schema),
+      }}
+      strategy="afterInteractive"
+    />
+  );
+}

--- a/docs/src/components/json-ld.tsx
+++ b/docs/src/components/json-ld.tsx
@@ -1,11 +1,20 @@
 const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
 const mainSiteUrl = "https://tambo.co";
 
+type JsonLdSchema =
+  | Record<string, unknown>
+  | readonly Record<string, unknown>[];
+
 type JsonLdProps = {
   readonly id: string;
-  readonly schema: unknown;
+  readonly schema: JsonLdSchema;
 };
 
+/**
+ * Render JSON-LD as an inline script tag.
+ *
+ * Intended for use in server components so crawlers can see it in initial HTML.
+ */
 export function JsonLd({ id, schema }: JsonLdProps) {
   return (
     <script
@@ -123,6 +132,7 @@ export function createDocPageSchema({
     headline: title,
     description,
     url,
+    // Omit `dateModified` when unknown to avoid implying freshness.
     ...(dateModified ? { dateModified } : {}),
     author: {
       "@type": "Organization",
@@ -210,7 +220,7 @@ export function PageJsonLd({
   schema,
 }: {
   id?: string;
-  schema: unknown;
+  schema: JsonLdSchema;
 }) {
   return <JsonLd id={id} schema={schema} />;
 }

--- a/docs/src/components/json-ld.tsx
+++ b/docs/src/components/json-ld.tsx
@@ -205,6 +205,12 @@ export function GlobalJsonLd() {
 /**
  * Renders page-specific JSON-LD schema.
  */
-export function PageJsonLd({ schema }: { schema: unknown }) {
-  return <JsonLd id="page-json-ld" schema={schema} />;
+export function PageJsonLd({
+  id = "page-json-ld",
+  schema,
+}: {
+  id?: string;
+  schema: unknown;
+}) {
+  return <JsonLd id={id} schema={schema} />;
 }

--- a/docs/src/components/json-ld.tsx
+++ b/docs/src/components/json-ld.tsx
@@ -1,7 +1,20 @@
-import Script from "next/script";
-
 const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://docs.tambo.co";
 const mainSiteUrl = "https://tambo.co";
+
+type JsonLdProps = {
+  readonly id: string;
+  readonly schema: unknown;
+};
+
+export function JsonLd({ id, schema }: JsonLdProps) {
+  return (
+    <script
+      id={id}
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+    />
+  );
+}
 
 /**
  * Organization schema for Tambo AI brand identity.
@@ -110,7 +123,7 @@ export function createDocPageSchema({
     headline: title,
     description,
     url,
-    dateModified: dateModified ?? new Date().toISOString(),
+    ...(dateModified ? { dateModified } : {}),
     author: {
       "@type": "Organization",
       name: "Tambo AI",
@@ -186,30 +199,12 @@ export function createHowToSchema({
 export function GlobalJsonLd() {
   const schemas = [organizationSchema, softwareSchema, websiteSchema];
 
-  return (
-    <Script
-      id="global-json-ld"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(schemas),
-      }}
-      strategy="afterInteractive"
-    />
-  );
+  return <JsonLd id="global-json-ld" schema={schemas} />;
 }
 
 /**
  * Renders page-specific JSON-LD schema.
  */
-export function PageJsonLd({ schema }: { schema: object | object[] }) {
-  return (
-    <Script
-      id="page-json-ld"
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(schema),
-      }}
-      strategy="afterInteractive"
-    />
-  );
+export function PageJsonLd({ schema }: { schema: unknown }) {
+  return <JsonLd id="page-json-ld" schema={schema} />;
 }

--- a/react-sdk/src/v1/hooks/use-tambo-v1-thread-list.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-thread-list.test.tsx
@@ -81,7 +81,7 @@ describe("useTamboV1ThreadList", () => {
       () =>
         useTamboV1ThreadList({
           userKey: "test-context",
-          limit: 10,
+          limit: "10",
         }),
       { wrapper: TestWrapper },
     );
@@ -92,7 +92,7 @@ describe("useTamboV1ThreadList", () => {
 
     expect(mockThreadsApi.list).toHaveBeenCalledWith({
       userKey: "test-context",
-      limit: 10,
+      limit: "10",
     });
   });
 

--- a/react-sdk/src/v1/hooks/use-tambo-v1-thread-list.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-thread-list.test.tsx
@@ -81,7 +81,7 @@ describe("useTamboV1ThreadList", () => {
       () =>
         useTamboV1ThreadList({
           userKey: "test-context",
-          limit: "10",
+          limit: 10,
         }),
       { wrapper: TestWrapper },
     );
@@ -92,7 +92,7 @@ describe("useTamboV1ThreadList", () => {
 
     expect(mockThreadsApi.list).toHaveBeenCalledWith({
       userKey: "test-context",
-      limit: "10",
+      limit: 10,
     });
   });
 


### PR DESCRIPTION
## Summary
- Add JSON-LD structured data (Organization, SoftwareApplication, WebSite, TechArticle schemas)
- Enhance per-page metadata with Open Graph, Twitter Cards, and canonical URLs
- Add AI bot rules to robots.txt (GPTBot, PerplexityBot, ClaudeBot, etc.)
- Fix sitemap to exclude invalid paths and use proper timestamps

## Why
GEO (Generative Engine Optimization) improves visibility in AI search engines like ChatGPT, Perplexity, and Claude.

🤖 Generated with [Claude Code](https://claude.ai/code)