### PR TITLE
feat(web): add delete button for MCP server custom headers

### DIFF
--- a/apps/web/components/dashboard-components/project-details/headers-editor.test.tsx
+++ b/apps/web/components/dashboard-components/project-details/headers-editor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HeadersEditor, type HeaderKV } from "./headers-editor";
 
@@ -70,7 +70,10 @@ describe("HeadersEditor", () => {
     // Delete the first header
     await user.click(deleteButtons[0]);
 
-    // onSave should be called with only the second header
+    // onSave should be called exactly once with only the second header
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
     expect(onSave).toHaveBeenCalledWith([{ header: "X-Custom", value: "foo" }]);
   });
 });

--- a/apps/web/components/dashboard-components/project-details/headers-editor.tsx
+++ b/apps/web/components/dashboard-components/project-details/headers-editor.tsx
@@ -168,6 +168,8 @@ export function HeadersEditor({
   const handleDeleteRow = (rowIndex: number) => {
     const updated = working.filter((_, i) => i !== rowIndex);
     setWorking(updated);
+    // Reset activeEditIndex to avoid stale index references after array shifts
+    setActiveEditIndex(null);
     onSave(updated);
   };
 


### PR DESCRIPTION
## Summary

- Added a delete button (trash icon) to each header row in the MCP server custom headers editor
- Users can now remove individual headers without having to clear and re-enter all headers
- Deletion immediately saves the change to the server

## Test plan

- [x] Add tests for the delete button functionality
- [ ] Manual test: Add some custom headers, click delete on one, verify it's removed and saved