### PR TITLE
fix(api,react-sdk): prevent MCP "Method not found" error when no servers configured

### DIFF
--- a/apps/api/src/mcp-server/server.ts
+++ b/apps/api/src/mcp-server/server.ts
@@ -51,7 +51,9 @@ export async function createMcpServer(
       version: "1.0.0",
     },
     {
-      capabilities: hasClients ? { prompts: { listChanged: true } } : {},
+      capabilities: hasClients
+        ? { prompts: { listChanged: true }, resources: { listChanged: true } }
+        : {},
       // Enable notification debouncing for specific methods
       debouncedNotificationMethods: [
         "notifications/tools/list_changed",
@@ -109,7 +111,9 @@ export async function createSessionlessMcpServer(
       version: "1.0.0",
     },
     {
-      capabilities: hasClients ? { prompts: { listChanged: true } } : {},
+      capabilities: hasClients
+        ? { prompts: { listChanged: true }, resources: { listChanged: true } }
+        : {},
       // Enable notification debouncing for specific methods
       debouncedNotificationMethods: [
         "notifications/tools/list_changed",


### PR DESCRIPTION
## Summary

Fixes the console error `MCP error -32601: Method not found` that appears when running Tambo projects locally without any MCP servers configured.

## The Problem

When you run a Tambo project **without any MCP servers configured**, this error appears in the console even though everything still works. This is confusing for developers.

## Root Cause

### Flow Before the Fix

1. **Client connects** to Tambo's internal MCP server at `{tamboBaseUrl}/mcp`

2. **Server creation** (`apps/api/src/mcp-server/server.ts`) always advertised prompts capability:
   ```typescript
   const server = new McpServer({...}, {
     capabilities: {
       prompts: { listChanged: true },  // Always set, even with no MCP servers
     },
   });
   
   // Then fetch MCP clients (could be empty array!)
   const mcpClients = await getThreadMCPClients(...);
   
   // Register handlers - loops over empty array, registers nothing
   await registerPromptHandlers(server, mcpClients);
   ```

3. **Client sees** the server advertises `prompts` capability, so it calls `listPrompts()`

4. **Server returns error** because no prompt handlers were actually registered (empty loop)

## The Fix

### Server-Side (`apps/api/src/mcp-server/server.ts`)

Fetch MCP clients **first**, then conditionally set capabilities:

```typescript
// Fetch clients first
const mcpClients = await getThreadMCPClients(...);

// Only advertise capabilities if we have clients to proxy from
const hasClients = mcpClients.length > 0;

const server = new McpServer({...}, {
  capabilities: hasClients 
    ? { prompts: { listChanged: true }, resources: { listChanged: true } } 
    : {},
});
```

### Client-Side (`react-sdk/src/mcp/mcp-hooks.ts`)

1. **Capability checking** before calling `listPrompts()` / `listResources()`:

```typescript
function serverSupportsPrompts(server: ConnectedMcpServer): boolean {
  const capabilities = server.client.getServerCapabilities?.();
  // If undefined, assume support (backward compatibility)
  if (capabilities === undefined) return true;
  // If capabilities exist but no prompts field, skip
  return capabilities.prompts != null;
}
```

2. **Graceful error handling** for MethodNotFound as a fallback:

```typescript
try {
  const result = await mcpServer.client.client.listPrompts();
  // ... process results
} catch (error) {
  // Gracefully handle MethodNotFound - return empty instead of throwing
  if (isMethodNotFoundError(error)) return [];
  throw error;
}
```

### Fixed Flow

1. **Client connects** to Tambo's internal MCP server
2. **Server checks** if any MCP clients are configured → none found
3. **Server advertises** `capabilities: {}` (empty, no prompts/resources)
4. **Client receives** capabilities, sees no `prompts` field
5. **Client's capability check** returns `false`
6. **Client skips** calling `listPrompts()` entirely
7. **No error** in console ✓

## Defense in Depth

- **Server-side fix** is the primary fix - correctly reports what the server actually supports
- **Client-side capability check** - avoids calling methods the server doesn't advertise
- **Client-side error handling** - graceful fallback if a MethodNotFound still slips through (returns empty array instead of throwing)

## Test plan

- [x] `npm run check-types` - passes
- [x] `npm run lint` - passes (warnings only)
- [x] `npm test -w apps/api` - 636 tests pass
- [x] `npm test -w react-sdk` - 1027 tests pass (including 18 mcp-hooks tests)
- [ ] Manual test: Run a Tambo project locally without any MCP servers configured, verify no "Method not found" error in console