### PR TITLE
fix(v1): set isError flag on tool result errors

### DIFF
--- a/apps/api/src/v1/v1-tool-results.test.ts
+++ b/apps/api/src/v1/v1-tool-results.test.ts
@@ -355,6 +355,26 @@ describe("v1-tool-results", () => {
       expect(messages[0].content[1].type).toBe(ContentPartType.Resource);
     });
 
+    it("persists isError as error field on the message", () => {
+      const toolResults = [
+        {
+          toolUseId: "call_err",
+          content: [{ type: "text" as const, text: "Something went wrong" }],
+          isError: true,
+        },
+        {
+          toolUseId: "call_ok",
+          content: [{ type: "text" as const, text: "All good" }],
+          isError: false,
+        },
+      ];
+
+      const messages = convertToolResultsToMessages(toolResults);
+
+      expect(messages[0].error).toBe("Tool execution failed");
+      expect(messages[1].error).toBeUndefined();
+    });
+
     it("returns empty array for empty input", () => {
       const messages = convertToolResultsToMessages([]);
 

--- a/apps/api/src/v1/v1-tool-results.ts
+++ b/apps/api/src/v1/v1-tool-results.ts
@@ -198,5 +198,6 @@ export function convertToolResultsToMessages(
           );
       }
     }),
+    ...(result.isError ? { error: "Tool execution failed" } : {}),
   }));
 }

--- a/react-sdk/src/v1/hooks/use-tambo-v1-send-message.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-send-message.test.tsx
@@ -795,6 +795,7 @@ describe("useTamboV1SendMessage mutation", () => {
     expect(continueCall[1].message.content[0]).toEqual({
       type: "tool_result",
       toolUseId: "call_1",
+      isError: true,
       content: [
         { type: "text", text: 'Tool "unknown_tool" not found in registry' },
       ],

--- a/react-sdk/src/v1/utils/tool-executor.test.ts
+++ b/react-sdk/src/v1/utils/tool-executor.test.ts
@@ -113,6 +113,7 @@ describe("tool-executor", () => {
       expect(result).toEqual({
         type: "tool_result",
         toolUseId: "call-5",
+        isError: true,
         content: [{ type: "text", text: "Tool failed!" }],
       });
     });
@@ -133,6 +134,7 @@ describe("tool-executor", () => {
       expect(result).toEqual({
         type: "tool_result",
         toolUseId: "call-6",
+        isError: true,
         content: [{ type: "text", text: "Tool execution failed" }],
       });
     });
@@ -221,6 +223,7 @@ describe("tool-executor", () => {
       expect(results[0]).toEqual({
         type: "tool_result",
         toolUseId: "call-1",
+        isError: true,
         content: [
           { type: "text", text: 'Tool "unknown_tool" not found in registry' },
         ],
@@ -249,7 +252,9 @@ describe("tool-executor", () => {
       const results = await executeAllPendingTools(toolCalls, registry);
 
       expect(results).toHaveLength(2);
+      expect(results[0].isError).toBeUndefined();
       expect(results[0].content[0]).toEqual({ type: "text", text: "success" });
+      expect(results[1].isError).toBe(true);
       expect(results[1].content[0]).toEqual({
         type: "text",
         text: 'Tool "unknown" not found in registry',

--- a/react-sdk/src/v1/utils/tool-executor.ts
+++ b/react-sdk/src/v1/utils/tool-executor.ts
@@ -70,6 +70,7 @@ export async function executeClientTool(
     return {
       type: "tool_result",
       toolUseId: toolCallId,
+      isError: true,
       content: [
         {
           type: "text" as const,
@@ -109,6 +110,7 @@ export async function executeAllPendingTools(
       results.push({
         type: "tool_result",
         toolUseId: toolCallId,
+        isError: true,
         content: [
           {
             type: "text" as const,


### PR DESCRIPTION
## Summary

- **React SDK**: `executeClientTool()` and `executeAllPendingTools()` now set `isError: true` on `ToolResultContent` when a tool throws an error or is not found in the registry
- **API**: `convertToolResultsToMessages()` now maps `isError: true` to the `error` field on `UnsavedThreadToolMessage`, so it gets persisted to the database

This completes the round-trip: client sets `isError` → API persists as `error` column → API reads back and maps to `isError` on output → UI renders error state.

Fixes TAM-1124

## Test plan

- [x] SDK `tool-executor.test.ts` — updated assertions for `isError: true` on error/not-found paths
- [x] API `v1-tool-results.test.ts` — new test verifying `isError` maps to `error` field on converted messages
- [x] All existing tests pass
- [ ] Manual: trigger a client tool error and verify the red X icon shows in the smoketest UI


🤖 Generated with [Claude Code](https://claude.com/claude-code)