### PR TITLE
feat(react-ui-base): compound component refactors for 12 components

### DIFF
--- a/packages/react-ui-base/package.json
+++ b/packages/react-ui-base/package.json
@@ -22,6 +22,76 @@
         "default": "./dist/cjs/index.cjs"
       }
     },
+    "./elicitation-ui": {
+      "import": {
+        "types": "./dist/esm/elicitation-ui/index.d.ts",
+        "default": "./dist/esm/elicitation-ui/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/elicitation-ui/index.d.ts",
+        "default": "./dist/cjs/elicitation-ui/index.cjs"
+      }
+    },
+    "./edit-with-tambo-button": {
+      "import": {
+        "types": "./dist/esm/edit-with-tambo-button/index.d.ts",
+        "default": "./dist/esm/edit-with-tambo-button/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/edit-with-tambo-button/index.d.ts",
+        "default": "./dist/cjs/edit-with-tambo-button/index.cjs"
+      }
+    },
+    "./canvas-space": {
+      "import": {
+        "types": "./dist/esm/canvas-space/index.d.ts",
+        "default": "./dist/esm/canvas-space/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/canvas-space/index.d.ts",
+        "default": "./dist/cjs/canvas-space/index.cjs"
+      }
+    },
+    "./form": {
+      "import": {
+        "types": "./dist/esm/form/index.d.ts",
+        "default": "./dist/esm/form/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/form/index.d.ts",
+        "default": "./dist/cjs/form/index.cjs"
+      }
+    },
+    "./graph": {
+      "import": {
+        "types": "./dist/esm/graph/index.d.ts",
+        "default": "./dist/esm/graph/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/graph/index.d.ts",
+        "default": "./dist/cjs/graph/index.cjs"
+      }
+    },
+    "./input-fields": {
+      "import": {
+        "types": "./dist/esm/input-fields/index.d.ts",
+        "default": "./dist/esm/input-fields/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/input-fields/index.d.ts",
+        "default": "./dist/cjs/input-fields/index.cjs"
+      }
+    },
+    "./message-suggestions": {
+      "import": {
+        "types": "./dist/esm/message-suggestions/index.d.ts",
+        "default": "./dist/esm/message-suggestions/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/message-suggestions/index.d.ts",
+        "default": "./dist/cjs/message-suggestions/index.cjs"
+      }
+    },
     "./message": {
       "import": {
         "types": "./dist/esm/message/index.d.ts",
@@ -30,6 +100,16 @@
       "require": {
         "types": "./dist/cjs/message/index.d.ts",
         "default": "./dist/cjs/message/index.cjs"
+      }
+    },
+    "./scrollable-message-container": {
+      "import": {
+        "types": "./dist/esm/scrollable-message-container/index.d.ts",
+        "default": "./dist/esm/scrollable-message-container/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/scrollable-message-container/index.d.ts",
+        "default": "./dist/cjs/scrollable-message-container/index.cjs"
       }
     },
     "./reasoning-info": {
@@ -42,6 +122,26 @@
         "default": "./dist/cjs/reasoning-info/index.cjs"
       }
     },
+    "./thread-content": {
+      "import": {
+        "types": "./dist/esm/thread-content/index.d.ts",
+        "default": "./dist/esm/thread-content/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/thread-content/index.d.ts",
+        "default": "./dist/cjs/thread-content/index.cjs"
+      }
+    },
+    "./thread-dropdown": {
+      "import": {
+        "types": "./dist/esm/thread-dropdown/index.d.ts",
+        "default": "./dist/esm/thread-dropdown/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/thread-dropdown/index.d.ts",
+        "default": "./dist/cjs/thread-dropdown/index.cjs"
+      }
+    },
     "./toolcall-info": {
       "import": {
         "types": "./dist/esm/toolcall-info/index.d.ts",
@@ -50,6 +150,26 @@
       "require": {
         "types": "./dist/cjs/toolcall-info/index.d.ts",
         "default": "./dist/cjs/toolcall-info/index.cjs"
+      }
+    },
+    "./map": {
+      "import": {
+        "types": "./dist/esm/map/index.d.ts",
+        "default": "./dist/esm/map/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/map/index.d.ts",
+        "default": "./dist/cjs/map/index.cjs"
+      }
+    },
+    "./thread-history": {
+      "import": {
+        "types": "./dist/esm/thread-history/index.d.ts",
+        "default": "./dist/esm/thread-history/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/thread-history/index.d.ts",
+        "default": "./dist/cjs/thread-history/index.cjs"
       }
     },
     "./types": {

--- a/packages/react-ui-base/src/canvas-space/content/canvas-space-content.tsx
+++ b/packages/react-ui-base/src/canvas-space/content/canvas-space-content.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useCanvasSpaceRootContext } from "../root/canvas-space-root-context";
+
+/**
+ * Props passed to the render callback of CanvasSpaceContent.
+ */
+export interface CanvasSpaceContentRenderProps {
+  /** The rendered component from the current thread. */
+  renderedComponent: React.ReactNode;
+}
+
+export type CanvasSpaceContentProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+>;
+
+/**
+ * Content primitive for the canvas space.
+ * Renders only when a component is available in the canvas.
+ * Displays the rendered component from the current thread.
+ * Supports a render prop to customize how the component is displayed.
+ * @returns The content element with the rendered component, or null if empty
+ */
+export const CanvasSpaceContent = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<
+    CanvasSpaceContentProps,
+    CanvasSpaceContentRenderProps
+  >
+>(function CanvasSpaceContent({ asChild, ...props }, ref) {
+  const { renderedComponent } = useCanvasSpaceRootContext();
+
+  const { content, componentProps } = useRender(props, {
+    renderedComponent: renderedComponent!,
+  });
+
+  if (!renderedComponent) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp ref={ref} data-slot="canvas-space-content" {...componentProps}>
+      {content ?? renderedComponent}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/canvas-space/empty-state/canvas-space-empty-state.tsx
+++ b/packages/react-ui-base/src/canvas-space/empty-state/canvas-space-empty-state.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useCanvasSpaceRootContext } from "../root/canvas-space-root-context";
+
+export type CanvasSpaceEmptyStateProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Empty state primitive for the canvas space.
+ * Renders only when no component is available in the canvas.
+ * Provides a slot for custom empty state content.
+ * @returns The empty state element, or null if a component is rendered
+ */
+export const CanvasSpaceEmptyState = React.forwardRef<
+  HTMLDivElement,
+  CanvasSpaceEmptyStateProps
+>(function CanvasSpaceEmptyState({ children, asChild, ...props }, ref) {
+  const { renderedComponent } = useCanvasSpaceRootContext();
+
+  if (renderedComponent) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp ref={ref} data-slot="canvas-space-empty-state" {...props}>
+      {children}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/canvas-space/index.tsx
+++ b/packages/react-ui-base/src/canvas-space/index.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { CanvasSpaceContent } from "./content/canvas-space-content";
+import { CanvasSpaceEmptyState } from "./empty-state/canvas-space-empty-state";
+import { CanvasSpaceRoot } from "./root/canvas-space-root";
+import { CanvasSpaceViewport } from "./viewport/canvas-space-viewport";
+
+/**
+ * CanvasSpace namespace containing all canvas space base components.
+ */
+const CanvasSpace = {
+  Root: CanvasSpaceRoot,
+  Viewport: CanvasSpaceViewport,
+  Content: CanvasSpaceContent,
+  EmptyState: CanvasSpaceEmptyState,
+};
+
+export type {
+  CanvasSpaceContentProps,
+  CanvasSpaceContentRenderProps,
+} from "./content/canvas-space-content";
+export type { CanvasSpaceEmptyStateProps } from "./empty-state/canvas-space-empty-state";
+export type { CanvasSpaceRootProps } from "./root/canvas-space-root";
+export type { CanvasSpaceViewportProps } from "./viewport/canvas-space-viewport";
+
+export { CanvasSpace };

--- a/packages/react-ui-base/src/canvas-space/root/canvas-space-root-context.tsx
+++ b/packages/react-ui-base/src/canvas-space/root/canvas-space-root-context.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+/**
+ * Context value shared among CanvasSpace primitive sub-components.
+ */
+export interface CanvasSpaceRootContextValue {
+  /** The currently rendered component, or null if the canvas is empty. */
+  renderedComponent: React.ReactNode | null;
+  /** Ref for the scrollable viewport container. */
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const CanvasSpaceRootContext =
+  React.createContext<CanvasSpaceRootContextValue | null>(null);
+
+/**
+ * Hook to access the canvas space context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The canvas space context value
+ * @throws Error if used outside of CanvasSpace.Root component
+ */
+function useCanvasSpaceRootContext(): CanvasSpaceRootContextValue {
+  const context = React.useContext(CanvasSpaceRootContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: CanvasSpaceRootContext is missing. CanvasSpace parts must be used within <CanvasSpace.Root>",
+    );
+  }
+  return context;
+}
+
+export { CanvasSpaceRootContext, useCanvasSpaceRootContext };

--- a/packages/react-ui-base/src/canvas-space/root/canvas-space-root.tsx
+++ b/packages/react-ui-base/src/canvas-space/root/canvas-space-root.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import type { TamboThreadMessage } from "@tambo-ai/react";
+import { useTamboThread } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { CanvasSpaceRootContext } from "./canvas-space-root-context";
+
+export type CanvasSpaceRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Root primitive for the canvas space component.
+ * Manages thread tracking, custom event listeners, and component state.
+ * Provides context for child components.
+ * @returns The root canvas space element with context provider
+ */
+export const CanvasSpaceRoot = React.forwardRef<
+  HTMLDivElement,
+  CanvasSpaceRootProps
+>(function CanvasSpaceRoot({ children, asChild, ...props }, ref) {
+  const { thread } = useTamboThread();
+
+  const [renderedComponent, setRenderedComponent] =
+    React.useState<React.ReactNode | null>(null);
+
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+  const previousThreadId = React.useRef<string | null>(null);
+
+  /**
+   * Clear the canvas when switching between threads.
+   * Prevents components from previous threads being displayed in new threads.
+   */
+  React.useEffect(() => {
+    if (
+      !thread ||
+      (previousThreadId.current && previousThreadId.current !== thread.id)
+    ) {
+      setRenderedComponent(null);
+    }
+
+    previousThreadId.current = thread?.id ?? null;
+  }, [thread]);
+
+  /**
+   * Handle custom 'tambo:showComponent' events.
+   * Allows external triggers to update the rendered component.
+   */
+  React.useEffect(() => {
+    const handleShowComponent = (
+      event: CustomEvent<{ messageId: string; component: React.ReactNode }>,
+    ) => {
+      try {
+        setRenderedComponent(event.detail.component);
+      } catch (error) {
+        console.error("Failed to render component:", error);
+        setRenderedComponent(null);
+      }
+    };
+
+    window.addEventListener(
+      "tambo:showComponent",
+      handleShowComponent as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        "tambo:showComponent",
+        handleShowComponent as EventListener,
+      );
+    };
+  }, []);
+
+  /**
+   * Automatically display the latest component from thread messages.
+   * Updates when thread messages change or new components are added.
+   */
+  React.useEffect(() => {
+    if (!thread?.messages) {
+      setRenderedComponent(null);
+      return;
+    }
+
+    const messagesWithComponents = thread.messages.filter(
+      (msg: TamboThreadMessage) => msg.renderedComponent,
+    );
+
+    if (messagesWithComponents.length > 0) {
+      const latestMessage =
+        messagesWithComponents[messagesWithComponents.length - 1];
+      setRenderedComponent(latestMessage.renderedComponent);
+    }
+  }, [thread?.messages]);
+
+  const contextValue = React.useMemo(
+    () => ({ renderedComponent, scrollContainerRef }),
+    [renderedComponent],
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <CanvasSpaceRootContext.Provider value={contextValue}>
+      <Comp
+        ref={ref}
+        data-slot="canvas-space-root"
+        data-canvas-space="true"
+        {...props}
+      >
+        {children}
+      </Comp>
+    </CanvasSpaceRootContext.Provider>
+  );
+});

--- a/packages/react-ui-base/src/canvas-space/viewport/canvas-space-viewport.tsx
+++ b/packages/react-ui-base/src/canvas-space/viewport/canvas-space-viewport.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useCanvasSpaceRootContext } from "../root/canvas-space-root-context";
+
+export type CanvasSpaceViewportProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Viewport primitive for the canvas space.
+ * Provides the scrollable container with auto-scroll behavior
+ * when new components are rendered.
+ * @returns The scrollable viewport element
+ */
+export const CanvasSpaceViewport = React.forwardRef<
+  HTMLDivElement,
+  CanvasSpaceViewportProps
+>(function CanvasSpaceViewport({ children, asChild, ...props }, ref) {
+  const { renderedComponent, scrollContainerRef } = useCanvasSpaceRootContext();
+
+  /**
+   * Auto-scroll to bottom when new components are rendered.
+   * Includes a small delay to ensure smooth scrolling.
+   */
+  React.useEffect(() => {
+    if (scrollContainerRef.current && renderedComponent) {
+      const timeoutId = setTimeout(() => {
+        if (scrollContainerRef.current) {
+          scrollContainerRef.current.scrollTo({
+            top: scrollContainerRef.current.scrollHeight,
+            behavior: "smooth",
+          });
+        }
+      }, 100);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [renderedComponent, scrollContainerRef]);
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp
+      ref={(node: HTMLDivElement | null) => {
+        // Assign to the context ref
+        (
+          scrollContainerRef as React.MutableRefObject<HTMLDivElement | null>
+        ).current = node;
+
+        // Forward the external ref
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      }}
+      data-slot="canvas-space-viewport"
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/edit-with-tambo-button/index.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/index.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { EditWithTamboButtonPopover } from "./popover/edit-with-tambo-button-popover";
+import { EditWithTamboButtonRoot } from "./root/edit-with-tambo-button-root";
+import { EditWithTamboButtonSendButton } from "./send-button/edit-with-tambo-button-send-button";
+import { EditWithTamboButtonSendModeDropdown } from "./send-button/edit-with-tambo-button-send-mode-dropdown";
+import { EditWithTamboButtonSendModeOption } from "./send-button/edit-with-tambo-button-send-mode-option";
+import { EditWithTamboButtonStatus } from "./status/edit-with-tambo-button-status";
+import { EditWithTamboButtonTextarea } from "./textarea/edit-with-tambo-button-textarea";
+import { EditWithTamboButtonTrigger } from "./trigger/edit-with-tambo-button-trigger";
+
+/**
+ * EditWithTamboButton namespace containing all base components.
+ */
+const EditWithTamboButtonBase = {
+  Root: EditWithTamboButtonRoot,
+  Trigger: EditWithTamboButtonTrigger,
+  Popover: EditWithTamboButtonPopover,
+  Textarea: EditWithTamboButtonTextarea,
+  SendButton: EditWithTamboButtonSendButton,
+  SendModeDropdown: EditWithTamboButtonSendModeDropdown,
+  SendModeOption: EditWithTamboButtonSendModeOption,
+  Status: EditWithTamboButtonStatus,
+};
+
+export type { EditWithTamboButtonPopoverProps } from "./popover/edit-with-tambo-button-popover";
+export type {
+  EditWithTamboButtonContextValue,
+  EditWithTamboButtonSendMode,
+} from "./root/edit-with-tambo-button-context";
+export type { EditWithTamboButtonRootProps } from "./root/edit-with-tambo-button-root";
+export type {
+  EditWithTamboButtonSendButtonProps,
+  EditWithTamboButtonSendButtonRenderProps,
+} from "./send-button/edit-with-tambo-button-send-button";
+export type { EditWithTamboButtonSendModeDropdownProps } from "./send-button/edit-with-tambo-button-send-mode-dropdown";
+export type { EditWithTamboButtonSendModeOptionProps } from "./send-button/edit-with-tambo-button-send-mode-option";
+export type {
+  EditWithTamboButtonStatusProps,
+  EditWithTamboButtonStatusRenderProps,
+} from "./status/edit-with-tambo-button-status";
+export type { EditWithTamboButtonTextareaProps } from "./textarea/edit-with-tambo-button-textarea";
+export type { EditWithTamboButtonTriggerProps } from "./trigger/edit-with-tambo-button-trigger";
+
+export { useEditWithTamboButtonContext } from "./root/edit-with-tambo-button-context";
+
+export { EditWithTamboButtonBase };

--- a/packages/react-ui-base/src/edit-with-tambo-button/popover/edit-with-tambo-button-popover.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/popover/edit-with-tambo-button-popover.tsx
@@ -1,0 +1,51 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useEditWithTamboButtonContext } from "../root/edit-with-tambo-button-context";
+
+export interface EditWithTamboButtonPopoverRenderProps {
+  /** Whether the popover is currently open. */
+  isOpen: boolean;
+  /** The tooltip/title text. */
+  tooltip: string;
+  /** The component name from the interactable. */
+  componentName: string | undefined;
+  /** Close the popover and clear the prompt. */
+  closeAndReset: () => void;
+}
+
+export type EditWithTamboButtonPopoverProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Popover panel that contains the prompt input and actions.
+ * Only renders its children when the popover is open.
+ * Provides data attributes for open/closed state.
+ * @returns A container div for the popover content, or null when closed.
+ */
+export const EditWithTamboButtonPopover = React.forwardRef<
+  HTMLDivElement,
+  EditWithTamboButtonPopoverProps
+>(({ asChild, children, ...props }, ref) => {
+  const { isOpen, component } = useEditWithTamboButtonContext();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="edit-with-tambo-button-popover"
+      data-state={isOpen ? "open" : "closed"}
+      data-component-name={component.componentName}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});
+EditWithTamboButtonPopover.displayName = "EditWithTamboButton.Popover";

--- a/packages/react-ui-base/src/edit-with-tambo-button/root/edit-with-tambo-button-context.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/root/edit-with-tambo-button-context.tsx
@@ -1,0 +1,62 @@
+import type { TamboCurrentComponent } from "@tambo-ai/react";
+import * as React from "react";
+
+export type EditWithTamboButtonSendMode = "send" | "thread";
+
+/**
+ * Context value shared among EditWithTamboButton primitive sub-components.
+ */
+export interface EditWithTamboButtonContextValue {
+  /** The current interactable component metadata. */
+  component: TamboCurrentComponent;
+  /** The current prompt text. */
+  prompt: string;
+  /** Set the prompt text. */
+  setPrompt: (value: string) => void;
+  /** Whether the popover is open. */
+  isOpen: boolean;
+  /** Set the popover open state. */
+  setIsOpen: (value: boolean) => void;
+  /** Whether the AI is currently generating a response. */
+  isGenerating: boolean;
+  /** The current send mode ("send" for inline edit, "thread" for thread). */
+  sendMode: EditWithTamboButtonSendMode;
+  /** Set the send mode. */
+  setSendMode: (mode: EditWithTamboButtonSendMode) => void;
+  /** Whether the send mode dropdown is open. */
+  isDropdownOpen: boolean;
+  /** Set the send mode dropdown open state. */
+  setDropdownOpen: (value: boolean) => void;
+  /** Execute the main action (send or send-in-thread based on current mode). */
+  handleMainAction: () => void;
+  /** Handle keyboard events on the textarea (Cmd/Ctrl+Enter to send). */
+  handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  /** Ref for the textarea element (used for auto-focus). */
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  /** Tooltip text for the button. */
+  tooltip: string;
+  /** Optional callback to open the thread panel. */
+  onOpenThread?: () => void;
+  /** Close the popover and clear the prompt. */
+  closeAndReset: () => void;
+}
+
+const EditWithTamboButtonContext =
+  React.createContext<EditWithTamboButtonContextValue | null>(null);
+
+/**
+ * Hook to access the edit-with-tambo-button context.
+ * @returns The edit-with-tambo-button context value
+ * @throws Error if used outside of EditWithTamboButton.Root
+ */
+function useEditWithTamboButtonContext(): EditWithTamboButtonContextValue {
+  const context = React.useContext(EditWithTamboButtonContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: EditWithTamboButtonContext is missing. EditWithTamboButton parts must be used within <EditWithTamboButton.Root>",
+    );
+  }
+  return context;
+}
+
+export { EditWithTamboButtonContext, useEditWithTamboButtonContext };

--- a/packages/react-ui-base/src/edit-with-tambo-button/root/edit-with-tambo-button-root.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/root/edit-with-tambo-button-root.tsx
@@ -1,0 +1,196 @@
+import {
+  useTambo,
+  useTamboCurrentComponent,
+  useTamboThreadInput,
+} from "@tambo-ai/react";
+import * as React from "react";
+import {
+  EditWithTamboButtonContext,
+  type EditWithTamboButtonSendMode,
+} from "./edit-with-tambo-button-context";
+
+/**
+ * Minimal interface for a TipTap-like editor instance.
+ * Only the methods used for "Send in Thread" text insertion are required.
+ * Uses a broad `commands` type to remain compatible with the actual TipTap Editor.
+ */
+interface EditorLike {
+  commands: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setContent: (...args: any[]) => any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    focus: (...args: any[]) => any;
+  };
+}
+
+export interface EditWithTamboButtonRootProps {
+  children: React.ReactNode;
+  /** Custom tooltip text. Defaults to "Edit with tambo". */
+  tooltip?: string;
+  /** Optional callback to open the thread panel/chat interface. */
+  onOpenThread?: () => void;
+  /**
+   * Optional TipTap editor ref for inserting text when using "Send in Thread".
+   *
+   * NOTE: This implementation uses simple text insertion (setContent) to remain
+   * portable across different editor setups. It does NOT use TipTap Mention nodes
+   * or context attachments.
+   */
+  editorRef?: { readonly current: EditorLike | null };
+}
+
+/**
+ * Root primitive for the edit-with-tambo-button compound component.
+ * Provides context for all child sub-components. Manages prompt state,
+ * send mode, popover visibility, and submission logic.
+ *
+ * Renders nothing if the current component is not an interactable or if
+ * it belongs to a Tambo thread (has a threadId).
+ * @returns The root provider wrapping children, or null if not applicable.
+ */
+export function EditWithTamboButtonRoot({
+  children,
+  tooltip = "Edit with tambo",
+  onOpenThread,
+  editorRef,
+}: EditWithTamboButtonRootProps) {
+  const component = useTamboCurrentComponent();
+  const { sendThreadMessage, isIdle, setInteractableSelected } = useTambo();
+  const { setValue: setThreadInputValue } = useTamboThreadInput();
+
+  const [prompt, setPrompt] = React.useState("");
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [sendMode, setSendMode] =
+    React.useState<EditWithTamboButtonSendMode>("send");
+  const [dropdownOpen, setDropdownOpen] = React.useState(false);
+  const [shouldCloseOnComplete, setShouldCloseOnComplete] =
+    React.useState(false);
+
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  const isGenerating = !isIdle;
+
+  // Close popover when generation completes
+  React.useEffect(() => {
+    if (shouldCloseOnComplete && !isGenerating) {
+      setShouldCloseOnComplete(false);
+      setIsOpen(false);
+      setPrompt("");
+    }
+  }, [shouldCloseOnComplete, isGenerating]);
+
+  const closeAndReset = React.useCallback(() => {
+    setIsOpen(false);
+    setPrompt("");
+  }, []);
+
+  const handleSend = React.useCallback(async () => {
+    if (!prompt.trim() || isGenerating || !component) {
+      return;
+    }
+
+    setShouldCloseOnComplete(true);
+
+    await sendThreadMessage(prompt.trim(), {
+      streamResponse: true,
+      additionalContext: {
+        inlineEdit: {
+          componentId: component.interactableId,
+          instruction:
+            "The user wants to edit this specific component inline. Please update the component's props to fulfill the user's request.",
+        },
+      },
+    });
+
+    setPrompt("");
+  }, [prompt, isGenerating, component, sendThreadMessage]);
+
+  const handleSendInThread = React.useCallback(() => {
+    if (!prompt.trim()) {
+      return;
+    }
+
+    const messageToInsert = prompt.trim();
+
+    const interactableId = component?.interactableId ?? "";
+    if (interactableId) {
+      setInteractableSelected(interactableId, true);
+    }
+
+    if (onOpenThread) {
+      onOpenThread();
+    }
+
+    setPrompt("");
+    setIsOpen(false);
+
+    if (editorRef?.current) {
+      const editor = editorRef.current;
+      editor.commands.setContent(messageToInsert);
+      editor.commands.focus("end");
+    } else {
+      setThreadInputValue(messageToInsert);
+    }
+  }, [
+    prompt,
+    component,
+    onOpenThread,
+    editorRef,
+    setInteractableSelected,
+    setThreadInputValue,
+  ]);
+
+  const handleMainAction = React.useCallback(() => {
+    if (sendMode === "thread") {
+      handleSendInThread();
+    } else {
+      void handleSend();
+    }
+  }, [sendMode, handleSendInThread, handleSend]);
+
+  const handleKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleMainAction();
+      }
+    },
+    [handleMainAction],
+  );
+
+  // If no component, the current component is not an interactable - don't render.
+  if (!component) {
+    return null;
+  }
+
+  // If in a Tambo thread (message with threadId), don't show the button
+  if (component.threadId) {
+    return null;
+  }
+
+  const contextValue: React.ContextType<typeof EditWithTamboButtonContext> = {
+    component,
+    prompt,
+    setPrompt,
+    isOpen,
+    setIsOpen,
+    isGenerating,
+    sendMode,
+    setSendMode,
+    isDropdownOpen: dropdownOpen,
+    setDropdownOpen,
+    handleMainAction,
+    handleKeyDown,
+    textareaRef,
+    tooltip,
+    onOpenThread,
+    closeAndReset,
+  };
+
+  return (
+    <EditWithTamboButtonContext.Provider value={contextValue}>
+      {children}
+    </EditWithTamboButtonContext.Provider>
+  );
+}
+EditWithTamboButtonRoot.displayName = "EditWithTamboButton.Root";

--- a/packages/react-ui-base/src/edit-with-tambo-button/send-button/edit-with-tambo-button-send-button.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/send-button/edit-with-tambo-button-send-button.tsx
@@ -1,0 +1,77 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useEditWithTamboButtonContext } from "../root/edit-with-tambo-button-context";
+import type { EditWithTamboButtonSendMode } from "../root/edit-with-tambo-button-context";
+
+/**
+ * Props passed to the SendButton render function.
+ */
+export interface EditWithTamboButtonSendButtonRenderProps {
+  /** Whether the AI is currently generating. */
+  isGenerating: boolean;
+  /** The current send mode. */
+  sendMode: EditWithTamboButtonSendMode;
+  /** Whether the button is disabled (no prompt or generating). */
+  isDisabled: boolean;
+  /** The label to display on the button. */
+  label: string;
+}
+
+export type EditWithTamboButtonSendButtonProps =
+  BasePropsWithChildrenOrRenderFunction<
+    Omit<
+      React.ButtonHTMLAttributes<HTMLButtonElement>,
+      "onClick" | "disabled" | "children"
+    >,
+    EditWithTamboButtonSendButtonRenderProps
+  >;
+
+/**
+ * Main action button that sends the prompt.
+ * Delegates to either inline send or send-in-thread based on the current mode.
+ * Supports render props for custom label rendering.
+ * @returns A button element that triggers the main send action.
+ */
+export const EditWithTamboButtonSendButton = React.forwardRef<
+  HTMLButtonElement,
+  EditWithTamboButtonSendButtonProps
+>(({ asChild, ...props }, ref) => {
+  const { handleMainAction, prompt, isGenerating, sendMode } =
+    useEditWithTamboButtonContext();
+
+  const isDisabled = !prompt.trim() || isGenerating;
+
+  let label = "Send";
+  if (isGenerating) {
+    label = "Sending...";
+  } else if (sendMode === "thread") {
+    label = "Send in Thread";
+  }
+
+  const Comp = asChild ? Slot : "button";
+
+  const { content, componentProps } = useRender(props, {
+    isGenerating,
+    sendMode,
+    isDisabled,
+    label,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      type="button"
+      onClick={handleMainAction}
+      disabled={isDisabled}
+      data-slot="edit-with-tambo-button-send-button"
+      data-send-mode={sendMode}
+      data-generating={isGenerating || undefined}
+      {...componentProps}
+    >
+      {content ?? label}
+    </Comp>
+  );
+});
+EditWithTamboButtonSendButton.displayName = "EditWithTamboButton.SendButton";

--- a/packages/react-ui-base/src/edit-with-tambo-button/send-button/edit-with-tambo-button-send-mode-dropdown.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/send-button/edit-with-tambo-button-send-mode-dropdown.tsx
@@ -1,0 +1,44 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useEditWithTamboButtonContext } from "../root/edit-with-tambo-button-context";
+
+export type EditWithTamboButtonSendModeDropdownProps = BaseProps<
+  Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onClick" | "disabled">
+>;
+
+/**
+ * Dropdown trigger button for switching between send modes.
+ * Toggles the send mode dropdown open/closed state.
+ * Disabled when there is no prompt or when generating.
+ * @returns A button element that toggles the send mode dropdown.
+ */
+export const EditWithTamboButtonSendModeDropdown = React.forwardRef<
+  HTMLButtonElement,
+  EditWithTamboButtonSendModeDropdownProps
+>(({ asChild, children, ...props }, ref) => {
+  const { prompt, isGenerating, isDropdownOpen, setDropdownOpen } =
+    useEditWithTamboButtonContext();
+
+  const isDisabled = !prompt.trim() || isGenerating;
+
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      type="button"
+      onClick={() => setDropdownOpen(!isDropdownOpen)}
+      disabled={isDisabled}
+      aria-expanded={isDropdownOpen}
+      aria-haspopup="true"
+      data-slot="edit-with-tambo-button-send-mode-dropdown"
+      data-state={isDropdownOpen ? "open" : "closed"}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});
+EditWithTamboButtonSendModeDropdown.displayName =
+  "EditWithTamboButton.SendModeDropdown";

--- a/packages/react-ui-base/src/edit-with-tambo-button/send-button/edit-with-tambo-button-send-mode-option.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/send-button/edit-with-tambo-button-send-mode-option.tsx
@@ -1,0 +1,53 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useEditWithTamboButtonContext } from "../root/edit-with-tambo-button-context";
+import type { EditWithTamboButtonSendMode } from "../root/edit-with-tambo-button-context";
+
+export type EditWithTamboButtonSendModeOptionProps = BaseProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    /** The send mode this option represents. */
+    mode: EditWithTamboButtonSendMode;
+  }
+>;
+
+/**
+ * An individual send mode option within the dropdown.
+ * When clicked, sets the send mode and closes the dropdown.
+ * Exposes the active state via data attribute.
+ * @returns A button element representing a send mode option.
+ */
+export const EditWithTamboButtonSendModeOption = React.forwardRef<
+  HTMLButtonElement,
+  EditWithTamboButtonSendModeOptionProps
+>(({ asChild, mode, onClick, children, ...props }, ref) => {
+  const { sendMode, setSendMode, setDropdownOpen } =
+    useEditWithTamboButtonContext();
+
+  const isActive = sendMode === mode;
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    setSendMode(mode);
+    setDropdownOpen(false);
+    onClick?.(e);
+  };
+
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      type="button"
+      role="menuitem"
+      onClick={handleClick}
+      data-slot="edit-with-tambo-button-send-mode-option"
+      data-mode={mode}
+      data-active={isActive || undefined}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});
+EditWithTamboButtonSendModeOption.displayName =
+  "EditWithTamboButton.SendModeOption";

--- a/packages/react-ui-base/src/edit-with-tambo-button/status/edit-with-tambo-button-status.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/status/edit-with-tambo-button-status.tsx
@@ -1,0 +1,56 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useEditWithTamboButtonContext } from "../root/edit-with-tambo-button-context";
+
+/**
+ * Props passed to the Status render function.
+ */
+export interface EditWithTamboButtonStatusRenderProps {
+  /** Whether the AI is currently generating. */
+  isGenerating: boolean;
+  /** Whether an onOpenThread callback is available. */
+  hasOpenThread: boolean;
+  /** The onOpenThread callback, if provided. */
+  onOpenThread: (() => void) | undefined;
+}
+
+export type EditWithTamboButtonStatusProps =
+  BasePropsWithChildrenOrRenderFunction<
+    Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
+    EditWithTamboButtonStatusRenderProps
+  >;
+
+/**
+ * Status area that displays generation state or helper text.
+ * Supports render props for custom status rendering.
+ * Exposes generating state via data attributes.
+ * @returns A div element showing the current status.
+ */
+export const EditWithTamboButtonStatus = React.forwardRef<
+  HTMLDivElement,
+  EditWithTamboButtonStatusProps
+>(({ asChild, ...props }, ref) => {
+  const { isGenerating, onOpenThread } = useEditWithTamboButtonContext();
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    isGenerating,
+    hasOpenThread: !!onOpenThread,
+    onOpenThread,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="edit-with-tambo-button-status"
+      data-generating={isGenerating || undefined}
+      {...componentProps}
+    >
+      {content}
+    </Comp>
+  );
+});
+EditWithTamboButtonStatus.displayName = "EditWithTamboButton.Status";

--- a/packages/react-ui-base/src/edit-with-tambo-button/textarea/edit-with-tambo-button-textarea.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/textarea/edit-with-tambo-button-textarea.tsx
@@ -1,0 +1,58 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useEditWithTamboButtonContext } from "../root/edit-with-tambo-button-context";
+
+export type EditWithTamboButtonTextareaProps = BaseProps<
+  Omit<
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    "value" | "onChange" | "onKeyDown" | "disabled"
+  >
+>;
+
+/**
+ * Textarea for entering the edit prompt.
+ * Automatically binds to the prompt state, keyboard handler, and disabled state
+ * from context. Uses the textarea ref from context for auto-focus support.
+ * @returns A textarea element bound to the prompt state.
+ */
+export const EditWithTamboButtonTextarea = React.forwardRef<
+  HTMLTextAreaElement,
+  EditWithTamboButtonTextareaProps
+>(({ asChild, ...props }, ref) => {
+  const { prompt, setPrompt, handleKeyDown, isGenerating, textareaRef } =
+    useEditWithTamboButtonContext();
+
+  // Combine the forwarded ref with the context ref
+  const combinedRef = React.useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      (
+        textareaRef as React.MutableRefObject<HTMLTextAreaElement | null>
+      ).current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    },
+    [ref, textareaRef],
+  );
+
+  const Comp = asChild ? Slot : "textarea";
+
+  return (
+    <Comp
+      ref={combinedRef}
+      value={prompt}
+      onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+        setPrompt(e.target.value)
+      }
+      onKeyDown={handleKeyDown}
+      disabled={isGenerating}
+      data-slot="edit-with-tambo-button-textarea"
+      data-generating={isGenerating || undefined}
+      {...props}
+    />
+  );
+});
+EditWithTamboButtonTextarea.displayName = "EditWithTamboButton.Textarea";

--- a/packages/react-ui-base/src/edit-with-tambo-button/trigger/edit-with-tambo-button-trigger.tsx
+++ b/packages/react-ui-base/src/edit-with-tambo-button/trigger/edit-with-tambo-button-trigger.tsx
@@ -1,0 +1,37 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useEditWithTamboButtonContext } from "../root/edit-with-tambo-button-context";
+
+export type EditWithTamboButtonTriggerProps = BaseProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>;
+
+/**
+ * Trigger button that opens the edit popover.
+ * Renders with data attributes for the open state.
+ * @returns A button element that toggles the popover.
+ */
+export const EditWithTamboButtonTrigger = React.forwardRef<
+  HTMLButtonElement,
+  EditWithTamboButtonTriggerProps
+>(({ asChild, children, ...props }, ref) => {
+  const { tooltip, isOpen, setIsOpen } = useEditWithTamboButtonContext();
+
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      type="button"
+      aria-label={tooltip}
+      onClick={() => setIsOpen(!isOpen)}
+      data-slot="edit-with-tambo-button-trigger"
+      data-state={isOpen ? "open" : "closed"}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});
+EditWithTamboButtonTrigger.displayName = "EditWithTamboButton.Trigger";

--- a/packages/react-ui-base/src/elicitation-ui/actions/elicitation-ui-actions.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/actions/elicitation-ui-actions.tsx
@@ -1,0 +1,90 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useElicitationUIContext } from "../root/elicitation-ui-context";
+
+/**
+ * Props passed to the Actions render function.
+ */
+export interface ElicitationUIActionsRenderProps {
+  /** Whether the form is in single-entry mode. */
+  isSingleEntry: boolean;
+  /** Whether the form is currently valid for submission. */
+  isValid: boolean;
+  /** Submit handler (accept with current form data). */
+  onAccept: () => void;
+  /** Decline handler. */
+  onDecline: () => void;
+  /** Cancel handler. */
+  onCancel: () => void;
+}
+
+export type ElicitationUIActionsProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLDivElement>,
+  ElicitationUIActionsRenderProps
+>;
+
+/**
+ * Actions primitive for the elicitation UI.
+ * Container for submit, decline, and cancel buttons.
+ * In single-entry mode, provides only cancel and decline by default.
+ * In multi-field mode, also provides a submit button.
+ * @returns A div element containing action buttons
+ */
+export const ElicitationUIActions = React.forwardRef<
+  HTMLDivElement,
+  ElicitationUIActionsProps
+>(({ asChild, ...props }, ref) => {
+  const { isSingleEntry, isValid, handleAccept, handleDecline, handleCancel } =
+    useElicitationUIContext();
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    isSingleEntry,
+    isValid,
+    onAccept: handleAccept,
+    onDecline: handleDecline,
+    onCancel: handleCancel,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="elicitation-ui-actions"
+      data-single-entry={isSingleEntry || undefined}
+      {...componentProps}
+    >
+      {content ?? (
+        <>
+          <button
+            type="button"
+            onClick={handleCancel}
+            data-slot="elicitation-ui-cancel-button"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleDecline}
+            data-slot="elicitation-ui-decline-button"
+          >
+            Decline
+          </button>
+          {!isSingleEntry && (
+            <button
+              type="button"
+              onClick={handleAccept}
+              disabled={!isValid}
+              data-slot="elicitation-ui-submit-button"
+            >
+              Submit
+            </button>
+          )}
+        </>
+      )}
+    </Comp>
+  );
+});
+ElicitationUIActions.displayName = "ElicitationUI.Actions";

--- a/packages/react-ui-base/src/elicitation-ui/boolean-field/elicitation-ui-boolean-field.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/boolean-field/elicitation-ui-boolean-field.tsx
@@ -1,0 +1,136 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useElicitationUIContext } from "../root/elicitation-ui-context";
+import type { FieldSchema } from "../root/validation";
+
+/**
+ * Props passed to the BooleanField render function.
+ */
+export interface ElicitationUIBooleanFieldRenderProps {
+  /** The field name. */
+  name: string;
+  /** The field schema. */
+  schema: FieldSchema;
+  /** The label text (schema description or field name). */
+  label: string;
+  /** Whether the field is required. */
+  required: boolean;
+  /** Whether this field should auto-focus. */
+  autoFocus: boolean;
+  /** The current boolean value, or undefined if not set. */
+  value: boolean | undefined;
+  /** Whether the "Yes" option is selected. */
+  isYesSelected: boolean;
+  /** Whether the "No" option is selected. */
+  isNoSelected: boolean;
+  /** Handler to select "Yes". */
+  onSelectYes: () => void;
+  /** Handler to select "No". */
+  onSelectNo: () => void;
+}
+
+export type ElicitationUIBooleanFieldProps =
+  BasePropsWithChildrenOrRenderFunction<
+    React.HTMLAttributes<HTMLDivElement> & {
+      /** The field name key. */
+      name: string;
+      /** Whether this field should auto-focus. */
+      autoFocus?: boolean;
+    },
+    ElicitationUIBooleanFieldRenderProps
+  >;
+
+/**
+ * Boolean field primitive for the elicitation UI.
+ * Renders a yes/no selection for boolean schema fields.
+ * @returns A div element with yes/no button controls, or null if the field schema is not boolean
+ */
+export const ElicitationUIBooleanField = React.forwardRef<
+  HTMLDivElement,
+  ElicitationUIBooleanFieldProps
+>(({ name, autoFocus = false, asChild, ...props }, ref) => {
+  const {
+    fields,
+    requiredFields,
+    formData,
+    isSingleEntry,
+    handleFieldChange,
+    handleSingleEntryChange,
+  } = useElicitationUIContext();
+
+  const fieldEntry = fields.find(([fieldName]) => fieldName === name);
+  if (!fieldEntry) {
+    return null;
+  }
+
+  const [, schema] = fieldEntry;
+  if (schema.type !== "boolean") {
+    return null;
+  }
+
+  const required = requiredFields.includes(name);
+  const value = formData[name] as boolean | undefined;
+  const label = schema.description ?? name;
+  const onChange = isSingleEntry ? handleSingleEntryChange : handleFieldChange;
+
+  const onSelectYes = () => onChange(name, true);
+  const onSelectNo = () => onChange(name, false);
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    name,
+    schema,
+    label,
+    required,
+    autoFocus,
+    value,
+    isYesSelected: value === true,
+    isNoSelected: value === false,
+    onSelectYes,
+    onSelectNo,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="elicitation-ui-boolean-field"
+      data-field-name={name}
+      data-value={value === undefined ? undefined : String(value)}
+      {...componentProps}
+    >
+      {content ?? (
+        <>
+          <label data-slot="elicitation-ui-boolean-field-label">
+            {label}
+            {required && (
+              <span data-slot="elicitation-ui-required-marker">*</span>
+            )}
+          </label>
+          <div data-slot="elicitation-ui-boolean-field-options">
+            <button
+              type="button"
+              autoFocus={autoFocus}
+              onClick={onSelectYes}
+              data-slot="elicitation-ui-boolean-field-option"
+              data-selected={value === true || undefined}
+            >
+              Yes
+            </button>
+            <button
+              type="button"
+              onClick={onSelectNo}
+              data-slot="elicitation-ui-boolean-field-option"
+              data-selected={value === false || undefined}
+            >
+              No
+            </button>
+          </div>
+        </>
+      )}
+    </Comp>
+  );
+});
+ElicitationUIBooleanField.displayName = "ElicitationUI.BooleanField";

--- a/packages/react-ui-base/src/elicitation-ui/enum-field/elicitation-ui-enum-field.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/enum-field/elicitation-ui-enum-field.tsx
@@ -1,0 +1,143 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useElicitationUIContext } from "../root/elicitation-ui-context";
+import type { FieldSchema } from "../root/validation";
+
+/**
+ * A single enum option with its value and display name.
+ */
+export interface ElicitationUIEnumOption {
+  /** The enum value. */
+  value: string;
+  /** The display label (from enumNames or the value itself). */
+  label: string;
+  /** Whether this option is currently selected. */
+  isSelected: boolean;
+  /** Handler to select this option. */
+  onSelect: () => void;
+}
+
+/**
+ * Props passed to the EnumField render function.
+ */
+export interface ElicitationUIEnumFieldRenderProps {
+  /** The field name. */
+  name: string;
+  /** The field schema. */
+  schema: FieldSchema;
+  /** The label text (schema description or field name). */
+  label: string;
+  /** Whether the field is required. */
+  required: boolean;
+  /** Whether this field should auto-focus. */
+  autoFocus: boolean;
+  /** The current string value, or undefined if not set. */
+  value: string | undefined;
+  /** The enum options with selection state and handlers. */
+  options: ElicitationUIEnumOption[];
+}
+
+export type ElicitationUIEnumFieldProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** The field name key. */
+    name: string;
+    /** Whether this field should auto-focus. */
+    autoFocus?: boolean;
+  },
+  ElicitationUIEnumFieldRenderProps
+>;
+
+/**
+ * Enum field primitive for the elicitation UI.
+ * Renders selectable options for string enum schema fields.
+ * @returns A div element with option buttons, or null if the field schema is not a string enum
+ */
+export const ElicitationUIEnumField = React.forwardRef<
+  HTMLDivElement,
+  ElicitationUIEnumFieldProps
+>(({ name, autoFocus = false, asChild, ...props }, ref) => {
+  const {
+    fields,
+    requiredFields,
+    formData,
+    isSingleEntry,
+    handleFieldChange,
+    handleSingleEntryChange,
+  } = useElicitationUIContext();
+
+  const fieldEntry = fields.find(([fieldName]) => fieldName === name);
+  if (!fieldEntry) {
+    return null;
+  }
+
+  const [, schema] = fieldEntry;
+  if (schema.type !== "string" || !("enum" in schema)) {
+    return null;
+  }
+
+  const required = requiredFields.includes(name);
+  const value = formData[name] as string | undefined;
+  const label = schema.description ?? name;
+  const enumValues = schema.enum ?? [];
+  const enumNames =
+    "enumNames" in schema ? (schema.enumNames ?? []) : enumValues;
+  const onChange = isSingleEntry ? handleSingleEntryChange : handleFieldChange;
+
+  const options: ElicitationUIEnumOption[] = enumValues.map(
+    (optionValue, index) => ({
+      value: optionValue,
+      label: enumNames[index] ?? optionValue,
+      isSelected: value === optionValue,
+      onSelect: () => onChange(name, optionValue),
+    }),
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    name,
+    schema,
+    label,
+    required,
+    autoFocus,
+    value,
+    options,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="elicitation-ui-enum-field"
+      data-field-name={name}
+      {...componentProps}
+    >
+      {content ?? (
+        <>
+          <label data-slot="elicitation-ui-enum-field-label">
+            {label}
+            {required && (
+              <span data-slot="elicitation-ui-required-marker">*</span>
+            )}
+          </label>
+          <div data-slot="elicitation-ui-enum-field-options">
+            {options.map((option, index) => (
+              <button
+                key={option.value}
+                type="button"
+                autoFocus={autoFocus && index === 0}
+                onClick={option.onSelect}
+                data-slot="elicitation-ui-enum-field-option"
+                data-selected={option.isSelected || undefined}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </Comp>
+  );
+});
+ElicitationUIEnumField.displayName = "ElicitationUI.EnumField";

--- a/packages/react-ui-base/src/elicitation-ui/field/elicitation-ui-field.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/field/elicitation-ui-field.tsx
@@ -1,0 +1,177 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { ElicitationUIBooleanField } from "../boolean-field/elicitation-ui-boolean-field";
+import { ElicitationUIEnumField } from "../enum-field/elicitation-ui-enum-field";
+import { ElicitationUINumberField } from "../number-field/elicitation-ui-number-field";
+import { useElicitationUIContext } from "../root/elicitation-ui-context";
+import type { FieldSchema } from "../root/validation";
+import { getValidationError } from "../root/validation";
+import { ElicitationUIStringField } from "../string-field/elicitation-ui-string-field";
+
+/**
+ * The resolved field type for a given schema.
+ */
+export type ElicitationUIFieldType =
+  | "boolean"
+  | "enum"
+  | "string"
+  | "number"
+  | "unknown";
+
+/**
+ * Props passed to the Field render function.
+ */
+export interface ElicitationUIFieldRenderProps {
+  /** The field name. */
+  name: string;
+  /** The field schema. */
+  schema: FieldSchema;
+  /** The label text (schema description or field name). */
+  label: string;
+  /** Whether the field is required. */
+  required: boolean;
+  /** Whether this field should auto-focus. */
+  autoFocus: boolean;
+  /** The resolved field type. */
+  fieldType: ElicitationUIFieldType;
+  /** The current field value. */
+  value: unknown;
+  /** The validation error message, or null if valid/untouched. */
+  validationError: string | null;
+}
+
+export type ElicitationUIFieldProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** The field name key. */
+    name: string;
+    /** Whether this field should auto-focus. */
+    autoFocus?: boolean;
+  },
+  ElicitationUIFieldRenderProps
+>;
+
+/**
+ * Resolves the field type from a schema definition.
+ * @returns The field type string
+ */
+function resolveFieldType(schema: FieldSchema): ElicitationUIFieldType {
+  if (schema.type === "boolean") {
+    return "boolean";
+  }
+  if (schema.type === "string" && "enum" in schema) {
+    return "enum";
+  }
+  if (schema.type === "string") {
+    return "string";
+  }
+  if (schema.type === "number" || schema.type === "integer") {
+    return "number";
+  }
+  return "unknown";
+}
+
+/**
+ * Generic field primitive for the elicitation UI.
+ * Dispatches to the correct field type component based on the schema.
+ * When used with a render function or children, provides field metadata
+ * without rendering a specific field type.
+ * @returns A field component appropriate for the schema type, or null for unknown types
+ */
+export const ElicitationUIField = React.forwardRef<
+  HTMLDivElement,
+  ElicitationUIFieldProps
+>(({ name, autoFocus = false, asChild, ...props }, ref) => {
+  const { fields, requiredFields, formData, touchedFields } =
+    useElicitationUIContext();
+
+  const fieldEntry = fields.find(([fieldName]) => fieldName === name);
+  if (!fieldEntry) {
+    return null;
+  }
+
+  const [, schema] = fieldEntry;
+  const fieldType = resolveFieldType(schema);
+  const required = requiredFields.includes(name);
+  const value = formData[name];
+  const label = schema.description ?? name;
+  const validationError = touchedFields.has(name)
+    ? getValidationError(formData[name], schema, required)
+    : null;
+
+  const hasRenderOrChildren =
+    ("render" in props && typeof props.render === "function") ||
+    ("children" in props && props.children !== undefined);
+
+  // If a render function or children are provided, use them directly
+  if (hasRenderOrChildren) {
+    const Comp = asChild ? Slot : "div";
+
+    const { content, componentProps } = useRender(props, {
+      name,
+      schema,
+      label,
+      required,
+      autoFocus,
+      fieldType,
+      value,
+      validationError,
+    });
+
+    return (
+      <Comp
+        ref={ref}
+        data-slot="elicitation-ui-field"
+        data-field-name={name}
+        data-field-type={fieldType}
+        {...componentProps}
+      >
+        {content}
+      </Comp>
+    );
+  }
+
+  // Otherwise, dispatch to the appropriate field type component
+  switch (fieldType) {
+    case "boolean":
+      return (
+        <ElicitationUIBooleanField
+          ref={ref}
+          name={name}
+          autoFocus={autoFocus}
+          {...props}
+        />
+      );
+    case "enum":
+      return (
+        <ElicitationUIEnumField
+          ref={ref}
+          name={name}
+          autoFocus={autoFocus}
+          {...props}
+        />
+      );
+    case "string":
+      return (
+        <ElicitationUIStringField
+          ref={ref}
+          name={name}
+          autoFocus={autoFocus}
+          {...props}
+        />
+      );
+    case "number":
+      return (
+        <ElicitationUINumberField
+          ref={ref}
+          name={name}
+          autoFocus={autoFocus}
+          {...props}
+        />
+      );
+    default:
+      return null;
+  }
+});
+ElicitationUIField.displayName = "ElicitationUI.Field";

--- a/packages/react-ui-base/src/elicitation-ui/index.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/index.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ElicitationUIActions } from "./actions/elicitation-ui-actions";
+import { ElicitationUIBooleanField } from "./boolean-field/elicitation-ui-boolean-field";
+import { ElicitationUIEnumField } from "./enum-field/elicitation-ui-enum-field";
+import { ElicitationUIField } from "./field/elicitation-ui-field";
+import { ElicitationUINumberField } from "./number-field/elicitation-ui-number-field";
+import { ElicitationUIRoot } from "./root/elicitation-ui-root";
+import { ElicitationUIStringField } from "./string-field/elicitation-ui-string-field";
+import { ElicitationUITitle } from "./title/elicitation-ui-title";
+
+/**
+ * ElicitationUI namespace containing all elicitation UI base components.
+ */
+const ElicitationUIBase = {
+  Root: ElicitationUIRoot,
+  Title: ElicitationUITitle,
+  Field: ElicitationUIField,
+  BooleanField: ElicitationUIBooleanField,
+  StringField: ElicitationUIStringField,
+  NumberField: ElicitationUINumberField,
+  EnumField: ElicitationUIEnumField,
+  Actions: ElicitationUIActions,
+};
+
+export type {
+  ElicitationUIActionsProps,
+  ElicitationUIActionsRenderProps,
+} from "./actions/elicitation-ui-actions";
+export type {
+  ElicitationUIBooleanFieldProps,
+  ElicitationUIBooleanFieldRenderProps,
+} from "./boolean-field/elicitation-ui-boolean-field";
+export type {
+  ElicitationUIEnumFieldProps,
+  ElicitationUIEnumFieldRenderProps,
+  ElicitationUIEnumOption,
+} from "./enum-field/elicitation-ui-enum-field";
+export type {
+  ElicitationUIFieldProps,
+  ElicitationUIFieldRenderProps,
+  ElicitationUIFieldType,
+} from "./field/elicitation-ui-field";
+export type {
+  ElicitationUINumberFieldProps,
+  ElicitationUINumberFieldRenderProps,
+} from "./number-field/elicitation-ui-number-field";
+export type { ElicitationUIContextValue } from "./root/elicitation-ui-context";
+export type { ElicitationUIRootProps } from "./root/elicitation-ui-root";
+export type { FieldSchema } from "./root/validation";
+export {
+  getInputType,
+  getValidationError,
+  isSingleEntryMode,
+  validateField,
+} from "./root/validation";
+export type {
+  ElicitationUIStringFieldProps,
+  ElicitationUIStringFieldRenderProps,
+} from "./string-field/elicitation-ui-string-field";
+export type {
+  ElicitationUITitleProps,
+  ElicitationUITitleRenderProps,
+} from "./title/elicitation-ui-title";
+
+export { ElicitationUIBase };

--- a/packages/react-ui-base/src/elicitation-ui/number-field/elicitation-ui-number-field.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/number-field/elicitation-ui-number-field.tsx
@@ -1,0 +1,167 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useElicitationUIContext } from "../root/elicitation-ui-context";
+import { getValidationError, type FieldSchema } from "../root/validation";
+
+/**
+ * Props passed to the NumberField render function.
+ */
+export interface ElicitationUINumberFieldRenderProps {
+  /** The field name. */
+  name: string;
+  /** The field schema. */
+  schema: FieldSchema;
+  /** The label text (schema description or field name). */
+  label: string;
+  /** Whether the field is required. */
+  required: boolean;
+  /** Whether this field should auto-focus. */
+  autoFocus: boolean;
+  /** The current number value, or undefined if not set. */
+  value: number | undefined;
+  /** The validation error message, or null if valid. */
+  validationError: string | null;
+  /** Whether the field currently has a validation error. */
+  hasError: boolean;
+  /** The generated input element ID for label association. */
+  inputId: string;
+  /** The generated error element ID for aria-describedby. */
+  errorId: string;
+  /** Change handler accepting a number or undefined (for empty input). */
+  onChange: (value: number | undefined) => void;
+  /** Minimum value constraint from schema, if any. */
+  min: number | undefined;
+  /** Maximum value constraint from schema, if any. */
+  max: number | undefined;
+  /** Step value: 1 for integers, "any" for numbers. */
+  step: number | "any";
+}
+
+export type ElicitationUINumberFieldProps =
+  BasePropsWithChildrenOrRenderFunction<
+    React.HTMLAttributes<HTMLDivElement> & {
+      /** The field name key. */
+      name: string;
+      /** Whether this field should auto-focus. */
+      autoFocus?: boolean;
+    },
+    ElicitationUINumberFieldRenderProps
+  >;
+
+/**
+ * Number field primitive for the elicitation UI.
+ * Renders a number input with constraints and validation support.
+ * @returns A div element with a labeled number input, or null if the field schema is not number/integer
+ */
+export const ElicitationUINumberField = React.forwardRef<
+  HTMLDivElement,
+  ElicitationUINumberFieldProps
+>(({ name, autoFocus = false, asChild, ...props }, ref) => {
+  const inputId = React.useId();
+  const { fields, requiredFields, formData, touchedFields, handleFieldChange } =
+    useElicitationUIContext();
+
+  const fieldEntry = fields.find(([fieldName]) => fieldName === name);
+  if (!fieldEntry) {
+    return null;
+  }
+
+  const [, schema] = fieldEntry;
+  if (schema.type !== "number" && schema.type !== "integer") {
+    return null;
+  }
+
+  const required = requiredFields.includes(name);
+  const value = formData[name] as number | undefined;
+  const label = schema.description ?? name;
+  const validationError = touchedFields.has(name)
+    ? getValidationError(formData[name], schema, required)
+    : null;
+  const hasError = !!validationError;
+  const errorId = `${inputId}-error`;
+  const min = schema.minimum;
+  const max = schema.maximum;
+  const step: number | "any" = schema.type === "integer" ? 1 : "any";
+
+  const onChange = (newValue: number | undefined) =>
+    handleFieldChange(name, newValue);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value: rawValue, valueAsNumber } = e.currentTarget;
+    onChange(
+      rawValue === "" || Number.isNaN(valueAsNumber)
+        ? undefined
+        : valueAsNumber,
+    );
+  };
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    name,
+    schema,
+    label,
+    required,
+    autoFocus,
+    value,
+    validationError,
+    hasError,
+    inputId,
+    errorId,
+    onChange,
+    min,
+    max,
+    step,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="elicitation-ui-number-field"
+      data-field-name={name}
+      data-has-error={hasError || undefined}
+      {...componentProps}
+    >
+      {content ?? (
+        <>
+          <label
+            htmlFor={inputId}
+            data-slot="elicitation-ui-number-field-label"
+          >
+            {label}
+            {required && (
+              <span data-slot="elicitation-ui-required-marker">*</span>
+            )}
+          </label>
+          <input
+            id={inputId}
+            type="number"
+            autoFocus={autoFocus}
+            value={value ?? ""}
+            onChange={handleInputChange}
+            placeholder={label}
+            min={min}
+            max={max}
+            step={step}
+            required={required}
+            aria-invalid={hasError || undefined}
+            aria-describedby={hasError ? errorId : undefined}
+            data-slot="elicitation-ui-number-field-input"
+          />
+          {validationError && (
+            <p
+              id={errorId}
+              aria-live="polite"
+              data-slot="elicitation-ui-field-error"
+            >
+              {validationError}
+            </p>
+          )}
+        </>
+      )}
+    </Comp>
+  );
+});
+ElicitationUINumberField.displayName = "ElicitationUI.NumberField";

--- a/packages/react-ui-base/src/elicitation-ui/root/elicitation-ui-context.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/root/elicitation-ui-context.tsx
@@ -1,0 +1,54 @@
+import type { TamboElicitationRequest } from "@tambo-ai/react/mcp";
+import * as React from "react";
+import type { FieldSchema } from "./validation";
+
+/**
+ * Context value shared among ElicitationUI primitive sub-components.
+ */
+export interface ElicitationUIContextValue {
+  /** The original elicitation request. */
+  request: TamboElicitationRequest;
+  /** Whether the form is in single-entry mode (auto-submits on selection). */
+  isSingleEntry: boolean;
+  /** The ordered field entries: [fieldName, fieldSchema]. */
+  fields: [string, FieldSchema][];
+  /** The required field names. */
+  requiredFields: string[];
+  /** Current form data keyed by field name. */
+  formData: Record<string, unknown>;
+  /** Set of field names the user has interacted with. */
+  touchedFields: Set<string>;
+  /** Whether the entire form passes validation. */
+  isValid: boolean;
+  /** Change handler for a field value. */
+  handleFieldChange: (name: string, value: unknown) => void;
+  /** Change handler for single-entry mode (submits immediately). */
+  handleSingleEntryChange: (name: string, value: unknown) => void;
+  /** Submit handler (accept with current form data). */
+  handleAccept: () => void;
+  /** Decline handler. */
+  handleDecline: () => void;
+  /** Cancel handler. */
+  handleCancel: () => void;
+}
+
+const ElicitationUIContext =
+  React.createContext<ElicitationUIContextValue | null>(null);
+
+/**
+ * Hook to access the elicitation UI context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The elicitation UI context value
+ * @throws Error if used outside of ElicitationUI.Root component
+ */
+function useElicitationUIContext(): ElicitationUIContextValue {
+  const context = React.useContext(ElicitationUIContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: ElicitationUIContext is missing. ElicitationUI parts must be used within <ElicitationUI.Root>",
+    );
+  }
+  return context;
+}
+
+export { ElicitationUIContext, useElicitationUIContext };

--- a/packages/react-ui-base/src/elicitation-ui/root/elicitation-ui-root.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/root/elicitation-ui-root.tsx
@@ -1,0 +1,146 @@
+import { Slot } from "@radix-ui/react-slot";
+import type {
+  TamboElicitationRequest,
+  TamboElicitationResponse,
+} from "@tambo-ai/react/mcp";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { ElicitationUIContext } from "./elicitation-ui-context";
+import { isSingleEntryMode, validateField } from "./validation";
+
+export type ElicitationUIRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** The active elicitation request from the MCP server. */
+    request: TamboElicitationRequest;
+    /** Callback fired when the user accepts, declines, or cancels. */
+    onResponse: (response: TamboElicitationResponse) => void;
+  }
+>;
+
+/**
+ * Root primitive for the elicitation UI component.
+ * Provides context with form state, validation, and handlers for child components.
+ * @returns A context-providing wrapper element for elicitation sub-components
+ */
+export const ElicitationUIRoot = React.forwardRef<
+  HTMLDivElement,
+  ElicitationUIRootProps
+>(function ElicitationUIRoot(
+  { children, request, onResponse, asChild, ...props },
+  ref,
+) {
+  const singleEntry = isSingleEntryMode(request);
+
+  const fields = React.useMemo(
+    () => Object.entries(request.requestedSchema.properties),
+    [request.requestedSchema.properties],
+  );
+
+  const requiredFields = React.useMemo(
+    () => request.requestedSchema.required ?? [],
+    [request.requestedSchema.required],
+  );
+
+  const [formData, setFormData] = React.useState<Record<string, unknown>>(
+    () => {
+      const initial: Record<string, unknown> = {};
+      fields.forEach(([name, schema]) => {
+        if (schema.default !== undefined) {
+          initial[name] = schema.default;
+        }
+      });
+      return initial;
+    },
+  );
+
+  const [touchedFields, setTouchedFields] = React.useState<Set<string>>(
+    new Set(),
+  );
+
+  const isValid = fields.every(([fieldName, fieldSchema]) => {
+    const value = formData[fieldName];
+    const isRequired = requiredFields.includes(fieldName);
+    return validateField(value, fieldSchema, isRequired).valid;
+  });
+
+  const handleFieldChange = React.useCallback(
+    (name: string, value: unknown) => {
+      setFormData((prev) => ({ ...prev, [name]: value }));
+      setTouchedFields((prev) => new Set(prev).add(name));
+    },
+    [],
+  );
+
+  const handleSingleEntryChange = React.useCallback(
+    (name: string, value: unknown) => {
+      const updatedData = { ...formData, [name]: value };
+      setFormData(updatedData);
+      setTouchedFields((prev) => new Set(prev).add(name));
+      onResponse({ action: "accept", content: updatedData });
+    },
+    [formData, onResponse],
+  );
+
+  const handleAccept = React.useCallback(() => {
+    if (!isValid) {
+      setTouchedFields(new Set(fields.map(([name]) => name)));
+      return;
+    }
+    onResponse({ action: "accept", content: formData });
+  }, [isValid, fields, formData, onResponse]);
+
+  const handleDecline = React.useCallback(() => {
+    onResponse({ action: "decline" });
+  }, [onResponse]);
+
+  const handleCancel = React.useCallback(() => {
+    onResponse({ action: "cancel" });
+  }, [onResponse]);
+
+  const contextValue = React.useMemo(
+    () => ({
+      request,
+      isSingleEntry: singleEntry,
+      fields,
+      requiredFields,
+      formData,
+      touchedFields,
+      isValid,
+      handleFieldChange,
+      handleSingleEntryChange,
+      handleAccept,
+      handleDecline,
+      handleCancel,
+    }),
+    [
+      request,
+      singleEntry,
+      fields,
+      requiredFields,
+      formData,
+      touchedFields,
+      isValid,
+      handleFieldChange,
+      handleSingleEntryChange,
+      handleAccept,
+      handleDecline,
+      handleCancel,
+    ],
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <ElicitationUIContext.Provider value={contextValue}>
+      <Comp
+        ref={ref}
+        data-slot="elicitation-ui-root"
+        data-single-entry={singleEntry || undefined}
+        {...props}
+      >
+        {children}
+      </Comp>
+    </ElicitationUIContext.Provider>
+  );
+});
+ElicitationUIRoot.displayName = "ElicitationUI.Root";

--- a/packages/react-ui-base/src/elicitation-ui/root/validation.ts
+++ b/packages/react-ui-base/src/elicitation-ui/root/validation.ts
@@ -1,0 +1,175 @@
+import type { TamboElicitationRequest } from "@tambo-ai/react/mcp";
+
+export type FieldSchema =
+  TamboElicitationRequest["requestedSchema"]["properties"][string];
+
+/**
+ * Unified validation function that returns both validity and a user-facing message.
+ * Avoids drift between boolean validation and error computation.
+ * @returns An object with `valid` (boolean) and `error` (string or null)
+ */
+export function validateField(
+  value: unknown,
+  schema: FieldSchema,
+  required: boolean,
+): { valid: boolean; error: string | null } {
+  // Required
+  if (required && (value === undefined || value === "" || value === null)) {
+    return { valid: false, error: "This field is required" };
+  }
+
+  // If empty and not required, it's valid
+  if (!required && (value === undefined || value === "" || value === null)) {
+    return { valid: true, error: null };
+  }
+
+  // String validation
+  if (schema.type === "string") {
+    const stringSchema = schema;
+    const stringValue = String(value);
+
+    if (
+      "minLength" in stringSchema &&
+      stringSchema.minLength !== undefined &&
+      stringValue.length < stringSchema.minLength
+    ) {
+      return {
+        valid: false,
+        error: `Minimum length is ${stringSchema.minLength} characters`,
+      };
+    }
+
+    if (
+      "maxLength" in stringSchema &&
+      stringSchema.maxLength !== undefined &&
+      stringValue.length > stringSchema.maxLength
+    ) {
+      return {
+        valid: false,
+        error: `Maximum length is ${stringSchema.maxLength} characters`,
+      };
+    }
+
+    if ("pattern" in stringSchema && stringSchema.pattern) {
+      try {
+        const regex = new RegExp(stringSchema.pattern as string);
+        if (!regex.test(stringValue)) {
+          return {
+            valid: false,
+            error: "Value does not match required pattern",
+          };
+        }
+      } catch {
+        // Invalid regex pattern, skip validation
+      }
+    }
+
+    // Format validation
+    if ("format" in stringSchema && stringSchema.format) {
+      switch (stringSchema.format) {
+        case "email":
+          if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(stringValue)) {
+            return {
+              valid: false,
+              error: "Please enter a valid email address",
+            };
+          }
+          break;
+        case "uri":
+          try {
+            new URL(stringValue);
+          } catch {
+            return { valid: false, error: "Please enter a valid URL" };
+          }
+          break;
+      }
+    }
+  }
+
+  // Number validation
+  if (schema.type === "number" || schema.type === "integer") {
+    const numberSchema = schema;
+    const numberValue = Number(value);
+
+    if (Number.isNaN(numberValue)) {
+      return { valid: false, error: "Please enter a valid number" };
+    }
+
+    if (
+      numberSchema.minimum !== undefined &&
+      numberValue < numberSchema.minimum
+    ) {
+      return {
+        valid: false,
+        error: `Minimum value is ${numberSchema.minimum}`,
+      };
+    }
+
+    if (
+      numberSchema.maximum !== undefined &&
+      numberValue > numberSchema.maximum
+    ) {
+      return {
+        valid: false,
+        error: `Maximum value is ${numberSchema.maximum}`,
+      };
+    }
+
+    if (schema.type === "integer" && !Number.isInteger(numberValue)) {
+      return { valid: false, error: "Please enter a whole number" };
+    }
+  }
+
+  return { valid: true, error: null };
+}
+
+/**
+ * Backwards-compatible helper that delegates to the unified validator.
+ * @returns A validation error message, or null if valid
+ */
+export function getValidationError(
+  value: unknown,
+  schema: FieldSchema,
+  required: boolean,
+): string | null {
+  return validateField(value, schema, required).error;
+}
+
+/**
+ * Determines if the elicitation should use single-entry mode
+ * (one field that is boolean or enum).
+ * @returns true when the request contains exactly one boolean or enum field
+ */
+export function isSingleEntryMode(request: TamboElicitationRequest): boolean {
+  const fields = Object.entries(request.requestedSchema.properties);
+
+  if (fields.length !== 1) {
+    return false;
+  }
+
+  const [, schema] = fields[0];
+
+  return (
+    schema.type === "boolean" || (schema.type === "string" && "enum" in schema)
+  );
+}
+
+/**
+ * Maps JSON Schema format to HTML5 input type.
+ * @returns The appropriate HTML input type string
+ */
+export function getInputType(schema: FieldSchema & { type: "string" }): string {
+  const format = "format" in schema ? schema.format : undefined;
+  switch (format) {
+    case "email":
+      return "email";
+    case "uri":
+      return "url";
+    case "date":
+      return "date";
+    case "date-time":
+      return "datetime-local";
+    default:
+      return "text";
+  }
+}

--- a/packages/react-ui-base/src/elicitation-ui/string-field/elicitation-ui-string-field.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/string-field/elicitation-ui-string-field.tsx
@@ -1,0 +1,165 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useElicitationUIContext } from "../root/elicitation-ui-context";
+import {
+  getInputType,
+  getValidationError,
+  type FieldSchema,
+} from "../root/validation";
+
+/**
+ * Props passed to the StringField render function.
+ */
+export interface ElicitationUIStringFieldRenderProps {
+  /** The field name. */
+  name: string;
+  /** The field schema. */
+  schema: FieldSchema;
+  /** The label text (schema description or field name). */
+  label: string;
+  /** Whether the field is required. */
+  required: boolean;
+  /** Whether this field should auto-focus. */
+  autoFocus: boolean;
+  /** The current string value. */
+  value: string;
+  /** The HTML input type derived from the schema format. */
+  inputType: string;
+  /** The validation error message, or null if valid. */
+  validationError: string | null;
+  /** Whether the field currently has a validation error. */
+  hasError: boolean;
+  /** The generated input element ID for label association. */
+  inputId: string;
+  /** The generated error element ID for aria-describedby. */
+  errorId: string;
+  /** Change handler for the input value. */
+  onChange: (value: string) => void;
+  /** Min length constraint from schema, if any. */
+  minLength: number | undefined;
+  /** Max length constraint from schema, if any. */
+  maxLength: number | undefined;
+}
+
+export type ElicitationUIStringFieldProps =
+  BasePropsWithChildrenOrRenderFunction<
+    React.HTMLAttributes<HTMLDivElement> & {
+      /** The field name key. */
+      name: string;
+      /** Whether this field should auto-focus. */
+      autoFocus?: boolean;
+    },
+    ElicitationUIStringFieldRenderProps
+  >;
+
+/**
+ * String field primitive for the elicitation UI.
+ * Renders a text input with format and validation support.
+ * @returns A div element with a labeled text input, or null if the field schema is not a plain string
+ */
+export const ElicitationUIStringField = React.forwardRef<
+  HTMLDivElement,
+  ElicitationUIStringFieldProps
+>(({ name, autoFocus = false, asChild, ...props }, ref) => {
+  const inputId = React.useId();
+  const { fields, requiredFields, formData, touchedFields, handleFieldChange } =
+    useElicitationUIContext();
+
+  const fieldEntry = fields.find(([fieldName]) => fieldName === name);
+  if (!fieldEntry) {
+    return null;
+  }
+
+  const [, schema] = fieldEntry;
+  if (schema.type !== "string") {
+    return null;
+  }
+
+  // Enum strings are handled by EnumField
+  if ("enum" in schema) {
+    return null;
+  }
+
+  const required = requiredFields.includes(name);
+  const value = (formData[name] as string | undefined) ?? "";
+  const label = schema.description ?? name;
+  const inputType = getInputType(schema);
+  const validationError = touchedFields.has(name)
+    ? getValidationError(formData[name], schema, required)
+    : null;
+  const hasError = !!validationError;
+  const errorId = `${inputId}-error`;
+  const minLength = "minLength" in schema ? schema.minLength : undefined;
+  const maxLength = "maxLength" in schema ? schema.maxLength : undefined;
+
+  const onChange = (newValue: string) => handleFieldChange(name, newValue);
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    name,
+    schema,
+    label,
+    required,
+    autoFocus,
+    value,
+    inputType,
+    validationError,
+    hasError,
+    inputId,
+    errorId,
+    onChange,
+    minLength,
+    maxLength,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="elicitation-ui-string-field"
+      data-field-name={name}
+      data-has-error={hasError || undefined}
+      {...componentProps}
+    >
+      {content ?? (
+        <>
+          <label
+            htmlFor={inputId}
+            data-slot="elicitation-ui-string-field-label"
+          >
+            {label}
+            {required && (
+              <span data-slot="elicitation-ui-required-marker">*</span>
+            )}
+          </label>
+          <input
+            id={inputId}
+            type={inputType}
+            autoFocus={autoFocus}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={label}
+            minLength={minLength}
+            maxLength={maxLength}
+            required={required}
+            aria-invalid={hasError || undefined}
+            aria-describedby={hasError ? errorId : undefined}
+            data-slot="elicitation-ui-string-field-input"
+          />
+          {validationError && (
+            <p
+              id={errorId}
+              aria-live="polite"
+              data-slot="elicitation-ui-field-error"
+            >
+              {validationError}
+            </p>
+          )}
+        </>
+      )}
+    </Comp>
+  );
+});
+ElicitationUIStringField.displayName = "ElicitationUI.StringField";

--- a/packages/react-ui-base/src/elicitation-ui/title/elicitation-ui-title.tsx
+++ b/packages/react-ui-base/src/elicitation-ui/title/elicitation-ui-title.tsx
@@ -1,0 +1,43 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useElicitationUIContext } from "../root/elicitation-ui-context";
+
+/**
+ * Props passed to the Title render function.
+ */
+export interface ElicitationUITitleRenderProps {
+  /** The elicitation message text. */
+  message: string;
+}
+
+export type ElicitationUITitleProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLDivElement>,
+  ElicitationUITitleRenderProps
+>;
+
+/**
+ * Title primitive for the elicitation UI.
+ * Displays the elicitation message/prompt text.
+ * @returns A div element containing the elicitation title
+ */
+export const ElicitationUITitle = React.forwardRef<
+  HTMLDivElement,
+  ElicitationUITitleProps
+>(({ asChild, ...props }, ref) => {
+  const { request } = useElicitationUIContext();
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    message: request.message,
+  });
+
+  return (
+    <Comp ref={ref} data-slot="elicitation-ui-title" {...componentProps}>
+      {content ?? request.message}
+    </Comp>
+  );
+});
+ElicitationUITitle.displayName = "ElicitationUI.Title";

--- a/packages/react-ui-base/src/form/error/form-error.tsx
+++ b/packages/react-ui-base/src/form/error/form-error.tsx
@@ -1,0 +1,29 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useFormRootContext } from "../root/form-root-context";
+
+export type FormErrorProps = BaseProps<React.HTMLAttributes<HTMLDivElement>>;
+
+/**
+ * Error primitive for displaying form-level errors.
+ * Only renders when an error message is present in the form context.
+ * @returns The rendered error element, or null if no error exists
+ */
+export const FormError = React.forwardRef<HTMLDivElement, FormErrorProps>(
+  function FormError({ asChild, children, ...props }, ref) {
+    const { errorMessage } = useFormRootContext();
+
+    if (!errorMessage) {
+      return null;
+    }
+
+    const Comp = asChild ? Slot : "div";
+
+    return (
+      <Comp ref={ref} data-slot="form-error" {...props}>
+        {children ?? <p>{errorMessage}</p>}
+      </Comp>
+    );
+  },
+);

--- a/packages/react-ui-base/src/form/field/form-field.tsx
+++ b/packages/react-ui-base/src/form/field/form-field.tsx
@@ -1,0 +1,437 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import {
+  FormFieldDefinition,
+  useFormRootContext,
+} from "../root/form-root-context";
+
+export type FormFieldProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** The field definition to render. */
+    field: FormFieldDefinition;
+  }
+>;
+
+/**
+ * Field primitive that renders a single form field with its label, description, and input.
+ * Handles all field types: text, number, select, textarea, radio, checkbox, slider, yes-no.
+ * @returns The rendered field element
+ */
+export const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
+  function FormField({ field, asChild, children, ...props }, ref) {
+    const Comp = asChild ? Slot : "div";
+
+    return (
+      <Comp
+        ref={ref}
+        data-slot="form-field"
+        data-field-id={field.id}
+        data-field-type={field.type}
+        {...props}
+      >
+        {children ?? <FormFieldDefault field={field} />}
+      </Comp>
+    );
+  },
+);
+
+/**
+ * Props for the FormFieldLabel sub-component.
+ */
+export type FormFieldLabelProps = BaseProps<
+  React.LabelHTMLAttributes<HTMLLabelElement> & {
+    /** The field definition. */
+    field: FormFieldDefinition;
+  }
+>;
+
+/**
+ * Label primitive for a form field.
+ * Displays the field label with a required indicator when applicable.
+ * @returns The rendered label element
+ */
+export const FormFieldLabel = React.forwardRef<
+  HTMLLabelElement,
+  FormFieldLabelProps
+>(function FormFieldLabel({ field, asChild, children, ...props }, ref) {
+  const Comp = asChild ? Slot : "label";
+
+  return (
+    <Comp ref={ref} data-slot="form-field-label" htmlFor={field.id} {...props}>
+      {children ?? (
+        <>
+          {field.label}
+          {field.required && <span data-slot="form-field-required">*</span>}
+        </>
+      )}
+    </Comp>
+  );
+});
+
+/**
+ * Props for the FormFieldDescription sub-component.
+ */
+export type FormFieldDescriptionProps = BaseProps<
+  React.HTMLAttributes<HTMLParagraphElement> & {
+    /** The field definition. */
+    field: FormFieldDefinition;
+  }
+>;
+
+/**
+ * Description primitive for a form field.
+ * Only renders when the field has a description.
+ * @returns The rendered description element, or null if no description exists
+ */
+export const FormFieldDescription = React.forwardRef<
+  HTMLParagraphElement,
+  FormFieldDescriptionProps
+>(function FormFieldDescription({ field, asChild, children, ...props }, ref) {
+  if (!field.description) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "p";
+
+  return (
+    <Comp ref={ref} data-slot="form-field-description" {...props}>
+      {children ?? field.description}
+    </Comp>
+  );
+});
+
+/**
+ * Props for the FormFieldInput sub-component.
+ */
+export type FormFieldInputProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** The field definition. */
+    field: FormFieldDefinition;
+  }
+>;
+
+/**
+ * Input primitive for a form field.
+ * Renders the appropriate input element based on field type.
+ * @returns The rendered input element
+ */
+export const FormFieldInput = React.forwardRef<
+  HTMLDivElement,
+  FormFieldInputProps
+>(function FormFieldInput({ field, asChild, children, ...props }, ref) {
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp ref={ref} data-slot="form-field-input" {...props}>
+      {children ?? <FormFieldInputDefault field={field} />}
+    </Comp>
+  );
+});
+
+/**
+ * Default field rendering including label, description, and input.
+ * Used when no children are provided to FormField.
+ */
+function FormFieldDefault({ field }: { field: FormFieldDefinition }) {
+  return (
+    <>
+      <FormFieldLabel field={field} />
+      <FormFieldDescription field={field} />
+      <FormFieldInputDefault field={field} />
+    </>
+  );
+}
+
+/**
+ * Default input rendering that dispatches to type-specific renderers.
+ */
+function FormFieldInputDefault({ field }: { field: FormFieldDefinition }) {
+  switch (field.type) {
+    case "text":
+      return <FormFieldText field={field} />;
+    case "number":
+      return <FormFieldNumber field={field} />;
+    case "textarea":
+      return <FormFieldTextarea field={field} />;
+    case "select":
+      return <FormFieldSelect field={field} />;
+    case "radio":
+      return <FormFieldRadio field={field} />;
+    case "checkbox":
+      return <FormFieldCheckbox field={field} />;
+    case "slider":
+      return <FormFieldSlider field={field} />;
+    case "yes-no":
+      return <FormFieldYesNo field={field} />;
+  }
+}
+
+/**
+ * Text input field.
+ */
+function FormFieldText({ field }: { field: FormFieldDefinition }) {
+  return (
+    <input
+      type="text"
+      id={field.id}
+      name={field.id}
+      placeholder={field.placeholder}
+      required={field.required}
+      data-slot="form-field-text"
+    />
+  );
+}
+
+/**
+ * Number input field.
+ */
+function FormFieldNumber({ field }: { field: FormFieldDefinition }) {
+  return (
+    <input
+      type="number"
+      id={field.id}
+      name={field.id}
+      placeholder={field.placeholder}
+      required={field.required}
+      data-slot="form-field-number"
+    />
+  );
+}
+
+/**
+ * Textarea field.
+ */
+function FormFieldTextarea({ field }: { field: FormFieldDefinition }) {
+  return (
+    <textarea
+      id={field.id}
+      name={field.id}
+      placeholder={field.placeholder}
+      required={field.required}
+      rows={4}
+      data-slot="form-field-textarea"
+    />
+  );
+}
+
+/**
+ * Select dropdown field.
+ */
+function FormFieldSelect({ field }: { field: FormFieldDefinition }) {
+  const { state, dropdownRefs, handleDropdownToggle, handleOptionSelect } =
+    useFormRootContext();
+
+  if (!field.options) return null;
+
+  return (
+    <div
+      data-slot="form-field-select"
+      ref={(el) => {
+        if (dropdownRefs.current) {
+          dropdownRefs.current[field.id] = el;
+        }
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => handleDropdownToggle(field.id)}
+        data-slot="form-field-select-trigger"
+        data-open={state.openDropdowns[field.id] || undefined}
+      >
+        <span
+          data-slot="form-field-select-value"
+          data-placeholder={!state.selectedValues[field.id] || undefined}
+        >
+          {state.selectedValues[field.id] ?? field.placeholder}
+        </span>
+        <svg
+          data-slot="form-field-select-icon"
+          data-open={state.openDropdowns[field.id] || undefined}
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+        >
+          <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" />
+        </svg>
+      </button>
+
+      {state.openDropdowns[field.id] && (
+        <div data-slot="form-field-select-options">
+          {field.options.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => handleOptionSelect(field.id, option)}
+              data-slot="form-field-select-option"
+              data-selected={
+                state.selectedValues[field.id] === option || undefined
+              }
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      )}
+      <input
+        type="hidden"
+        name={field.id}
+        value={state.selectedValues[field.id] ?? ""}
+        required={field.required}
+      />
+    </div>
+  );
+}
+
+/**
+ * Radio button group field.
+ */
+function FormFieldRadio({ field }: { field: FormFieldDefinition }) {
+  if (!field.options) return null;
+
+  return (
+    <div data-slot="form-field-radio">
+      {field.options.map((option) => (
+        <label key={option} data-slot="form-field-radio-option">
+          <input
+            type="radio"
+            id={`${field.id}-${option}`}
+            name={field.id}
+            value={option}
+            required={field.required}
+          />
+          <span>{option}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Checkbox group field.
+ */
+function FormFieldCheckbox({ field }: { field: FormFieldDefinition }) {
+  const { state, handleCheckboxChange } = useFormRootContext();
+
+  if (!field.options) return null;
+
+  return (
+    <div data-slot="form-field-checkbox">
+      {field.options.map((option) => {
+        const selections = state.checkboxSelections[field.id] ?? [];
+        const isChecked = selections.includes(option);
+
+        return (
+          <label key={option} data-slot="form-field-checkbox-option">
+            <input
+              type="checkbox"
+              id={`${field.id}-${option}`}
+              checked={isChecked}
+              value={option}
+              onChange={(e) =>
+                handleCheckboxChange(field.id, option, e.target.checked)
+              }
+            />
+            <span>{option}</span>
+          </label>
+        );
+      })}
+      <input
+        type="hidden"
+        name={field.id}
+        value={state.checkboxSelections[field.id]?.join(",") ?? ""}
+      />
+    </div>
+  );
+}
+
+/**
+ * Slider/range field.
+ */
+function FormFieldSlider({ field }: { field: FormFieldDefinition }) {
+  const { state, handleSliderChange, getDefaultSliderValue } =
+    useFormRootContext();
+
+  const maxValue =
+    field.sliderLabels && field.sliderLabels.length > 0
+      ? (field.sliderLabels.length - 1).toString()
+      : (field.sliderMax ?? 10).toString();
+
+  const currentValue =
+    state.values[field.id]?.split(" : ")[0] ??
+    field.sliderDefault?.toString() ??
+    (field.sliderLabels && field.sliderLabels.length > 0
+      ? Math.floor((field.sliderLabels.length - 1) / 2).toString()
+      : "5");
+
+  return (
+    <div data-slot="form-field-slider">
+      <input
+        type="range"
+        id={`${field.id}-range`}
+        min="0"
+        max={maxValue}
+        step="1"
+        value={currentValue}
+        required={field.required}
+        data-slot="form-field-slider-input"
+        onChange={(e) => handleSliderChange(field.id, e.target.value, field)}
+      />
+      <input
+        type="hidden"
+        name={field.id}
+        value={state.values[field.id] ?? getDefaultSliderValue(field)}
+      />
+      {field.sliderLabels && field.sliderLabels.length > 0 ? (
+        <div data-slot="form-field-slider-labels">
+          {field.sliderLabels.map((label, index) => (
+            <span key={index}>{label}</span>
+          ))}
+        </div>
+      ) : (
+        <div data-slot="form-field-slider-labels">
+          <span>Min</span>
+          <span>Mid</span>
+          <span>Max</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Yes/No toggle field.
+ */
+function FormFieldYesNo({ field }: { field: FormFieldDefinition }) {
+  const { state, handleYesNoSelection } = useFormRootContext();
+
+  return (
+    <div data-slot="form-field-yesno">
+      <button
+        type="button"
+        onClick={() => handleYesNoSelection(field.id, "Yes")}
+        data-slot="form-field-yesno-option"
+        data-selected={state.yesNoSelections[field.id] === "Yes" || undefined}
+        data-value="yes"
+      >
+        Yes
+      </button>
+      <button
+        type="button"
+        onClick={() => handleYesNoSelection(field.id, "No")}
+        data-slot="form-field-yesno-option"
+        data-selected={state.yesNoSelections[field.id] === "No" || undefined}
+        data-value="no"
+      >
+        No
+      </button>
+      <input
+        type="hidden"
+        id={field.id}
+        name={field.id}
+        value={state.yesNoSelections[field.id] ?? ""}
+        required={field.required}
+      />
+    </div>
+  );
+}

--- a/packages/react-ui-base/src/form/fields/form-fields.tsx
+++ b/packages/react-ui-base/src/form/fields/form-fields.tsx
@@ -1,0 +1,45 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import {
+  FormFieldDefinition,
+  useFormRootContext,
+} from "../root/form-root-context";
+
+/**
+ * Props passed to the render function of FormFields.
+ */
+export interface FormFieldsRenderProps {
+  /** The validated array of form field definitions. */
+  fields: FormFieldDefinition[];
+}
+
+export type FormFieldsProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+>;
+
+/**
+ * Fields container primitive that provides the validated fields list.
+ * Uses a render prop to delegate field rendering to the consumer.
+ * @returns The rendered fields container element
+ */
+export const FormFields = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<FormFieldsProps, FormFieldsRenderProps>
+>(function FormFields({ asChild, ...props }, ref) {
+  const { validFields } = useFormRootContext();
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    fields: validFields,
+  });
+
+  return (
+    <Comp ref={ref} data-slot="form-fields" {...componentProps}>
+      {content}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/form/index.tsx
+++ b/packages/react-ui-base/src/form/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { FormError } from "./error/form-error";
+import {
+  FormField,
+  FormFieldDescription,
+  FormFieldInput,
+  FormFieldLabel,
+} from "./field/form-field";
+import { FormFields } from "./fields/form-fields";
+import { FormRoot } from "./root/form-root";
+import { FormSubmit } from "./submit/form-submit";
+
+/**
+ * Form namespace containing all form base components.
+ */
+const Form = {
+  Root: FormRoot,
+  Error: FormError,
+  Fields: FormFields,
+  Field: FormField,
+  FieldLabel: FormFieldLabel,
+  FieldDescription: FormFieldDescription,
+  FieldInput: FormFieldInput,
+  Submit: FormSubmit,
+};
+
+export type { FormErrorProps } from "./error/form-error";
+export type {
+  FormFieldDescriptionProps,
+  FormFieldInputProps,
+  FormFieldLabelProps,
+  FormFieldProps,
+} from "./field/form-field";
+export type {
+  FormFieldsProps,
+  FormFieldsRenderProps,
+} from "./fields/form-fields";
+export type {
+  FormFieldDefinition,
+  FormFieldType,
+  FormRootContextValue,
+  FormState,
+} from "./root/form-root-context";
+export type { FormRootProps } from "./root/form-root";
+export type {
+  FormSubmitProps,
+  FormSubmitRenderProps,
+} from "./submit/form-submit";
+
+export { Form };

--- a/packages/react-ui-base/src/form/root/form-root-context.tsx
+++ b/packages/react-ui-base/src/form/root/form-root-context.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+
+/**
+ * Supported form field types.
+ */
+export type FormFieldType =
+  | "text"
+  | "number"
+  | "select"
+  | "textarea"
+  | "radio"
+  | "checkbox"
+  | "slider"
+  | "yes-no";
+
+/**
+ * Definition of a single form field.
+ */
+export interface FormFieldDefinition {
+  /** Unique identifier for the field. */
+  id: string;
+  /** Type of form field. */
+  type: FormFieldType;
+  /** Display label for the field. */
+  label: string;
+  /** Optional placeholder text. */
+  placeholder?: string;
+  /** Options for select, radio, and checkbox fields. */
+  options?: string[];
+  /** Whether the field is required. */
+  required?: boolean;
+  /** Additional description text for the field. */
+  description?: string;
+  /** The minimum value for slider fields. */
+  sliderMin?: number;
+  /** The maximum value for slider fields. */
+  sliderMax?: number;
+  /** The step value for slider fields. */
+  sliderStep?: number;
+  /** Default value for slider fields. */
+  sliderDefault?: number;
+  /** Labels to display under slider. */
+  sliderLabels?: string[];
+}
+
+/**
+ * State of the form managed by Tambo component state.
+ */
+export interface FormState {
+  /** Text/number/slider values keyed by field ID. */
+  values: Record<string, string>;
+  /** Open/closed state for dropdown fields keyed by field ID. */
+  openDropdowns: Record<string, boolean>;
+  /** Selected value for select fields keyed by field ID. */
+  selectedValues: Record<string, string>;
+  /** Yes/no selections keyed by field ID. */
+  yesNoSelections: Record<string, string>;
+  /** Checkbox selections keyed by field ID. */
+  checkboxSelections: Record<string, string[]>;
+}
+
+/**
+ * Context value shared among Form sub-components.
+ */
+export interface FormRootContextValue {
+  /** The form state. */
+  state: FormState;
+  /** Callback to update the form state. */
+  setState: (state: FormState) => void;
+  /** The validated fields to render. */
+  validFields: FormFieldDefinition[];
+  /** Whether the form is currently generating (not idle). */
+  isGenerating: boolean;
+  /** Optional error message to display. */
+  errorMessage?: string;
+  /** Text for the submit button. */
+  submitText: string;
+  /** References to dropdown DOM elements for click-outside behavior. */
+  dropdownRefs: React.RefObject<Record<string, HTMLDivElement | null>>;
+  /** Handles form submission. */
+  handleSubmit: (e: React.FormEvent) => void;
+  /** Handles toggling a dropdown open/closed. */
+  handleDropdownToggle: (fieldId: string) => void;
+  /** Handles selecting an option in a dropdown. */
+  handleOptionSelect: (fieldId: string, option: string) => void;
+  /** Handles yes/no selection. */
+  handleYesNoSelection: (fieldId: string, value: string) => void;
+  /** Handles checkbox change. */
+  handleCheckboxChange: (
+    fieldId: string,
+    option: string,
+    checked: boolean,
+  ) => void;
+  /** Handles slider value change. */
+  handleSliderChange: (
+    fieldId: string,
+    value: string,
+    field: FormFieldDefinition,
+  ) => void;
+  /**
+   * Calculates the default value for a slider field.
+   * @returns The formatted default value in "value : label" format
+   */
+  getDefaultSliderValue: (field: FormFieldDefinition) => string;
+}
+
+const FormRootContext = React.createContext<FormRootContextValue | null>(null);
+
+/**
+ * Hook to access the form root context.
+ * @returns The form root context value
+ * @throws Error if used outside of Form.Root component
+ */
+function useFormRootContext(): FormRootContextValue {
+  const context = React.useContext(FormRootContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: FormRootContext is missing. Form parts must be used within <Form.Root>",
+    );
+  }
+  return context;
+}
+
+export { FormRootContext, useFormRootContext };

--- a/packages/react-ui-base/src/form/root/form-root.tsx
+++ b/packages/react-ui-base/src/form/root/form-root.tsx
@@ -1,0 +1,290 @@
+import { Slot } from "@radix-ui/react-slot";
+import { useTambo, useTamboComponentState } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import {
+  FormFieldDefinition,
+  FormRootContext,
+  FormState,
+} from "./form-root-context";
+
+export type FormRootProps = BaseProps<
+  React.HTMLAttributes<HTMLFormElement> & {
+    /** Array of form fields to display. */
+    fields: FormFieldDefinition[];
+    /** Callback function called when the form is submitted with form data as argument. */
+    onSubmit: (data: Record<string, string>) => void;
+    /** Optional error message to display. */
+    errorMessage?: string;
+    /** Text to display on the submit button. */
+    submitText?: string;
+  }
+>;
+
+/**
+ * Root primitive for a form component.
+ * Provides context with form state management for child components.
+ * Handles field validation, dropdown state, selections, and form submission.
+ * @returns The rendered form element with context provider, or null if state is not initialized
+ */
+export const FormRoot = React.forwardRef<HTMLFormElement, FormRootProps>(
+  function FormRoot(
+    {
+      children,
+      fields = [],
+      onSubmit,
+      errorMessage,
+      submitText = "Submit",
+      asChild,
+      ...props
+    },
+    ref,
+  ) {
+    const { isIdle } = useTambo();
+    const isGenerating = !isIdle;
+
+    const baseId = React.useId();
+    const formId = React.useMemo(() => {
+      const ids = (fields ?? [])
+        .map((f) => f.id)
+        .filter(Boolean)
+        .join("-");
+      return ids ? `form-${baseId}-${ids}` : `form-${baseId}`;
+    }, [baseId, fields]);
+
+    const [state, setState] = useTamboComponentState<FormState>(formId, {
+      values: {},
+      openDropdowns: {},
+      selectedValues: {},
+      yesNoSelections: {},
+      checkboxSelections: {},
+    });
+
+    const dropdownRefs = React.useRef<Record<string, HTMLDivElement | null>>(
+      {},
+    );
+
+    const validFields = React.useMemo(() => {
+      return fields.filter((field): field is FormFieldDefinition => {
+        if (!field || typeof field !== "object") {
+          console.warn("Invalid field object detected");
+          return false;
+        }
+        if (!field.id || typeof field.id !== "string") {
+          console.warn("Field missing required id property");
+          return false;
+        }
+        return true;
+      });
+    }, [fields]);
+
+    const handleSubmit = React.useCallback(
+      (e: React.FormEvent) => {
+        e.preventDefault();
+        const formData = new FormData(e.target as HTMLFormElement);
+        const data = Object.fromEntries(
+          Array.from(formData.entries()).map(([k, v]) => [k, v.toString()]),
+        );
+        onSubmit(data);
+      },
+      [onSubmit],
+    );
+
+    const handleDropdownToggle = React.useCallback(
+      (fieldId: string) => {
+        if (!state) return;
+        setState({
+          ...state,
+          openDropdowns: {
+            ...state.openDropdowns,
+            [fieldId]: !state.openDropdowns[fieldId],
+          },
+        });
+      },
+      [state, setState],
+    );
+
+    const handleOptionSelect = React.useCallback(
+      (fieldId: string, option: string) => {
+        if (!state) return;
+        setState({
+          ...state,
+          selectedValues: {
+            ...state.selectedValues,
+            [fieldId]: option,
+          },
+          openDropdowns: {
+            ...state.openDropdowns,
+            [fieldId]: false,
+          },
+        });
+      },
+      [state, setState],
+    );
+
+    const handleYesNoSelection = React.useCallback(
+      (fieldId: string, value: string) => {
+        if (!state) return;
+        setState({
+          ...state,
+          yesNoSelections: {
+            ...state.yesNoSelections,
+            [fieldId]: value,
+          },
+          values: {
+            ...state.values,
+            [fieldId]: value,
+          },
+        });
+      },
+      [state, setState],
+    );
+
+    const handleCheckboxChange = React.useCallback(
+      (fieldId: string, option: string, checked: boolean) => {
+        if (!state) return;
+
+        const currentSelections = state.checkboxSelections[fieldId] ?? [];
+
+        const newSelections = checked
+          ? [...currentSelections, option]
+          : currentSelections.filter((item) => item !== option);
+
+        setState({
+          ...state,
+          checkboxSelections: {
+            ...state.checkboxSelections,
+            [fieldId]: newSelections,
+          },
+          values: {
+            ...state.values,
+            [fieldId]: newSelections.join(","),
+          },
+        });
+      },
+      [state, setState],
+    );
+
+    const handleSliderChange = React.useCallback(
+      (fieldId: string, value: string, field: FormFieldDefinition) => {
+        if (!state) return;
+
+        const label =
+          field.sliderLabels && field.sliderLabels.length > 0
+            ? field.sliderLabels[parseInt(value)]
+            : value;
+
+        setState({
+          ...state,
+          values: {
+            ...state.values,
+            [fieldId]: `${value} : ${label}`,
+          },
+        });
+      },
+      [state, setState],
+    );
+
+    const getDefaultSliderValue = React.useCallback(
+      (field: FormFieldDefinition): string => {
+        const defaultVal =
+          field.sliderDefault?.toString() ??
+          (field.sliderLabels && field.sliderLabels.length > 0
+            ? Math.floor((field.sliderLabels.length - 1) / 2).toString()
+            : "5");
+
+        const defaultLabel =
+          field.sliderLabels && field.sliderLabels.length > 0
+            ? field.sliderLabels[parseInt(defaultVal)]
+            : defaultVal;
+
+        return `${defaultVal} : ${defaultLabel}`;
+      },
+      [],
+    );
+
+    /**
+     * Keeps track of latest state for event handlers.
+     */
+    const stateRef = React.useRef(state);
+    React.useEffect(() => {
+      stateRef.current = state;
+    }, [state]);
+
+    /**
+     * Handles closing dropdowns when clicking outside their containing elements.
+     */
+    React.useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        Object.entries(dropdownRefs.current).forEach(([fieldId, ref]) => {
+          if (ref && !ref.contains(event.target as Node) && stateRef.current) {
+            setState({
+              ...stateRef.current,
+              openDropdowns: {
+                ...stateRef.current.openDropdowns,
+                [fieldId]: false,
+              },
+            });
+          }
+        });
+      };
+
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }, [setState]);
+
+    const contextValue = React.useMemo(
+      () => ({
+        state: state as FormState,
+        setState,
+        validFields,
+        isGenerating,
+        errorMessage,
+        submitText,
+        dropdownRefs: dropdownRefs as React.RefObject<
+          Record<string, HTMLDivElement | null>
+        >,
+        handleSubmit,
+        handleDropdownToggle,
+        handleOptionSelect,
+        handleYesNoSelection,
+        handleCheckboxChange,
+        handleSliderChange,
+        getDefaultSliderValue,
+      }),
+      [
+        state,
+        setState,
+        validFields,
+        isGenerating,
+        errorMessage,
+        submitText,
+        handleSubmit,
+        handleDropdownToggle,
+        handleOptionSelect,
+        handleYesNoSelection,
+        handleCheckboxChange,
+        handleSliderChange,
+        getDefaultSliderValue,
+      ],
+    );
+
+    if (!state) return null;
+
+    const Comp = asChild ? Slot : "form";
+
+    return (
+      <FormRootContext.Provider value={contextValue}>
+        <Comp
+          ref={ref}
+          data-slot="form-root"
+          onSubmit={handleSubmit}
+          {...props}
+        >
+          {children}
+        </Comp>
+      </FormRootContext.Provider>
+    );
+  },
+);

--- a/packages/react-ui-base/src/form/submit/form-submit.tsx
+++ b/packages/react-ui-base/src/form/submit/form-submit.tsx
@@ -1,0 +1,53 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useFormRootContext } from "../root/form-root-context";
+
+/**
+ * Props passed to the render function of FormSubmit.
+ */
+export interface FormSubmitRenderProps {
+  /** Whether the form is currently generating (not idle). */
+  isGenerating: boolean;
+  /** The text for the submit button. */
+  submitText: string;
+}
+
+export type FormSubmitProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+>;
+
+/**
+ * Submit button primitive for the form.
+ * Automatically disables when the form is generating.
+ * Supports a render prop to customize the button content based on loading state.
+ * @returns The rendered submit button element
+ */
+export const FormSubmit = React.forwardRef<
+  HTMLButtonElement,
+  BasePropsWithChildrenOrRenderFunction<FormSubmitProps, FormSubmitRenderProps>
+>(function FormSubmit({ asChild, disabled, ...props }, ref) {
+  const { isGenerating, submitText } = useFormRootContext();
+
+  const Comp = asChild ? Slot : "button";
+
+  const { content, componentProps } = useRender(props, {
+    isGenerating,
+    submitText,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      type="submit"
+      disabled={disabled ?? isGenerating}
+      data-slot="form-submit"
+      data-generating={isGenerating || undefined}
+      {...componentProps}
+    >
+      {content ?? submitText}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/graph/chart/graph-chart.tsx
+++ b/packages/react-ui-base/src/graph/chart/graph-chart.tsx
@@ -1,0 +1,67 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useGraphRootContext } from "../root/graph-root-context";
+import type { GraphDataset } from "../root/validate-graph-data";
+
+/**
+ * Props passed to the Graph.Chart render function.
+ */
+export interface GraphChartRenderProps {
+  /** The type of chart to render. */
+  chartType: "bar" | "line" | "pie";
+  /** Transformed data ready for charting. Each entry has a 'name' key plus dataset label keys. */
+  chartData: Array<Record<string, string | number>>;
+  /** The validated datasets with their labels, data, and optional colors. */
+  validDatasets: GraphDataset[];
+  /** Maximum number of data points (minimum of labels length and shortest dataset). */
+  maxDataPoints: number;
+  /** Whether to show the chart legend. */
+  showLegend: boolean;
+  /** The raw labels array from the graph data. */
+  labels: string[];
+}
+
+export type GraphChartProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLDivElement>,
+  GraphChartRenderProps
+>;
+
+/**
+ * Chart primitive that provides validated chart data via render props.
+ * Only renders when graph data is in a valid state.
+ * The actual chart rendering (e.g. with Recharts) is delegated to the render prop or children.
+ * @returns The chart container element, or null if data is not valid
+ */
+export const GraphChart = React.forwardRef<HTMLDivElement, GraphChartProps>(
+  function GraphChart({ asChild, ...props }, ref) {
+    const { dataState, showLegend, data } = useGraphRootContext();
+
+    if (dataState.status !== "valid" || !data) {
+      return null;
+    }
+
+    const Comp = asChild ? Slot : "div";
+
+    const { content, componentProps } = useRender(props, {
+      chartType: data.type,
+      chartData: dataState.chartData,
+      validDatasets: dataState.validDatasets,
+      maxDataPoints: dataState.maxDataPoints,
+      showLegend,
+      labels: data.labels,
+    });
+
+    return (
+      <Comp
+        ref={ref}
+        data-slot="graph-chart"
+        data-chart-type={data.type}
+        {...componentProps}
+      >
+        {content}
+      </Comp>
+    );
+  },
+);

--- a/packages/react-ui-base/src/graph/error-boundary/graph-error-boundary.tsx
+++ b/packages/react-ui-base/src/graph/error-boundary/graph-error-boundary.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+
+/**
+ * Props for the Graph error boundary component.
+ */
+export interface GraphErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Optional render function for custom error UI. Receives the caught error. */
+  renderError?: (error: Error) => React.ReactNode;
+}
+
+interface GraphErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+/**
+ * Error boundary for catching rendering errors in graph sub-components.
+ * Wraps chart content to prevent rendering errors from crashing the entire UI.
+ * @returns The children if no error, or the error UI if an error was caught
+ */
+class GraphErrorBoundaryClass extends React.Component<
+  GraphErrorBoundaryProps,
+  GraphErrorBoundaryState
+> {
+  constructor(props: GraphErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): GraphErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error("Error rendering chart:", error, errorInfo);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError && this.state.error) {
+      if (this.props.renderError) {
+        return this.props.renderError(this.state.error);
+      }
+
+      return (
+        <div data-slot="graph-error">
+          <div>
+            <p>Error loading chart</p>
+            <p>An error occurred while rendering. Please try again.</p>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export { GraphErrorBoundaryClass as GraphErrorBoundary };

--- a/packages/react-ui-base/src/graph/index.tsx
+++ b/packages/react-ui-base/src/graph/index.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { GraphChart } from "./chart/graph-chart";
+import { GraphErrorBoundary } from "./error-boundary/graph-error-boundary";
+import { GraphLoading } from "./loading/graph-loading";
+import { GraphRoot } from "./root/graph-root";
+import { GraphTitle } from "./title/graph-title";
+
+/**
+ * Graph namespace containing all graph base components.
+ */
+const Graph = {
+  Root: GraphRoot,
+  Title: GraphTitle,
+  Chart: GraphChart,
+  Loading: GraphLoading,
+  ErrorBoundary: GraphErrorBoundary,
+};
+
+export type {
+  GraphChartProps,
+  GraphChartRenderProps,
+} from "./chart/graph-chart";
+export type { GraphErrorBoundaryProps } from "./error-boundary/graph-error-boundary";
+export type {
+  GraphLoadingProps,
+  GraphLoadingRenderProps,
+  GraphLoadingStatus,
+} from "./loading/graph-loading";
+export type { GraphRootContextValue } from "./root/graph-root-context";
+export type { GraphRootProps } from "./root/graph-root";
+export type {
+  GraphData,
+  GraphDataset,
+  GraphDataState,
+} from "./root/validate-graph-data";
+export { validateGraphData } from "./root/validate-graph-data";
+export type {
+  GraphTitleProps,
+  GraphTitleRenderProps,
+} from "./title/graph-title";
+
+export { Graph };

--- a/packages/react-ui-base/src/graph/loading/graph-loading.tsx
+++ b/packages/react-ui-base/src/graph/loading/graph-loading.tsx
@@ -1,0 +1,65 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useGraphRootContext } from "../root/graph-root-context";
+
+/**
+ * The specific loading status for the graph.
+ * - "no-data": No data has been received yet (awaiting data).
+ * - "invalid-structure": Data exists but structure is incomplete (building chart).
+ * - "no-valid-datasets": Structure exists but datasets are incomplete (preparing datasets).
+ */
+export type GraphLoadingStatus =
+  | "no-data"
+  | "invalid-structure"
+  | "no-valid-datasets";
+
+/**
+ * Props passed to the Graph.Loading render function.
+ */
+export interface GraphLoadingRenderProps {
+  /** The specific loading status. */
+  status: GraphLoadingStatus;
+}
+
+export type GraphLoadingProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLDivElement>,
+  GraphLoadingRenderProps
+>;
+
+/**
+ * Loading indicator for the graph component.
+ * Only renders when graph data is not yet valid (no data, invalid structure, or no valid datasets).
+ * @returns The loading container element, or null if data is valid
+ */
+export const GraphLoading = React.forwardRef<HTMLDivElement, GraphLoadingProps>(
+  function GraphLoading({ asChild, ...props }, ref) {
+    const { dataState } = useGraphRootContext();
+
+    if (
+      dataState.status !== "no-data" &&
+      dataState.status !== "invalid-structure" &&
+      dataState.status !== "no-valid-datasets"
+    ) {
+      return null;
+    }
+
+    const Comp = asChild ? Slot : "div";
+
+    const { content, componentProps } = useRender(props, {
+      status: dataState.status,
+    });
+
+    return (
+      <Comp
+        ref={ref}
+        data-slot="graph-loading"
+        data-loading-status={dataState.status}
+        {...componentProps}
+      >
+        {content}
+      </Comp>
+    );
+  },
+);

--- a/packages/react-ui-base/src/graph/root/graph-root-context.tsx
+++ b/packages/react-ui-base/src/graph/root/graph-root-context.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import type { GraphData, GraphDataState } from "./validate-graph-data";
+
+/**
+ * Context value shared among Graph primitive sub-components.
+ */
+export interface GraphRootContextValue {
+  /** The raw graph data passed to the root component. */
+  data: GraphData | undefined;
+  /** The result of validating the graph data. */
+  dataState: GraphDataState;
+  /** The title of the graph. */
+  title: string;
+  /** Whether to show the chart legend. */
+  showLegend: boolean;
+}
+
+const GraphRootContext = React.createContext<GraphRootContextValue | null>(
+  null,
+);
+
+/**
+ * Hook to access the graph root context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The graph root context value
+ * @throws Error if used outside of Graph.Root component
+ */
+function useGraphRootContext(): GraphRootContextValue {
+  const context = React.useContext(GraphRootContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: GraphRootContext is missing. Graph parts must be used within <Graph.Root>",
+    );
+  }
+  return context;
+}
+
+export { GraphRootContext, useGraphRootContext };

--- a/packages/react-ui-base/src/graph/root/graph-root.tsx
+++ b/packages/react-ui-base/src/graph/root/graph-root.tsx
@@ -1,0 +1,50 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { GraphRootContext } from "./graph-root-context";
+import { type GraphData, validateGraphData } from "./validate-graph-data";
+
+export type GraphRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** The graph data to render. */
+    data: GraphData | undefined;
+    /** Title for the chart. */
+    title: string;
+    /** Whether to show the legend. Defaults to true. */
+    showLegend?: boolean;
+  }
+>;
+
+/**
+ * Root primitive for a graph component.
+ * Validates graph data and provides context for child components.
+ * @returns The root graph element with context provider
+ */
+export const GraphRoot = React.forwardRef<HTMLDivElement, GraphRootProps>(
+  function GraphRoot(
+    { children, data, title, showLegend = true, asChild, ...props },
+    ref,
+  ) {
+    const dataState = React.useMemo(() => validateGraphData(data), [data]);
+
+    const contextValue = React.useMemo(
+      () => ({ data, dataState, title, showLegend }),
+      [data, dataState, title, showLegend],
+    );
+
+    const Comp = asChild ? Slot : "div";
+
+    return (
+      <GraphRootContext.Provider value={contextValue}>
+        <Comp
+          ref={ref}
+          data-slot="graph-root"
+          data-graph-status={dataState.status}
+          {...props}
+        >
+          {children}
+        </Comp>
+      </GraphRootContext.Provider>
+    );
+  },
+);

--- a/packages/react-ui-base/src/graph/root/validate-graph-data.test.ts
+++ b/packages/react-ui-base/src/graph/root/validate-graph-data.test.ts
@@ -1,0 +1,157 @@
+import { validateGraphData } from "./validate-graph-data";
+import type { GraphData } from "./validate-graph-data";
+
+describe("validateGraphData", () => {
+  it("returns no-data when data is undefined", () => {
+    expect(validateGraphData(undefined)).toEqual({ status: "no-data" });
+  });
+
+  it("returns invalid-structure when data has no labels", () => {
+    const data = {
+      type: "bar",
+      labels: [],
+      datasets: [{ label: "A", data: [1] }],
+    } as GraphData;
+    expect(validateGraphData(data)).toEqual({ status: "invalid-structure" });
+  });
+
+  it("returns invalid-structure when data has no datasets", () => {
+    const data = {
+      type: "bar",
+      labels: ["Jan"],
+      datasets: [],
+    } as GraphData;
+    expect(validateGraphData(data)).toEqual({ status: "invalid-structure" });
+  });
+
+  it("returns no-valid-datasets when datasets have no data", () => {
+    const data: GraphData = {
+      type: "bar",
+      labels: ["Jan"],
+      datasets: [{ label: "A", data: [] }],
+    };
+    expect(validateGraphData(data)).toEqual({ status: "no-valid-datasets" });
+  });
+
+  it("returns no-valid-datasets when datasets have no label", () => {
+    const data: GraphData = {
+      type: "bar",
+      labels: ["Jan"],
+      datasets: [{ label: "", data: [1] }],
+    };
+    expect(validateGraphData(data)).toEqual({ status: "no-valid-datasets" });
+  });
+
+  it("returns unsupported-type for unknown chart types", () => {
+    const data = {
+      type: "radar" as "bar",
+      labels: ["Jan"],
+      datasets: [{ label: "A", data: [1] }],
+    };
+    expect(validateGraphData(data)).toEqual({
+      status: "unsupported-type",
+      type: "radar",
+    });
+  });
+
+  it("returns valid for bar chart with proper data", () => {
+    const data: GraphData = {
+      type: "bar",
+      labels: ["Jan", "Feb", "Mar"],
+      datasets: [
+        { label: "Sales", data: [100, 200, 300] },
+        { label: "Revenue", data: [150, 250, 350] },
+      ],
+    };
+    const result = validateGraphData(data);
+    expect(result.status).toBe("valid");
+    if (result.status === "valid") {
+      expect(result.validDatasets).toHaveLength(2);
+      expect(result.maxDataPoints).toBe(3);
+      expect(result.chartData).toEqual([
+        { name: "Jan", Sales: 100, Revenue: 150 },
+        { name: "Feb", Sales: 200, Revenue: 250 },
+        { name: "Mar", Sales: 300, Revenue: 350 },
+      ]);
+    }
+  });
+
+  it("returns valid for line chart", () => {
+    const data: GraphData = {
+      type: "line",
+      labels: ["Q1", "Q2"],
+      datasets: [{ label: "Growth", data: [10, 20] }],
+    };
+    const result = validateGraphData(data);
+    expect(result.status).toBe("valid");
+  });
+
+  it("returns valid for pie chart", () => {
+    const data: GraphData = {
+      type: "pie",
+      labels: ["A", "B"],
+      datasets: [{ label: "Share", data: [60, 40] }],
+    };
+    const result = validateGraphData(data);
+    expect(result.status).toBe("valid");
+  });
+
+  it("uses minimum length between labels and datasets", () => {
+    const data: GraphData = {
+      type: "bar",
+      labels: ["Jan", "Feb"],
+      datasets: [{ label: "Sales", data: [100, 200, 300] }],
+    };
+    const result = validateGraphData(data);
+    expect(result.status).toBe("valid");
+    if (result.status === "valid") {
+      expect(result.maxDataPoints).toBe(2);
+      expect(result.chartData).toHaveLength(2);
+    }
+  });
+
+  it("filters out invalid datasets", () => {
+    const data: GraphData = {
+      type: "bar",
+      labels: ["Jan"],
+      datasets: [
+        { label: "Valid", data: [100] },
+        { label: "", data: [200] },
+        { label: "AlsoValid", data: [300] },
+      ],
+    };
+    const result = validateGraphData(data);
+    expect(result.status).toBe("valid");
+    if (result.status === "valid") {
+      expect(result.validDatasets).toHaveLength(2);
+      expect(result.validDatasets[0].label).toBe("Valid");
+      expect(result.validDatasets[1].label).toBe("AlsoValid");
+    }
+  });
+
+  it("handles missing data points with fallback to 0", () => {
+    const data: GraphData = {
+      type: "bar",
+      labels: ["Jan"],
+      datasets: [{ label: "Sales", data: [100] }],
+    };
+    const result = validateGraphData(data);
+    expect(result.status).toBe("valid");
+    if (result.status === "valid") {
+      expect(result.chartData[0]).toEqual({ name: "Jan", Sales: 100 });
+    }
+  });
+
+  it("preserves dataset colors", () => {
+    const data: GraphData = {
+      type: "bar",
+      labels: ["Jan"],
+      datasets: [{ label: "Sales", data: [100], color: "#ff0000" }],
+    };
+    const result = validateGraphData(data);
+    expect(result.status).toBe("valid");
+    if (result.status === "valid") {
+      expect(result.validDatasets[0].color).toBe("#ff0000");
+    }
+  });
+});

--- a/packages/react-ui-base/src/graph/root/validate-graph-data.ts
+++ b/packages/react-ui-base/src/graph/root/validate-graph-data.ts
@@ -1,0 +1,92 @@
+/**
+ * Represents a single dataset within graph data.
+ */
+export interface GraphDataset {
+  label: string;
+  data: number[];
+  color?: string;
+}
+
+/**
+ * Represents the data structure for a graph.
+ */
+export interface GraphData {
+  type: "bar" | "line" | "pie";
+  labels: string[];
+  datasets: GraphDataset[];
+}
+
+/**
+ * Describes the validation state of graph data.
+ */
+export type GraphDataState =
+  | { status: "no-data" }
+  | { status: "invalid-structure" }
+  | { status: "no-valid-datasets" }
+  | { status: "unsupported-type"; type: string }
+  | {
+      status: "valid";
+      validDatasets: GraphDataset[];
+      maxDataPoints: number;
+      chartData: Array<Record<string, string | number>>;
+    };
+
+/**
+ * Validates graph data and returns the validation state.
+ * Handles partial/streaming data gracefully by returning appropriate status.
+ * @param data - The graph data to validate, or undefined if not yet available
+ * @returns The validation state describing whether the data is usable
+ */
+export function validateGraphData(data: GraphData | undefined): GraphDataState {
+  if (!data) {
+    return { status: "no-data" };
+  }
+
+  const hasValidStructure =
+    data.type &&
+    data.labels &&
+    data.datasets &&
+    Array.isArray(data.labels) &&
+    Array.isArray(data.datasets) &&
+    data.labels.length > 0 &&
+    data.datasets.length > 0;
+
+  if (!hasValidStructure) {
+    return { status: "invalid-structure" };
+  }
+
+  const validDatasets = data.datasets.filter(
+    (dataset) =>
+      dataset.label &&
+      dataset.data &&
+      Array.isArray(dataset.data) &&
+      dataset.data.length > 0,
+  );
+
+  if (validDatasets.length === 0) {
+    return { status: "no-valid-datasets" };
+  }
+
+  if (!["bar", "line", "pie"].includes(data.type)) {
+    return { status: "unsupported-type", type: data.type };
+  }
+
+  const maxDataPoints = Math.min(
+    data.labels.length,
+    Math.min(...validDatasets.map((d) => d.data.length)),
+  );
+
+  const chartData = data.labels.slice(0, maxDataPoints).map((label, index) => ({
+    name: label,
+    ...Object.fromEntries(
+      validDatasets.map((dataset) => [dataset.label, dataset.data[index] ?? 0]),
+    ),
+  }));
+
+  return {
+    status: "valid",
+    validDatasets,
+    maxDataPoints,
+    chartData,
+  };
+}

--- a/packages/react-ui-base/src/graph/title/graph-title.tsx
+++ b/packages/react-ui-base/src/graph/title/graph-title.tsx
@@ -1,0 +1,43 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useGraphRootContext } from "../root/graph-root-context";
+
+/**
+ * Props passed to the Graph.Title render function.
+ */
+export interface GraphTitleRenderProps {
+  /** The title text from the graph context. */
+  title: string;
+}
+
+export type GraphTitleProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLHeadingElement>,
+  GraphTitleRenderProps
+>;
+
+/**
+ * Displays the graph title.
+ * Renders nothing if the title is empty.
+ * @returns The title heading element, or null if title is empty
+ */
+export const GraphTitle = React.forwardRef<HTMLHeadingElement, GraphTitleProps>(
+  function GraphTitle({ asChild, ...props }, ref) {
+    const { title } = useGraphRootContext();
+
+    const Comp = asChild ? Slot : "h3";
+
+    const { content, componentProps } = useRender(props, { title });
+
+    if (!title) {
+      return null;
+    }
+
+    return (
+      <Comp ref={ref} data-slot="graph-title" {...componentProps}>
+        {content ?? title}
+      </Comp>
+    );
+  },
+);

--- a/packages/react-ui-base/src/index.ts
+++ b/packages/react-ui-base/src/index.ts
@@ -6,6 +6,137 @@
  * allowing consumers to apply their own design system.
  */
 
+// ElicitationUI components
+export { ElicitationUIBase } from "./elicitation-ui";
+export type {
+  ElicitationUIActionsProps,
+  ElicitationUIActionsRenderProps,
+  ElicitationUIBooleanFieldProps,
+  ElicitationUIBooleanFieldRenderProps,
+  ElicitationUIContextValue,
+  ElicitationUIEnumFieldProps,
+  ElicitationUIEnumFieldRenderProps,
+  ElicitationUIEnumOption,
+  ElicitationUIFieldProps,
+  ElicitationUIFieldRenderProps,
+  ElicitationUIFieldType,
+  ElicitationUINumberFieldProps,
+  ElicitationUINumberFieldRenderProps,
+  ElicitationUIRootProps,
+  ElicitationUIStringFieldProps,
+  ElicitationUIStringFieldRenderProps,
+  ElicitationUITitleProps,
+  ElicitationUITitleRenderProps,
+  FieldSchema,
+} from "./elicitation-ui";
+export {
+  getInputType,
+  getValidationError,
+  isSingleEntryMode,
+  validateField,
+} from "./elicitation-ui";
+
+// EditWithTamboButton components
+export { EditWithTamboButtonBase } from "./edit-with-tambo-button";
+export { useEditWithTamboButtonContext } from "./edit-with-tambo-button";
+export type {
+  EditWithTamboButtonContextValue,
+  EditWithTamboButtonPopoverProps,
+  EditWithTamboButtonRootProps,
+  EditWithTamboButtonSendButtonProps,
+  EditWithTamboButtonSendButtonRenderProps,
+  EditWithTamboButtonSendMode,
+  EditWithTamboButtonSendModeDropdownProps,
+  EditWithTamboButtonSendModeOptionProps,
+  EditWithTamboButtonStatusProps,
+  EditWithTamboButtonStatusRenderProps,
+  EditWithTamboButtonTextareaProps,
+  EditWithTamboButtonTriggerProps,
+} from "./edit-with-tambo-button";
+
+// CanvasSpace components
+export { CanvasSpace } from "./canvas-space";
+export type {
+  CanvasSpaceContentProps,
+  CanvasSpaceContentRenderProps,
+  CanvasSpaceEmptyStateProps,
+  CanvasSpaceRootProps,
+  CanvasSpaceViewportProps,
+} from "./canvas-space";
+
+// Graph components
+export { Graph, validateGraphData } from "./graph";
+export type {
+  GraphChartProps,
+  GraphChartRenderProps,
+  GraphData,
+  GraphDataset,
+  GraphDataState,
+  GraphErrorBoundaryProps,
+  GraphLoadingProps,
+  GraphLoadingRenderProps,
+  GraphLoadingStatus,
+  GraphRootContextValue,
+  GraphRootProps,
+  GraphTitleProps,
+  GraphTitleRenderProps,
+} from "./graph";
+
+// Form components
+export { Form } from "./form";
+export type {
+  FormErrorProps,
+  FormFieldDefinition,
+  FormFieldDescriptionProps,
+  FormFieldInputProps,
+  FormFieldLabelProps,
+  FormFieldProps,
+  FormFieldsProps,
+  FormFieldsRenderProps,
+  FormFieldType,
+  FormRootContextValue,
+  FormRootProps,
+  FormState,
+  FormSubmitProps,
+  FormSubmitRenderProps,
+} from "./form";
+
+// InputFields components
+export { InputFields } from "./input-fields";
+export {
+  fieldSchema,
+  inputFieldsSchema,
+  useInputFieldsRootContext,
+} from "./input-fields";
+export type {
+  Field,
+  InputFieldsDescriptionProps,
+  InputFieldsErrorProps,
+  InputFieldsFieldProps,
+  InputFieldsInputProps,
+  InputFieldsLabelProps,
+  InputFieldsProps,
+  InputFieldsRootProps,
+  InputFieldsState,
+} from "./input-fields";
+
+// MessageSuggestions components
+export { MessageSuggestions } from "./message-suggestions";
+export {
+  useMessageSuggestionsContext,
+  useOptionalMessageSuggestionsContext,
+} from "./message-suggestions";
+export type {
+  MessageSuggestionsContextValue,
+  MessageSuggestionsGenerationStageProps,
+  MessageSuggestionsGenerationStageRenderProps,
+  MessageSuggestionsItemProps,
+  MessageSuggestionsListProps,
+  MessageSuggestionsListRenderProps,
+  MessageSuggestionsRootProps,
+  MessageSuggestionsStatusProps,
+} from "./message-suggestions";
+
 // Message components
 export { Message } from "./message";
 export type {
@@ -18,6 +149,16 @@ export type {
   MessageRootProps,
 } from "./message";
 
+// ScrollableMessageContainer components
+export { ScrollableMessageContainer } from "./scrollable-message-container";
+export type {
+  ScrollableMessageContainerRootContextValue,
+  ScrollableMessageContainerRootProps,
+  ScrollableMessageContainerScrollToBottomProps,
+  ScrollableMessageContainerScrollToBottomRenderProps,
+  ScrollableMessageContainerViewportProps,
+} from "./scrollable-message-container";
+
 // ReasoningInfo components
 export { ReasoningInfo } from "./reasoning-info";
 export type {
@@ -28,6 +169,34 @@ export type {
   ReasoningInfoStepsRenderFunctionProps,
   ReasoningInfoTriggerProps,
 } from "./reasoning-info";
+
+// ThreadContent components
+export { getMessageKey, ThreadContent } from "./thread-content";
+export type {
+  ThreadContentMessageListProps,
+  ThreadContentMessageListRenderProps,
+  ThreadContentMessageProps,
+  ThreadContentRootContextValue,
+  ThreadContentRootProps,
+} from "./thread-content";
+export {
+  useOptionalThreadContentRootContext,
+  useThreadContentRootContext,
+} from "./thread-content";
+
+// ThreadDropdown components
+export { ThreadDropdown } from "./thread-dropdown";
+export type {
+  ThreadDropdownContextValue,
+  ThreadDropdownMenuProps,
+  ThreadDropdownNewThreadItemProps,
+  ThreadDropdownNewThreadItemRenderProps,
+  ThreadDropdownRootProps,
+  ThreadDropdownThread,
+  ThreadDropdownThreadItemProps,
+  ThreadDropdownThreadItemRenderProps,
+  ThreadDropdownTriggerProps,
+} from "./thread-dropdown";
 
 // ToolcallInfo components
 export { ToolcallInfo } from "./toolcall-info";
@@ -47,6 +216,47 @@ export type {
   ToolcallInfoToolStatus,
   ToolcallInfoTriggerProps,
 } from "./toolcall-info";
+
+// ThreadHistory components
+export { ThreadHistory } from "./thread-history";
+export type {
+  ThreadHistoryCollapseToggleProps,
+  ThreadHistoryHeaderProps,
+  ThreadHistoryHeaderRenderProps,
+  ThreadHistoryItemProps,
+  ThreadHistoryItemRenderProps,
+  ThreadHistoryListProps,
+  ThreadHistoryListRenderProps,
+  ThreadHistoryNewThreadButtonProps,
+  ThreadHistoryNewThreadButtonRenderProps,
+  ThreadHistoryRootContextValue,
+  ThreadHistoryRootProps,
+  ThreadHistoryRootRenderProps,
+  ThreadHistorySearchInputProps,
+  ThreadHistorySearchInputRenderProps,
+} from "./thread-history";
+
+// Map components
+export { MapBase } from "./map";
+export type {
+  HeatData,
+  MapContainerProps,
+  MapContainerRenderProps,
+  MapErrorProps,
+  MapErrorRenderProps,
+  MapHeatmapProps,
+  MapHeatmapRenderProps,
+  MapLoadingProps,
+  MapLoadingRenderProps,
+  MapMarkersProps,
+  MapMarkersRenderProps,
+  MapRootContextValue,
+  MapRootProps,
+  MarkerData,
+  TileTheme,
+  ValidatedHeatDataTuple,
+  ValidatedMarkerData,
+} from "./map";
 
 // Types
 export type {

--- a/packages/react-ui-base/src/input-fields/description/input-fields-description.tsx
+++ b/packages/react-ui-base/src/input-fields/description/input-fields-description.tsx
@@ -1,0 +1,33 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useInputFieldsFieldContext } from "../field/input-fields-field-context";
+
+export type InputFieldsDescriptionProps = BaseProps<
+  React.HTMLAttributes<HTMLParagraphElement>
+>;
+
+/**
+ * Description sub-component for an individual field.
+ * Renders the field's description text if present.
+ * Returns null when the field has no description.
+ * @returns The description paragraph element, or null if no description exists
+ */
+export const InputFieldsDescription = React.forwardRef<
+  HTMLParagraphElement,
+  InputFieldsDescriptionProps
+>(function InputFieldsDescription({ asChild, children, ...props }, ref) {
+  const { field } = useInputFieldsFieldContext();
+
+  if (!field.description && !children) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "p";
+
+  return (
+    <Comp ref={ref} data-slot="input-fields-description" {...props}>
+      {children ?? field.description}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/input-fields/error/input-fields-error.tsx
+++ b/packages/react-ui-base/src/input-fields/error/input-fields-error.tsx
@@ -1,0 +1,33 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useInputFieldsFieldContext } from "../field/input-fields-field-context";
+
+export type InputFieldsErrorProps = BaseProps<
+  React.HTMLAttributes<HTMLParagraphElement>
+>;
+
+/**
+ * Error sub-component for an individual field.
+ * Renders the field's error message if present.
+ * Returns null when the field has no error.
+ * @returns The error paragraph element, or null if no error exists
+ */
+export const InputFieldsError = React.forwardRef<
+  HTMLParagraphElement,
+  InputFieldsErrorProps
+>(function InputFieldsError({ asChild, children, ...props }, ref) {
+  const { field } = useInputFieldsFieldContext();
+
+  if (!field.error && !children) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "p";
+
+  return (
+    <Comp ref={ref} data-slot="input-fields-error" {...props}>
+      {children ?? field.error}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/input-fields/field/input-fields-field-context.tsx
+++ b/packages/react-ui-base/src/input-fields/field/input-fields-field-context.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import type { Field } from "../root/input-fields-context";
+
+/**
+ * Context value for an individual field within InputFields.
+ */
+export interface InputFieldsFieldContextValue {
+  /** The field configuration. */
+  field: Field;
+  /** The current value of this field. */
+  value: string;
+  /** Whether this field's input should be disabled. */
+  isDisabled: boolean;
+  /**
+   * Handler for this field's value changes.
+   * @param value - The new value
+   */
+  onChange: (value: string) => void;
+}
+
+const InputFieldsFieldContext =
+  React.createContext<InputFieldsFieldContextValue | null>(null);
+
+/**
+ * Hook to access the per-field context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The field context value
+ * @throws Error if used outside of InputFields.Field
+ */
+function useInputFieldsFieldContext(): InputFieldsFieldContextValue {
+  const context = React.useContext(InputFieldsFieldContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: InputFieldsFieldContext is missing. Field parts must be used within <InputFields.Field>",
+    );
+  }
+  return context;
+}
+
+export { InputFieldsFieldContext, useInputFieldsFieldContext };

--- a/packages/react-ui-base/src/input-fields/field/input-fields-field.tsx
+++ b/packages/react-ui-base/src/input-fields/field/input-fields-field.tsx
@@ -1,0 +1,63 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import type { Field } from "../root/input-fields-context";
+import { useInputFieldsRootContext } from "../root/input-fields-context";
+import { InputFieldsFieldContext } from "./input-fields-field-context";
+
+export type InputFieldsFieldProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** The field configuration to render. */
+    field: Field;
+  }
+>;
+
+/**
+ * Wraps a single field within the InputFields compound component.
+ * Provides per-field context (value, disabled state, onChange handler)
+ * to child sub-components like Label, Input, Description, and Error.
+ * @returns The field container element with per-field context provider
+ */
+export const InputFieldsField = React.forwardRef<
+  HTMLDivElement,
+  InputFieldsFieldProps
+>(function InputFieldsField({ asChild, children, field, ...props }, ref) {
+  const { values, isGenerating, handleInputChange } =
+    useInputFieldsRootContext();
+
+  const value = values[field.id] ?? "";
+  const isDisabled = field.disabled ?? isGenerating;
+
+  const onChange = React.useCallback(
+    (newValue: string) => {
+      handleInputChange(field.id, newValue);
+    },
+    [handleInputChange, field.id],
+  );
+
+  const contextValue = React.useMemo(
+    () => ({
+      field,
+      value,
+      isDisabled,
+      onChange,
+    }),
+    [field, value, isDisabled, onChange],
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <InputFieldsFieldContext.Provider value={contextValue}>
+      <Comp
+        ref={ref}
+        data-slot="input-fields-field"
+        data-field-id={field.id}
+        data-field-type={field.type}
+        {...props}
+      >
+        {children}
+      </Comp>
+    </InputFieldsFieldContext.Provider>
+  );
+});

--- a/packages/react-ui-base/src/input-fields/index.tsx
+++ b/packages/react-ui-base/src/input-fields/index.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { InputFieldsDescription } from "./description/input-fields-description";
+import { InputFieldsError } from "./error/input-fields-error";
+import { InputFieldsField } from "./field/input-fields-field";
+import { InputFieldsInput } from "./input/input-fields-input";
+import { InputFieldsLabel } from "./label/input-fields-label";
+import { InputFieldsRoot } from "./root/input-fields-root";
+
+/**
+ * InputFields namespace containing all input fields base components.
+ */
+const InputFields = {
+  Root: InputFieldsRoot,
+  Field: InputFieldsField,
+  Label: InputFieldsLabel,
+  Description: InputFieldsDescription,
+  Input: InputFieldsInput,
+  Error: InputFieldsError,
+};
+
+export type { InputFieldsDescriptionProps } from "./description/input-fields-description";
+export type { InputFieldsErrorProps } from "./error/input-fields-error";
+export type { InputFieldsFieldProps } from "./field/input-fields-field";
+export type { InputFieldsInputProps } from "./input/input-fields-input";
+export type { InputFieldsLabelProps } from "./label/input-fields-label";
+export type {
+  Field,
+  InputFieldsProps,
+  InputFieldsState,
+} from "./root/input-fields-context";
+export type { InputFieldsRootProps } from "./root/input-fields-root";
+export {
+  fieldSchema,
+  inputFieldsSchema,
+  useInputFieldsRootContext,
+} from "./root/input-fields-context";
+
+export { InputFields };

--- a/packages/react-ui-base/src/input-fields/input/input-fields-input.tsx
+++ b/packages/react-ui-base/src/input-fields/input/input-fields-input.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { useInputFieldsFieldContext } from "../field/input-fields-field-context";
+
+export type InputFieldsInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "value" | "onChange" | "type" | "id" | "name" | "disabled"
+>;
+
+/**
+ * Input sub-component for an individual field.
+ * Automatically binds to the field's value, type, validation attributes,
+ * and disabled state from context.
+ * @returns The input element for the field
+ */
+export const InputFieldsInput = React.forwardRef<
+  HTMLInputElement,
+  InputFieldsInputProps
+>(function InputFieldsInput(props, ref) {
+  const { field, value, isDisabled, onChange } = useInputFieldsFieldContext();
+
+  return (
+    <input
+      ref={ref}
+      data-slot="input-fields-input"
+      type={field.type}
+      id={field.id}
+      name={field.id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={field.placeholder}
+      required={field.required}
+      disabled={isDisabled}
+      maxLength={field.maxLength}
+      minLength={field.minLength}
+      pattern={field.pattern}
+      autoComplete={field.autoComplete}
+      {...props}
+    />
+  );
+});

--- a/packages/react-ui-base/src/input-fields/label/input-fields-label.tsx
+++ b/packages/react-ui-base/src/input-fields/label/input-fields-label.tsx
@@ -1,0 +1,40 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useInputFieldsFieldContext } from "../field/input-fields-field-context";
+
+export type InputFieldsLabelProps = BaseProps<
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>;
+
+/**
+ * Label sub-component for an individual field.
+ * Automatically sets the `htmlFor` attribute to match the field ID.
+ * Renders the field's label text and a required indicator when applicable.
+ * @returns The label element for the field
+ */
+export const InputFieldsLabel = React.forwardRef<
+  HTMLLabelElement,
+  InputFieldsLabelProps
+>(function InputFieldsLabel({ asChild, children, ...props }, ref) {
+  const { field } = useInputFieldsFieldContext();
+
+  const Comp = asChild ? Slot : "label";
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="input-fields-label"
+      data-required={field.required || undefined}
+      htmlFor={field.id}
+      {...props}
+    >
+      {children ?? (
+        <>
+          {field.label}
+          {field.required && <span data-slot="input-fields-required">*</span>}
+        </>
+      )}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/input-fields/root/input-fields-context.tsx
+++ b/packages/react-ui-base/src/input-fields/root/input-fields-context.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import { z } from "zod/v3";
+
+/**
+ * Zod schema for a single input field configuration.
+ */
+export const fieldSchema = z.object({
+  id: z.string().describe("Unique identifier for the field"),
+  type: z
+    .enum(["text", "number", "email", "password"])
+    .describe("Type of input field"),
+  label: z.string().describe("Display label for the field"),
+  placeholder: z.string().optional().describe("Optional placeholder text"),
+  required: z.boolean().optional().describe("Whether the field is required"),
+  description: z
+    .string()
+    .optional()
+    .describe("Additional description text for the field"),
+  disabled: z.boolean().optional().describe("Whether the field is disabled"),
+  maxLength: z.number().optional().describe("Maximum length of the field"),
+  minLength: z.number().optional().describe("Minimum length of the field"),
+  pattern: z
+    .string()
+    .optional()
+    .describe("Regular expression pattern for validation"),
+  autoComplete: z.string().optional().describe("Autocomplete attribute value"),
+  error: z.string().optional().describe("Error message for the field"),
+});
+
+/**
+ * Zod schema for InputFields component props.
+ */
+export const inputFieldsSchema = z.object({
+  fields: z
+    .array(fieldSchema)
+    .describe("Array of field configurations to render"),
+  variant: z
+    .enum(["default", "solid", "bordered"])
+    .optional()
+    .describe("Visual style variant"),
+  layout: z
+    .enum(["default", "compact", "relaxed"])
+    .optional()
+    .describe("Spacing layout"),
+  className: z
+    .string()
+    .optional()
+    .describe("Additional CSS classes for styling"),
+});
+
+/**
+ * Represents a single field configuration.
+ */
+export type Field = z.infer<typeof fieldSchema>;
+
+/**
+ * Interface representing the state of the InputFields component,
+ * managed by Tambo.
+ */
+export interface InputFieldsState {
+  values: Record<string, string>;
+}
+
+/**
+ * Props inferred from the InputFields Zod schema.
+ */
+export type InputFieldsProps = z.infer<typeof inputFieldsSchema>;
+
+/**
+ * Context value shared among InputFields sub-components.
+ */
+export interface InputFieldsRootContextValue {
+  /** The validated array of field configurations. */
+  validFields: Field[];
+  /** Current values for all fields, keyed by field ID. */
+  values: Record<string, string>;
+  /** Whether the AI is currently generating (fields should be disabled). */
+  isGenerating: boolean;
+  /**
+   * Handler for field value changes.
+   * @param fieldId - The ID of the field being updated
+   * @param value - The new value
+   */
+  handleInputChange: (fieldId: string, value: string) => void;
+}
+
+const InputFieldsRootContext =
+  React.createContext<InputFieldsRootContextValue | null>(null);
+
+/**
+ * Hook to access the InputFields root context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The InputFields root context value
+ * @throws Error if used outside of InputFields.Root
+ */
+function useInputFieldsRootContext(): InputFieldsRootContextValue {
+  const context = React.useContext(InputFieldsRootContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: InputFieldsRootContext is missing. InputFields parts must be used within <InputFields.Root>",
+    );
+  }
+  return context;
+}
+
+export { InputFieldsRootContext, useInputFieldsRootContext };

--- a/packages/react-ui-base/src/input-fields/root/input-fields-root.tsx
+++ b/packages/react-ui-base/src/input-fields/root/input-fields-root.tsx
@@ -1,0 +1,96 @@
+import { Slot } from "@radix-ui/react-slot";
+import { useTambo, useTamboComponentState } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import {
+  type Field,
+  type InputFieldsState,
+  InputFieldsRootContext,
+} from "./input-fields-context";
+
+export type InputFieldsRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** Array of field configurations to render. */
+    fields: Field[];
+  }
+>;
+
+/**
+ * Root component for the InputFields compound component.
+ * Manages Tambo component state, validates fields, and provides context
+ * for child sub-components.
+ * @returns The root container element with context provider, or null if state is not yet initialized
+ */
+export const InputFieldsRoot = React.forwardRef<
+  HTMLDivElement,
+  InputFieldsRootProps
+>(function InputFieldsRoot({ asChild, children, fields = [], ...props }, ref) {
+  const { isIdle } = useTambo();
+  const isGenerating = !isIdle;
+
+  const baseId = React.useId();
+  const inputFieldsId = React.useMemo(() => {
+    const ids = (fields ?? [])
+      .map((f) => f.id)
+      .filter(Boolean)
+      .join("-");
+    return ids ? `input-fields-${baseId}-${ids}` : `input-fields-${baseId}`;
+  }, [baseId, fields]);
+
+  const [state, setState] = useTamboComponentState<InputFieldsState>(
+    inputFieldsId,
+    {
+      values: {},
+    },
+  );
+
+  const validFields = React.useMemo(() => {
+    return fields.filter((field): field is Field => {
+      if (!field || typeof field !== "object") {
+        console.warn("Invalid field object detected");
+        return false;
+      }
+      if (!field.id || typeof field.id !== "string") {
+        console.warn("Field missing required id property");
+        return false;
+      }
+      return true;
+    });
+  }, [fields]);
+
+  const handleInputChange = React.useCallback(
+    (fieldId: string, value: string) => {
+      if (!state) return;
+      setState({
+        ...state,
+        values: {
+          ...state.values,
+          [fieldId]: value,
+        },
+      });
+    },
+    [state, setState],
+  );
+
+  const contextValue = React.useMemo(
+    () => ({
+      validFields,
+      values: state?.values ?? {},
+      isGenerating,
+      handleInputChange,
+    }),
+    [validFields, state?.values, isGenerating, handleInputChange],
+  );
+
+  if (!state) return null;
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <InputFieldsRootContext.Provider value={contextValue}>
+      <Comp ref={ref} data-slot="input-fields-root" {...props}>
+        {children}
+      </Comp>
+    </InputFieldsRootContext.Provider>
+  );
+});

--- a/packages/react-ui-base/src/map/container/map-container.tsx
+++ b/packages/react-ui-base/src/map/container/map-container.tsx
@@ -1,0 +1,80 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import {
+  useMapRootContext,
+  type ValidatedHeatDataTuple,
+  type ValidatedMarkerData,
+} from "../root/map-root-context";
+
+/**
+ * Props passed to the MapContainer render function.
+ */
+export interface MapContainerRenderProps {
+  /** Center coordinates as [lat, lng] tuple */
+  center: [number, number];
+  /** Zoom level */
+  zoom: number;
+  /** Whether zoom controls should be shown */
+  zoomControl: boolean;
+  /** The tile theme to apply */
+  tileTheme: "default" | "dark" | "light" | "satellite";
+  /** Validated marker data */
+  validMarkers: ValidatedMarkerData[];
+  /** Validated heat data as tuples [lat, lng, intensity] */
+  validHeatData: ValidatedHeatDataTuple[];
+}
+
+export type MapContainerProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+>;
+
+/**
+ * Container primitive for the map rendering area.
+ * Only renders when the map is not in a loading or error state.
+ * Provides map configuration and validated data via render prop for the
+ * consumer to pass to their mapping library (e.g., react-leaflet).
+ * @returns The map container element or null if loading/error
+ */
+export const MapContainer = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<
+    MapContainerProps,
+    MapContainerRenderProps
+  >
+>((props, ref) => {
+  const {
+    center,
+    zoom,
+    zoomControl,
+    tileTheme,
+    validMarkers,
+    validHeatData,
+    isLoading,
+    hasError,
+  } = useMapRootContext();
+
+  if (isLoading || hasError || !center) {
+    return null;
+  }
+
+  const Comp = "asChild" in props && props.asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    center: [center.lat, center.lng] as [number, number],
+    zoom,
+    zoomControl,
+    tileTheme,
+    validMarkers,
+    validHeatData,
+  });
+
+  return (
+    <Comp ref={ref} data-slot="map-container" {...componentProps}>
+      {content}
+    </Comp>
+  );
+});
+MapContainer.displayName = "MapBase.Container";

--- a/packages/react-ui-base/src/map/error/map-error.tsx
+++ b/packages/react-ui-base/src/map/error/map-error.tsx
@@ -1,0 +1,49 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useMapRootContext } from "../root/map-root-context";
+
+/**
+ * Props passed to the MapError render function.
+ */
+export interface MapErrorRenderProps {
+  /** Whether the map has an error (missing center coordinates) */
+  hasError: boolean;
+}
+
+export type MapErrorProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+>;
+
+/**
+ * Error primitive for the map component.
+ * Only renders when the map is in an error state (e.g., missing center coordinates).
+ * Does not render during loading state even if error is present.
+ * The consumer provides the actual error UI via children or render prop.
+ * @returns The error container element or null if no error
+ */
+export const MapError = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<MapErrorProps, MapErrorRenderProps>
+>((props, ref) => {
+  const { hasError, isLoading } = useMapRootContext();
+
+  if (!hasError || isLoading) {
+    return null;
+  }
+
+  const Comp = "asChild" in props && props.asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    hasError,
+  });
+
+  return (
+    <Comp ref={ref} data-slot="map-error" {...componentProps}>
+      {content}
+    </Comp>
+  );
+});
+MapError.displayName = "MapBase.Error";

--- a/packages/react-ui-base/src/map/heatmap/map-heatmap.tsx
+++ b/packages/react-ui-base/src/map/heatmap/map-heatmap.tsx
@@ -1,0 +1,52 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import {
+  useMapRootContext,
+  type ValidatedHeatDataTuple,
+} from "../root/map-root-context";
+
+/**
+ * Props passed to the MapHeatmap render function.
+ */
+export interface MapHeatmapRenderProps {
+  /** Array of validated heat data tuples in [lat, lng, intensity] format */
+  heatData: ValidatedHeatDataTuple[];
+}
+
+export type MapHeatmapProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+>;
+
+/**
+ * Heatmap primitive for rendering heatmap data.
+ * Provides validated heat data via render prop for the consumer
+ * to render with their mapping library.
+ * Renders nothing if there is no valid heat data.
+ * @returns The heatmap container element or null if no heat data
+ */
+export const MapHeatmap = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<MapHeatmapProps, MapHeatmapRenderProps>
+>((props, ref) => {
+  const { validHeatData, isLoading, hasError } = useMapRootContext();
+
+  if (isLoading || hasError || validHeatData.length === 0) {
+    return null;
+  }
+
+  const Comp = "asChild" in props && props.asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    heatData: validHeatData,
+  });
+
+  return (
+    <Comp ref={ref} data-slot="map-heatmap" {...componentProps}>
+      {content}
+    </Comp>
+  );
+});
+MapHeatmap.displayName = "MapBase.Heatmap";

--- a/packages/react-ui-base/src/map/index.tsx
+++ b/packages/react-ui-base/src/map/index.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { MapContainer } from "./container/map-container";
+import { MapError } from "./error/map-error";
+import { MapHeatmap } from "./heatmap/map-heatmap";
+import { MapLoading } from "./loading/map-loading";
+import { MapMarkers } from "./markers/map-markers";
+import { MapRoot } from "./root/map-root";
+
+/**
+ * MapBase namespace containing all map base components.
+ */
+const MapBase = {
+  Root: MapRoot,
+  Container: MapContainer,
+  Markers: MapMarkers,
+  Heatmap: MapHeatmap,
+  Loading: MapLoading,
+  Error: MapError,
+};
+
+export type {
+  MapContainerProps,
+  MapContainerRenderProps,
+} from "./container/map-container";
+export type { MapErrorProps, MapErrorRenderProps } from "./error/map-error";
+export type {
+  MapHeatmapProps,
+  MapHeatmapRenderProps,
+} from "./heatmap/map-heatmap";
+export type {
+  MapLoadingProps,
+  MapLoadingRenderProps,
+} from "./loading/map-loading";
+export type {
+  MapMarkersProps,
+  MapMarkersRenderProps,
+} from "./markers/map-markers";
+export type {
+  HeatData,
+  MapRootContextValue,
+  MarkerData,
+  TileTheme,
+  ValidatedHeatDataTuple,
+  ValidatedMarkerData,
+} from "./root/map-root-context";
+export type { MapRootProps } from "./root/map-root";
+
+export { MapBase };

--- a/packages/react-ui-base/src/map/loading/map-loading.tsx
+++ b/packages/react-ui-base/src/map/loading/map-loading.tsx
@@ -1,0 +1,48 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useMapRootContext } from "../root/map-root-context";
+
+/**
+ * Props passed to the MapLoading render function.
+ */
+export interface MapLoadingRenderProps {
+  /** Whether the map is currently loading */
+  isLoading: boolean;
+}
+
+export type MapLoadingProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+>;
+
+/**
+ * Loading primitive for the map component.
+ * Only renders when the map is in a loading state.
+ * The consumer provides the actual loading UI via children or render prop.
+ * @returns The loading container element or null if not loading
+ */
+export const MapLoading = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<MapLoadingProps, MapLoadingRenderProps>
+>((props, ref) => {
+  const { isLoading } = useMapRootContext();
+
+  if (!isLoading) {
+    return null;
+  }
+
+  const Comp = "asChild" in props && props.asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    isLoading,
+  });
+
+  return (
+    <Comp ref={ref} data-slot="map-loading" {...componentProps}>
+      {content}
+    </Comp>
+  );
+});
+MapLoading.displayName = "MapBase.Loading";

--- a/packages/react-ui-base/src/map/markers/map-markers.tsx
+++ b/packages/react-ui-base/src/map/markers/map-markers.tsx
@@ -1,0 +1,52 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import {
+  useMapRootContext,
+  type ValidatedMarkerData,
+} from "../root/map-root-context";
+
+/**
+ * Props passed to the MapMarkers render function.
+ */
+export interface MapMarkersRenderProps {
+  /** Array of validated marker data */
+  markers: ValidatedMarkerData[];
+}
+
+export type MapMarkersProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+>;
+
+/**
+ * Markers primitive for rendering map markers.
+ * Provides validated marker data via render prop for the consumer
+ * to render with their mapping library.
+ * Renders nothing if there are no valid markers.
+ * @returns The markers container element or null if no markers
+ */
+export const MapMarkers = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<MapMarkersProps, MapMarkersRenderProps>
+>((props, ref) => {
+  const { validMarkers, isLoading, hasError } = useMapRootContext();
+
+  if (isLoading || hasError || validMarkers.length === 0) {
+    return null;
+  }
+
+  const Comp = "asChild" in props && props.asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    markers: validMarkers,
+  });
+
+  return (
+    <Comp ref={ref} data-slot="map-markers" {...componentProps}>
+      {content}
+    </Comp>
+  );
+});
+MapMarkers.displayName = "MapBase.Markers";

--- a/packages/react-ui-base/src/map/root/map-root-context.tsx
+++ b/packages/react-ui-base/src/map/root/map-root-context.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+
+/**
+ * Marker data for display on the map.
+ */
+export interface MarkerData {
+  /** Latitude coordinate (must be between -90 and 90) */
+  lat: number;
+  /** Longitude coordinate (must be between -180 and 180) */
+  lng: number;
+  /** Display label for the marker */
+  label: string;
+  /** Optional unique identifier for the marker */
+  id?: string;
+}
+
+/**
+ * Heat data point for heatmap visualization.
+ */
+export interface HeatData {
+  /** Latitude coordinate (must be between -90 and 90) */
+  lat: number;
+  /** Longitude coordinate (must be between -180 and 180) */
+  lng: number;
+  /** Intensity value for heatmap (must be between 0 and 1) */
+  intensity: number;
+}
+
+/** Supported tile theme values */
+export type TileTheme = "default" | "dark" | "light" | "satellite";
+
+/**
+ * Validated marker data with the same shape as MarkerData, confirmed to be
+ * within valid coordinate ranges.
+ */
+export type ValidatedMarkerData = MarkerData;
+
+/** A validated heat data tuple in the format [lat, lng, intensity] */
+export type ValidatedHeatDataTuple = [number, number, number];
+
+/**
+ * Context value shared among MapBase sub-components.
+ */
+export interface MapRootContextValue {
+  /** Center coordinates of the map */
+  center: { lat: number; lng: number } | undefined;
+  /** Zoom level */
+  zoom: number;
+  /** Whether to show zoom controls */
+  zoomControl: boolean;
+  /** Effective tile theme for the map */
+  tileTheme: TileTheme;
+  /** Validated marker data */
+  validMarkers: ValidatedMarkerData[];
+  /** Validated heat data as tuples */
+  validHeatData: ValidatedHeatDataTuple[];
+  /** Whether the component is in a loading/generating state */
+  isLoading: boolean;
+  /** Whether the center is missing (error state) */
+  hasError: boolean;
+  /** Size variant */
+  size?: "sm" | "md" | "lg" | "full";
+  /** Rounded variant */
+  rounded?: "none" | "sm" | "md" | "full";
+}
+
+const MapRootContext = React.createContext<MapRootContextValue | null>(null);
+
+/**
+ * Hook to access the map root context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The map root context value
+ * @throws Error if used outside of MapBase.Root component
+ */
+function useMapRootContext(): MapRootContextValue {
+  const context = React.useContext(MapRootContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: MapRootContext is missing. Map parts must be used within <MapBase.Root>",
+    );
+  }
+  return context;
+}
+
+export { MapRootContext, useMapRootContext };

--- a/packages/react-ui-base/src/map/root/map-root.tsx
+++ b/packages/react-ui-base/src/map/root/map-root.tsx
@@ -1,0 +1,179 @@
+import { Slot } from "@radix-ui/react-slot";
+import {
+  GenerationStage,
+  useTambo,
+  useTamboCurrentMessage,
+} from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import {
+  type HeatData,
+  type MarkerData,
+  MapRootContext,
+  type TileTheme,
+  type ValidatedHeatDataTuple,
+  type ValidatedMarkerData,
+} from "./map-root-context";
+
+export type MapRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** Center coordinates of the map */
+    center?: { lat: number; lng: number };
+    /** Initial zoom level (1-20, default: 10) */
+    zoom?: number;
+    /** Array of marker objects to display on the map */
+    markers?: MarkerData[];
+    /** Optional array of heatmap data points */
+    heatData?: HeatData[] | null;
+    /** Whether to show zoom controls (default: true) */
+    zoomControl?: boolean;
+    /** Size variant for the map */
+    size?: "sm" | "md" | "lg" | "full";
+    /** Map tile theme */
+    tileTheme?: TileTheme;
+    /** @deprecated Use tileTheme instead */
+    theme?: TileTheme;
+    /** Border radius variant */
+    rounded?: "none" | "sm" | "md" | "full";
+  }
+>;
+
+/**
+ * Filters and validates marker data.
+ * Removes markers that don't meet coordinate or label requirements.
+ * @param markers - Array of marker objects to validate
+ * @returns Array of valid marker objects
+ */
+function useValidMarkers(markers: MarkerData[] = []): ValidatedMarkerData[] {
+  return React.useMemo(
+    () =>
+      (markers || []).filter(
+        (m) =>
+          typeof m.lat === "number" &&
+          m.lat >= -90 &&
+          m.lat <= 90 &&
+          typeof m.lng === "number" &&
+          m.lng >= -180 &&
+          m.lng <= 180 &&
+          typeof m.label === "string" &&
+          m.label.length > 0,
+      ),
+    [markers],
+  );
+}
+
+/**
+ * Filters and validates heatmap data.
+ * Converts valid heat data to tuple format [lat, lng, intensity].
+ * @param heatData - Array of heatmap data points
+ * @returns Array of validated heat data tuples
+ */
+function useValidHeatData(
+  heatData?: HeatData[] | null,
+): ValidatedHeatDataTuple[] {
+  return React.useMemo(() => {
+    if (!Array.isArray(heatData)) return [];
+    return heatData
+      .filter(
+        (d) =>
+          typeof d.lat === "number" &&
+          d.lat >= -90 &&
+          d.lat <= 90 &&
+          typeof d.lng === "number" &&
+          d.lng >= -180 &&
+          d.lng <= 180 &&
+          typeof d.intensity === "number" &&
+          d.intensity >= 0 &&
+          d.intensity <= 1,
+      )
+      .map((d) => [d.lat, d.lng, d.intensity] as ValidatedHeatDataTuple);
+  }, [heatData]);
+}
+
+/**
+ * Root primitive for the map component.
+ * Provides context with validated data for child components.
+ * Handles loading state detection via Tambo thread generation stage.
+ * @returns The root map container with context provider
+ */
+export const MapRoot = React.forwardRef<HTMLDivElement, MapRootProps>(
+  function MapRoot(
+    {
+      children,
+      asChild,
+      center,
+      zoom = 10,
+      markers = [],
+      heatData,
+      zoomControl = true,
+      size,
+      tileTheme,
+      theme,
+      rounded,
+      ...props
+    },
+    ref,
+  ) {
+    const effectiveTileTheme = tileTheme ?? theme ?? "default";
+    const { thread } = useTambo();
+    const currentMessage = useTamboCurrentMessage();
+
+    const message = thread?.messages[thread?.messages.length - 1];
+    const isLatestMessage = message?.id && message.id === currentMessage?.id;
+
+    const generationStage = thread?.generationStage;
+    const isGenerating =
+      generationStage &&
+      generationStage !== GenerationStage.COMPLETE &&
+      generationStage !== GenerationStage.ERROR;
+
+    const isLoading = !!isLatestMessage && !!isGenerating;
+    const hasError = !center;
+
+    const validMarkers = useValidMarkers(markers);
+    const validHeatData = useValidHeatData(heatData);
+
+    const contextValue = React.useMemo(
+      () => ({
+        center,
+        zoom,
+        zoomControl,
+        tileTheme: effectiveTileTheme,
+        validMarkers,
+        validHeatData,
+        isLoading,
+        hasError,
+        size,
+        rounded,
+      }),
+      [
+        center,
+        zoom,
+        zoomControl,
+        effectiveTileTheme,
+        validMarkers,
+        validHeatData,
+        isLoading,
+        hasError,
+        size,
+        rounded,
+      ],
+    );
+
+    const Comp = asChild ? Slot : "div";
+
+    return (
+      <MapRootContext.Provider value={contextValue}>
+        <Comp
+          ref={ref}
+          data-slot="map-root"
+          data-loading={isLoading || undefined}
+          data-error={hasError || undefined}
+          {...props}
+        >
+          {children}
+        </Comp>
+      </MapRootContext.Provider>
+    );
+  },
+);

--- a/packages/react-ui-base/src/message-suggestions/generation-stage/message-suggestions-generation-stage.tsx
+++ b/packages/react-ui-base/src/message-suggestions/generation-stage/message-suggestions-generation-stage.tsx
@@ -1,0 +1,92 @@
+import { Slot } from "@radix-ui/react-slot";
+import { type GenerationStage, useTambo } from "@tambo-ai/react";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+
+/**
+ * Props passed to the render callback for generation stage.
+ */
+export interface MessageSuggestionsGenerationStageRenderProps {
+  /** The current generation stage string value. */
+  stage: string;
+  /** A human-friendly label for the current generation stage. */
+  label: string;
+  /** Whether the thread is idle (not actively processing). */
+  isIdle: boolean;
+  /** Whether to show the label text. */
+  showLabel: boolean;
+}
+
+export interface MessageSuggestionsGenerationStageProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  /** Whether to show the label text. Defaults to true. */
+  showLabel?: boolean;
+}
+
+/** Map of generation stage values to human-friendly labels. */
+const stageLabels: Record<GenerationStage, string> = {
+  IDLE: "Idle",
+  CHOOSING_COMPONENT: "Choosing component",
+  FETCHING_CONTEXT: "Fetching context",
+  HYDRATING_COMPONENT: "Preparing component",
+  STREAMING_RESPONSE: "Generating response",
+  COMPLETE: "Complete",
+  ERROR: "Error",
+  CANCELLED: "Cancelled",
+};
+
+/**
+ * Generation stage primitive for message suggestions.
+ * Displays the current generation stage of the thread.
+ * Renders nothing if no stage is active or the thread is idle.
+ *
+ * Applies data attributes for styling:
+ * - `data-stage` with the current generation stage value
+ * - `data-idle` when the thread is idle
+ *
+ * @returns A container element with generation stage information, or null when inactive.
+ */
+export const MessageSuggestionsGenerationStage = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<
+    MessageSuggestionsGenerationStageProps,
+    MessageSuggestionsGenerationStageRenderProps
+  >
+>(function MessageSuggestionsGenerationStage(
+  { showLabel = true, asChild, ...props },
+  ref,
+) {
+  const { thread, isIdle } = useTambo();
+  const stage = thread?.generationStage;
+
+  if (!stage || isIdle) {
+    return null;
+  }
+
+  const label =
+    stageLabels[stage] || stage.charAt(0).toUpperCase() + stage.slice(1);
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    stage,
+    label,
+    isIdle,
+    showLabel,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="message-suggestions-generation-stage"
+      data-stage={stage}
+      data-idle={isIdle ? "" : undefined}
+      {...componentProps}
+    >
+      {content}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/message-suggestions/index.tsx
+++ b/packages/react-ui-base/src/message-suggestions/index.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { MessageSuggestionsGenerationStage } from "./generation-stage/message-suggestions-generation-stage";
+import { MessageSuggestionsItem } from "./item/message-suggestions-item";
+import { MessageSuggestionsList } from "./list/message-suggestions-list";
+import { MessageSuggestionsRoot } from "./root/message-suggestions-root";
+import { MessageSuggestionsStatus } from "./status/message-suggestions-status";
+
+/**
+ * MessageSuggestions namespace containing all message suggestions base components.
+ */
+const MessageSuggestions = {
+  Root: MessageSuggestionsRoot,
+  Status: MessageSuggestionsStatus,
+  GenerationStage: MessageSuggestionsGenerationStage,
+  List: MessageSuggestionsList,
+  Item: MessageSuggestionsItem,
+};
+
+export type {
+  MessageSuggestionsGenerationStageProps,
+  MessageSuggestionsGenerationStageRenderProps,
+} from "./generation-stage/message-suggestions-generation-stage";
+export type { MessageSuggestionsItemProps } from "./item/message-suggestions-item";
+export type {
+  MessageSuggestionsListProps,
+  MessageSuggestionsListRenderProps,
+} from "./list/message-suggestions-list";
+export type { MessageSuggestionsContextValue } from "./root/message-suggestions-context";
+export type { MessageSuggestionsRootProps } from "./root/message-suggestions-root";
+export type { MessageSuggestionsStatusProps } from "./status/message-suggestions-status";
+
+export {
+  useMessageSuggestionsContext,
+  useOptionalMessageSuggestionsContext,
+} from "./root/message-suggestions-context";
+
+export { MessageSuggestions };

--- a/packages/react-ui-base/src/message-suggestions/item/message-suggestions-item.tsx
+++ b/packages/react-ui-base/src/message-suggestions/item/message-suggestions-item.tsx
@@ -1,0 +1,63 @@
+import { Slot } from "@radix-ui/react-slot";
+import type { Suggestion } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useMessageSuggestionsContext } from "../root/message-suggestions-context";
+
+export type MessageSuggestionsItemProps = BaseProps<
+  Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onClick"> & {
+    /** The suggestion to display and handle acceptance for. */
+    suggestion: Suggestion;
+    /** The index of this suggestion in the list. */
+    index: number;
+  }
+>;
+
+/**
+ * Item primitive for an individual message suggestion.
+ * Renders a button that accepts the suggestion when clicked.
+ *
+ * Applies data attributes for styling:
+ * - `data-suggestion-id` with the suggestion's ID
+ * - `data-suggestion-index` with the suggestion's position in the list
+ * - `data-selected` when this suggestion is currently selected
+ * - `data-generating` when suggestions are being generated (button is disabled)
+ *
+ * @returns A button element representing a single suggestion.
+ */
+export const MessageSuggestionsItem = React.forwardRef<
+  HTMLButtonElement,
+  MessageSuggestionsItemProps
+>(function MessageSuggestionsItem(
+  { suggestion, index, asChild, children, ...props },
+  ref,
+) {
+  const { selectedSuggestionId, accept, isGenerating } =
+    useMessageSuggestionsContext();
+
+  const isSelected = selectedSuggestionId === suggestion.id;
+
+  const handleClick = async () => {
+    if (!isGenerating) {
+      await accept({ suggestion });
+    }
+  };
+
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="message-suggestions-item"
+      data-suggestion-id={suggestion.id}
+      data-suggestion-index={index}
+      data-selected={isSelected ? "" : undefined}
+      data-generating={isGenerating ? "" : undefined}
+      onClick={handleClick}
+      disabled={isGenerating}
+      {...props}
+    >
+      {children ?? <span>{suggestion.title}</span>}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/message-suggestions/list/message-suggestions-list.tsx
+++ b/packages/react-ui-base/src/message-suggestions/list/message-suggestions-list.tsx
@@ -1,0 +1,100 @@
+import { Slot } from "@radix-ui/react-slot";
+import type { Suggestion } from "@tambo-ai/react";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useMessageSuggestionsContext } from "../root/message-suggestions-context";
+
+/**
+ * Props passed to the render callback for the suggestion list.
+ */
+export interface MessageSuggestionsListRenderProps {
+  /** The array of current suggestions. */
+  suggestions: Suggestion[];
+  /** Whether suggestions are currently being generated. */
+  isGenerating: boolean;
+  /** The ID of the currently selected suggestion, or null. */
+  selectedSuggestionId: string | null;
+  /** Whether the user is on macOS. */
+  isMac: boolean;
+  /** The modifier key label (e.g. "Cmd" on Mac, "Ctrl" on other platforms). */
+  modKey: string;
+  /** The alt key label (e.g. "Option" on Mac, "Alt" on other platforms). */
+  altKey: string;
+}
+
+export interface MessageSuggestionsListProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  /** Number of placeholder items to show when no suggestions are available. Defaults to 3. */
+  placeholderCount?: number;
+}
+
+/**
+ * List primitive for message suggestions.
+ * Renders the list of suggestion items.
+ *
+ * Applies data attributes for styling:
+ * - `data-generating` when suggestions are being generated
+ * - `data-empty` when there are no suggestions
+ *
+ * When using the render prop, provides the suggestions array and related state.
+ * When using children, renders them directly.
+ *
+ * @returns A container element for the suggestion list.
+ */
+export const MessageSuggestionsList = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<
+    MessageSuggestionsListProps,
+    MessageSuggestionsListRenderProps
+  >
+>(function MessageSuggestionsList(
+  { asChild, placeholderCount = 3, ...props },
+  ref,
+) {
+  const { suggestions, selectedSuggestionId, isGenerating, isMac } =
+    useMessageSuggestionsContext();
+
+  const modKey = isMac ? "\u2318" : "Ctrl";
+  const altKey = isMac ? "\u2325" : "Alt";
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    suggestions,
+    isGenerating,
+    selectedSuggestionId,
+    isMac,
+    modKey,
+    altKey,
+  });
+
+  // When no render prop or children, render default placeholders if empty
+  const defaultContent =
+    content ??
+    (suggestions.length === 0
+      ? Array.from({ length: placeholderCount }, (_, index) => (
+          <div
+            key={`placeholder-${index}`}
+            data-slot="message-suggestions-placeholder"
+            data-placeholder-index={index}
+          >
+            <span />
+          </div>
+        ))
+      : null);
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="message-suggestions-list"
+      data-generating={isGenerating ? "" : undefined}
+      data-empty={suggestions.length === 0 ? "" : undefined}
+      {...componentProps}
+    >
+      {defaultContent}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/message-suggestions/root/message-suggestions-context.tsx
+++ b/packages/react-ui-base/src/message-suggestions/root/message-suggestions-context.tsx
@@ -1,0 +1,51 @@
+import type { Suggestion, TamboThread } from "@tambo-ai/react";
+import * as React from "react";
+
+/**
+ * Context value shared among MessageSuggestions primitive sub-components.
+ */
+export interface MessageSuggestionsContextValue {
+  /** Array of suggestion objects. */
+  suggestions: Suggestion[];
+  /** ID of the currently selected suggestion, or null if none selected. */
+  selectedSuggestionId: string | null;
+  /** Function to accept a suggestion. */
+  accept: (options: { suggestion: Suggestion }) => Promise<void>;
+  /** Whether suggestions are currently being generated. */
+  isGenerating: boolean;
+  /** Any error from suggestion generation. */
+  error: Error | null;
+  /** The current Tambo thread. */
+  thread: TamboThread;
+  /** Whether the user is on macOS (affects keyboard shortcut display). */
+  isMac: boolean;
+}
+
+export const MessageSuggestionsContext =
+  React.createContext<MessageSuggestionsContextValue | null>(null);
+
+/**
+ * Hook to access the message suggestions context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The message suggestions context value
+ * @throws Error if used outside of MessageSuggestions.Root
+ */
+export function useMessageSuggestionsContext(): MessageSuggestionsContextValue {
+  const context = React.useContext(MessageSuggestionsContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: MessageSuggestionsContext is missing. MessageSuggestions parts must be used within <MessageSuggestions.Root>",
+    );
+  }
+  return context;
+}
+
+/**
+ * Hook to optionally access the message suggestions context.
+ * Returns null if not within a MessageSuggestions.Root component.
+ * @internal This hook is for internal use by base components only.
+ * @returns The message suggestions context value or null
+ */
+export function useOptionalMessageSuggestionsContext(): MessageSuggestionsContextValue | null {
+  return React.useContext(MessageSuggestionsContext);
+}

--- a/packages/react-ui-base/src/message-suggestions/root/message-suggestions-root.tsx
+++ b/packages/react-ui-base/src/message-suggestions/root/message-suggestions-root.tsx
@@ -1,0 +1,144 @@
+import { Slot } from "@radix-ui/react-slot";
+import type { Suggestion } from "@tambo-ai/react";
+import { useTambo, useTamboSuggestions } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { MessageSuggestionsContext } from "./message-suggestions-context";
+
+export type MessageSuggestionsRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** Maximum number of suggestions to display. Defaults to 3. */
+    maxSuggestions?: number;
+    /** Pre-seeded suggestions to display when the thread is empty. */
+    initialSuggestions?: Suggestion[];
+  }
+>;
+
+/**
+ * Root primitive for the message suggestions compound component.
+ * Provides context with suggestion state, generation progress, and keyboard shortcuts.
+ * Renders nothing if the thread has no messages and no initial suggestions are provided.
+ * @returns A context provider wrapping child components, or null if there is nothing to display.
+ */
+export const MessageSuggestionsRoot = React.forwardRef<
+  HTMLDivElement,
+  MessageSuggestionsRootProps
+>(function MessageSuggestionsRoot(
+  { children, asChild, maxSuggestions = 3, initialSuggestions = [], ...props },
+  ref,
+) {
+  const { thread } = useTambo();
+  const {
+    suggestions: generatedSuggestions,
+    selectedSuggestionId,
+    accept,
+    generateResult: { isPending: isGenerating, error },
+  } = useTamboSuggestions({ maxSuggestions });
+
+  // Combine initial and generated suggestions.
+  // Only use pre-seeded suggestions if the thread is empty.
+  const suggestions = React.useMemo(() => {
+    if (!thread?.messages?.length && initialSuggestions.length > 0) {
+      return initialSuggestions.slice(0, maxSuggestions);
+    }
+    return generatedSuggestions;
+  }, [
+    thread?.messages?.length,
+    generatedSuggestions,
+    initialSuggestions,
+    maxSuggestions,
+  ]);
+
+  const isMac =
+    typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
+
+  // Track the last AI message ID to detect new messages
+  const lastAiMessageIdRef = React.useRef<string | null>(null);
+  const loadingTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+
+  const contextValue = React.useMemo(
+    () => ({
+      suggestions,
+      selectedSuggestionId,
+      accept,
+      isGenerating,
+      error,
+      thread,
+      isMac,
+    }),
+    [
+      suggestions,
+      selectedSuggestionId,
+      accept,
+      isGenerating,
+      error,
+      thread,
+      isMac,
+    ],
+  );
+
+  // Find the last AI message
+  const lastAiMessage = thread?.messages
+    ? [...thread.messages].reverse().find((msg) => msg.role === "assistant")
+    : null;
+
+  // When a new AI message appears, update the reference
+  React.useEffect(() => {
+    if (lastAiMessage && lastAiMessage.id !== lastAiMessageIdRef.current) {
+      lastAiMessageIdRef.current = lastAiMessage.id;
+
+      if (loadingTimeoutRef.current) {
+        clearTimeout(loadingTimeoutRef.current);
+      }
+
+      loadingTimeoutRef.current = setTimeout(() => {}, 5000);
+    }
+
+    return () => {
+      if (loadingTimeoutRef.current) {
+        clearTimeout(loadingTimeoutRef.current);
+      }
+    };
+  }, [lastAiMessage, suggestions.length]);
+
+  // Handle keyboard shortcuts for selecting suggestions
+  React.useEffect(() => {
+    if (!suggestions || suggestions.length === 0) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const modifierPressed = isMac
+        ? event.metaKey && event.altKey
+        : event.ctrlKey && event.altKey;
+
+      if (modifierPressed) {
+        const keyNum = parseInt(event.key);
+        if (!isNaN(keyNum) && keyNum > 0 && keyNum <= suggestions.length) {
+          event.preventDefault();
+          const suggestionIndex = keyNum - 1;
+          void accept({ suggestion: suggestions[suggestionIndex] });
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [suggestions, accept, isMac]);
+
+  // If we have no messages yet and no initial suggestions, render nothing
+  if (!thread?.messages?.length && initialSuggestions.length === 0) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <MessageSuggestionsContext.Provider value={contextValue}>
+      <Comp ref={ref} data-slot="message-suggestions" {...props}>
+        {children}
+      </Comp>
+    </MessageSuggestionsContext.Provider>
+  );
+});

--- a/packages/react-ui-base/src/message-suggestions/status/message-suggestions-status.tsx
+++ b/packages/react-ui-base/src/message-suggestions/status/message-suggestions-status.tsx
@@ -1,0 +1,50 @@
+import { Slot } from "@radix-ui/react-slot";
+import { GenerationStage } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useMessageSuggestionsContext } from "../root/message-suggestions-context";
+
+export type MessageSuggestionsStatusProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Status primitive for message suggestions.
+ * Renders error and generation stage information.
+ * Delegates visual rendering to children.
+ *
+ * Applies data attributes for styling:
+ * - `data-error` when there is a generation error
+ * - `data-generating` when suggestions are being generated
+ * - `data-generation-stage` with the current generation stage value
+ * - `data-idle` when there is no active status to display
+ *
+ * @returns A container element with data attributes reflecting the current suggestion status.
+ */
+export const MessageSuggestionsStatus = React.forwardRef<
+  HTMLDivElement,
+  MessageSuggestionsStatusProps
+>(function MessageSuggestionsStatus({ asChild, children, ...props }, ref) {
+  const { error, isGenerating, thread } = useMessageSuggestionsContext();
+
+  const generationStage = thread?.generationStage;
+  const hasActiveStage =
+    generationStage && generationStage !== GenerationStage.COMPLETE;
+  const isIdle = !error && !isGenerating && !hasActiveStage;
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="message-suggestions-status"
+      data-error={error ? "" : undefined}
+      data-generating={isGenerating ? "" : undefined}
+      data-generation-stage={generationStage || undefined}
+      data-idle={isIdle ? "" : undefined}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/scrollable-message-container/index.tsx
+++ b/packages/react-ui-base/src/scrollable-message-container/index.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { ScrollableMessageContainerRoot } from "./root/scrollable-message-container-root";
+import { ScrollableMessageContainerScrollToBottom } from "./scroll-to-bottom/scrollable-message-container-scroll-to-bottom";
+import { ScrollableMessageContainerViewport } from "./viewport/scrollable-message-container-viewport";
+
+/**
+ * ScrollableMessageContainer namespace containing all scrollable message container base components.
+ */
+const ScrollableMessageContainer = {
+  Root: ScrollableMessageContainerRoot,
+  Viewport: ScrollableMessageContainerViewport,
+  ScrollToBottom: ScrollableMessageContainerScrollToBottom,
+};
+
+export type { ScrollableMessageContainerRootContextValue } from "./root/scrollable-message-container-root-context";
+export type { ScrollableMessageContainerRootProps } from "./root/scrollable-message-container-root";
+export type {
+  ScrollableMessageContainerScrollToBottomProps,
+  ScrollableMessageContainerScrollToBottomRenderProps,
+} from "./scroll-to-bottom/scrollable-message-container-scroll-to-bottom";
+export type { ScrollableMessageContainerViewportProps } from "./viewport/scrollable-message-container-viewport";
+
+export { ScrollableMessageContainer };

--- a/packages/react-ui-base/src/scrollable-message-container/root/scrollable-message-container-root-context.tsx
+++ b/packages/react-ui-base/src/scrollable-message-container/root/scrollable-message-container-root-context.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+/**
+ * Context value shared among ScrollableMessageContainer primitive sub-components.
+ */
+export interface ScrollableMessageContainerRootContextValue {
+  /** Whether the container should auto-scroll to the bottom when content changes. */
+  shouldAutoscroll: boolean;
+  /** Whether the scroll position is currently at the bottom of the container. */
+  isAtBottom: boolean;
+  /** Scroll the container to the bottom. */
+  scrollToBottom: () => void;
+  /** Suspend auto-scrolling (e.g., when user scrolls up). */
+  suspendAutoscroll: () => void;
+  /** Resume auto-scrolling (e.g., when user scrolls to bottom). */
+  resumeAutoscroll: () => void;
+  /** Ref for the scrollable viewport element. */
+  viewportRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const ScrollableMessageContainerRootContext =
+  React.createContext<ScrollableMessageContainerRootContextValue | null>(null);
+
+/**
+ * Hook to access the scrollable message container context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The scrollable message container context value
+ * @throws Error if used outside of ScrollableMessageContainer.Root component
+ */
+function useScrollableMessageContainerRootContext(): ScrollableMessageContainerRootContextValue {
+  const context = React.useContext(ScrollableMessageContainerRootContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: ScrollableMessageContainerRootContext is missing. ScrollableMessageContainer parts must be used within <ScrollableMessageContainer.Root>",
+    );
+  }
+  return context;
+}
+
+export {
+  ScrollableMessageContainerRootContext,
+  useScrollableMessageContainerRootContext,
+};

--- a/packages/react-ui-base/src/scrollable-message-container/root/scrollable-message-container-root.tsx
+++ b/packages/react-ui-base/src/scrollable-message-container/root/scrollable-message-container-root.tsx
@@ -1,0 +1,149 @@
+import { Slot } from "@radix-ui/react-slot";
+import { GenerationStage, useTambo } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { ScrollableMessageContainerRootContext } from "./scrollable-message-container-root-context";
+
+export type ScrollableMessageContainerRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Root primitive for the scrollable message container component.
+ * Manages auto-scroll state, scroll position tracking, and thread message observation.
+ * Provides context for child components (Viewport, ScrollToBottom).
+ * @returns The root scrollable message container element with context provider
+ */
+export const ScrollableMessageContainerRoot = React.forwardRef<
+  HTMLDivElement,
+  ScrollableMessageContainerRootProps
+>(function ScrollableMessageContainerRoot(
+  { children, asChild, ...props },
+  ref,
+) {
+  const viewportRef = React.useRef<HTMLDivElement>(null);
+  const { thread } = useTambo();
+  const [shouldAutoscroll, setShouldAutoscroll] = React.useState(true);
+  const [isAtBottom, setIsAtBottom] = React.useState(true);
+  const lastScrollTopRef = React.useRef(0);
+
+  const messagesContent = React.useMemo(() => {
+    if (!thread.messages) return null;
+
+    return thread.messages.map((message) => ({
+      id: message.id,
+      content: message.content,
+      tool_calls: message.tool_calls,
+      component: message.component,
+      reasoning: message.reasoning,
+      componentState: message.componentState,
+    }));
+  }, [thread.messages]);
+
+  const generationStage = React.useMemo(
+    () => thread?.generationStage ?? GenerationStage.IDLE,
+    [thread?.generationStage],
+  );
+
+  const scrollToBottom = React.useCallback(() => {
+    if (!viewportRef.current) return;
+
+    viewportRef.current.scrollTo({
+      top: viewportRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, []);
+
+  const suspendAutoscroll = React.useCallback(() => {
+    setShouldAutoscroll(false);
+  }, []);
+
+  const resumeAutoscroll = React.useCallback(() => {
+    setShouldAutoscroll(true);
+  }, []);
+
+  /**
+   * Handle scroll events from the viewport to detect user scrolling direction
+   * and update isAtBottom state.
+   */
+  const handleViewportScroll = React.useCallback(() => {
+    if (!viewportRef.current) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = viewportRef.current;
+    const atBottom = Math.abs(scrollHeight - scrollTop - clientHeight) < 8;
+
+    setIsAtBottom(atBottom);
+
+    if (scrollTop < lastScrollTopRef.current) {
+      setShouldAutoscroll(false);
+    } else if (atBottom) {
+      setShouldAutoscroll(true);
+    }
+
+    lastScrollTopRef.current = scrollTop;
+  }, []);
+
+  /**
+   * Attach scroll listener to the viewport element.
+   */
+  React.useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    viewport.addEventListener("scroll", handleViewportScroll);
+    return () => {
+      viewport.removeEventListener("scroll", handleViewportScroll);
+    };
+  }, [handleViewportScroll]);
+
+  /**
+   * Auto-scroll to bottom when message content changes and autoscroll is enabled.
+   */
+  React.useEffect(() => {
+    if (viewportRef.current && messagesContent && shouldAutoscroll) {
+      const scroll = () => {
+        if (viewportRef.current) {
+          viewportRef.current.scrollTo({
+            top: viewportRef.current.scrollHeight,
+            behavior: "smooth",
+          });
+        }
+      };
+
+      if (generationStage === GenerationStage.STREAMING_RESPONSE) {
+        requestAnimationFrame(scroll);
+      } else {
+        const timeoutId = setTimeout(scroll, 50);
+        return () => clearTimeout(timeoutId);
+      }
+    }
+  }, [messagesContent, generationStage, shouldAutoscroll]);
+
+  const contextValue = React.useMemo(
+    () => ({
+      shouldAutoscroll,
+      isAtBottom,
+      scrollToBottom,
+      suspendAutoscroll,
+      resumeAutoscroll,
+      viewportRef,
+    }),
+    [
+      shouldAutoscroll,
+      isAtBottom,
+      scrollToBottom,
+      suspendAutoscroll,
+      resumeAutoscroll,
+    ],
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <ScrollableMessageContainerRootContext.Provider value={contextValue}>
+      <Comp ref={ref} data-slot="scrollable-message-container-root" {...props}>
+        {children}
+      </Comp>
+    </ScrollableMessageContainerRootContext.Provider>
+  );
+});

--- a/packages/react-ui-base/src/scrollable-message-container/scroll-to-bottom/scrollable-message-container-scroll-to-bottom.tsx
+++ b/packages/react-ui-base/src/scrollable-message-container/scroll-to-bottom/scrollable-message-container-scroll-to-bottom.tsx
@@ -1,0 +1,56 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useScrollableMessageContainerRootContext } from "../root/scrollable-message-container-root-context";
+
+/**
+ * Props passed to the render function of ScrollToBottom.
+ */
+export interface ScrollableMessageContainerScrollToBottomRenderProps {
+  /** Whether the scroll position is currently at the bottom. */
+  isAtBottom: boolean;
+  /** Scroll the container to the bottom. */
+  scrollToBottom: () => void;
+}
+
+export type ScrollableMessageContainerScrollToBottomProps =
+  BasePropsWithChildrenOrRenderFunction<
+    React.HTMLAttributes<HTMLDivElement>,
+    ScrollableMessageContainerScrollToBottomRenderProps
+  >;
+
+/**
+ * ScrollToBottom primitive for the scrollable message container.
+ * Provides render props with isAtBottom and scrollToBottom for building
+ * scroll-to-bottom indicators or buttons.
+ * @returns The scroll-to-bottom element, or null if no render content is provided
+ */
+export const ScrollableMessageContainerScrollToBottom = React.forwardRef<
+  HTMLDivElement,
+  ScrollableMessageContainerScrollToBottomProps
+>(function ScrollableMessageContainerScrollToBottom(
+  { asChild, ...props },
+  ref,
+) {
+  const { isAtBottom, scrollToBottom } =
+    useScrollableMessageContainerRootContext();
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    isAtBottom,
+    scrollToBottom,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="scrollable-message-container-scroll-to-bottom"
+      data-at-bottom={isAtBottom || undefined}
+      {...componentProps}
+    >
+      {content}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/scrollable-message-container/viewport/scrollable-message-container-viewport.tsx
+++ b/packages/react-ui-base/src/scrollable-message-container/viewport/scrollable-message-container-viewport.tsx
@@ -1,0 +1,47 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useScrollableMessageContainerRootContext } from "../root/scrollable-message-container-root-context";
+
+export type ScrollableMessageContainerViewportProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Viewport primitive for the scrollable message container.
+ * This is the scrollable div that holds the message content.
+ * Connects to the root context to enable scroll tracking and auto-scroll behavior.
+ * @returns The scrollable viewport element
+ */
+export const ScrollableMessageContainerViewport = React.forwardRef<
+  HTMLDivElement,
+  ScrollableMessageContainerViewportProps
+>(function ScrollableMessageContainerViewport(
+  { children, asChild, ...props },
+  ref,
+) {
+  const { viewportRef } = useScrollableMessageContainerRootContext();
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp
+      ref={(node: HTMLDivElement | null) => {
+        // Assign to the context ref
+        (viewportRef as React.MutableRefObject<HTMLDivElement | null>).current =
+          node;
+
+        // Forward the external ref
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      }}
+      data-slot="scrollable-message-container-viewport"
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/thread-content/index.tsx
+++ b/packages/react-ui-base/src/thread-content/index.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { ThreadContentMessage } from "./message/thread-content-message";
+import { ThreadContentMessageList } from "./message-list/thread-content-message-list";
+import { ThreadContentRoot } from "./root/thread-content-root";
+
+/**
+ * ThreadContent namespace containing all thread content base components.
+ */
+const ThreadContent = {
+  Root: ThreadContentRoot,
+  MessageList: ThreadContentMessageList,
+  Message: ThreadContentMessage,
+};
+
+export type {
+  ThreadContentMessageListProps,
+  ThreadContentMessageListRenderProps,
+} from "./message-list/thread-content-message-list";
+export type { ThreadContentMessageProps } from "./message/thread-content-message";
+export type { ThreadContentRootContextValue } from "./root/thread-content-root-context";
+export type { ThreadContentRootProps } from "./root/thread-content-root";
+
+export { getMessageKey } from "./message/thread-content-message";
+export {
+  useOptionalThreadContentRootContext,
+  useThreadContentRootContext,
+} from "./root/thread-content-root-context";
+export { ThreadContent };

--- a/packages/react-ui-base/src/thread-content/message-list/thread-content-message-list.tsx
+++ b/packages/react-ui-base/src/thread-content/message-list/thread-content-message-list.tsx
@@ -1,0 +1,67 @@
+import { Slot } from "@radix-ui/react-slot";
+import { TamboThreadMessage } from "@tambo-ai/react";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useThreadContentRootContext } from "../root/thread-content-root-context";
+
+/**
+ * Props passed to the render function of ThreadContentMessageList.
+ */
+export interface ThreadContentMessageListRenderProps {
+  /** The filtered messages to display (excludes system and child messages). */
+  messages: TamboThreadMessage[];
+  /** Whether the thread is currently generating a response. */
+  isGenerating: boolean;
+}
+
+export type ThreadContentMessageListProps =
+  BasePropsWithChildrenOrRenderFunction<
+    Omit<React.HTMLAttributes<HTMLDivElement>, "children"> & {
+      /**
+       * Optional custom filter function for messages.
+       * When not provided, system messages and child messages (with parentMessageId) are excluded.
+       */
+      filter?: (message: TamboThreadMessage) => boolean;
+    },
+    ThreadContentMessageListRenderProps
+  >;
+
+/**
+ * Default message filter that excludes system messages and child messages.
+ * @returns Whether the message should be included in the list
+ */
+function defaultMessageFilter(message: TamboThreadMessage): boolean {
+  return message.role !== "system" && !message.parentMessageId;
+}
+
+/**
+ * Primitive for rendering the list of messages in a thread.
+ * Supports render props for custom message rendering.
+ * @returns The message list container element
+ */
+export const ThreadContentMessageList = React.forwardRef<
+  HTMLDivElement,
+  ThreadContentMessageListProps
+>(function ThreadContentMessageList({ filter, asChild, ...props }, ref) {
+  const { messages, isGenerating } = useThreadContentRootContext();
+
+  const filterFn = filter ?? defaultMessageFilter;
+  const filteredMessages = React.useMemo(
+    () => messages.filter(filterFn),
+    [messages, filterFn],
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    messages: filteredMessages,
+    isGenerating,
+  });
+
+  return (
+    <Comp ref={ref} data-slot="thread-content-message-list" {...componentProps}>
+      {content}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/thread-content/message/thread-content-message.tsx
+++ b/packages/react-ui-base/src/thread-content/message/thread-content-message.tsx
@@ -1,0 +1,65 @@
+import { Slot } from "@radix-ui/react-slot";
+import { TamboThreadMessage } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+
+export type ThreadContentMessageProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** The message to display. */
+    message: TamboThreadMessage;
+    /** Index of the message in the filtered list. */
+    index: number;
+    /** Total number of messages in the filtered list. */
+    total: number;
+    /** Whether the thread is currently generating a response. */
+    isGenerating: boolean;
+  }
+>;
+
+/**
+ * Generates a stable key for a thread message.
+ * Falls back to a composite key when the message has no id.
+ * @returns A string key suitable for use as a React key
+ */
+export function getMessageKey(
+  message: TamboThreadMessage,
+  index: number,
+): string {
+  if (message.id) {
+    return message.id;
+  }
+  const contentPrefix = message.content?.toString().substring(0, 10) ?? "";
+  return `${message.role}-${message.createdAt ?? index}-${contentPrefix}`;
+}
+
+/**
+ * Primitive wrapper for an individual message in the thread content.
+ * Provides data attributes for the message role and position.
+ * @returns The message wrapper element
+ */
+export const ThreadContentMessage = React.forwardRef<
+  HTMLDivElement,
+  ThreadContentMessageProps
+>(function ThreadContentMessage(
+  { message, index, total, isGenerating, asChild, children, ...props },
+  ref,
+) {
+  const isLast = index === total - 1;
+  const isLoading = isGenerating && isLast;
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="thread-content-message"
+      data-message-role={message.role === "assistant" ? "assistant" : "user"}
+      data-message-index={index}
+      data-message-loading={isLoading || undefined}
+      data-message-last={isLast || undefined}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/thread-content/root/thread-content-root-context.tsx
+++ b/packages/react-ui-base/src/thread-content/root/thread-content-root-context.tsx
@@ -1,0 +1,49 @@
+import { TamboThreadMessage } from "@tambo-ai/react";
+import React from "react";
+
+/**
+ * Context value shared among ThreadContent primitive sub-components.
+ */
+export interface ThreadContentRootContextValue {
+  /** Array of message objects in the thread. */
+  messages: TamboThreadMessage[];
+  /** Whether a response is currently being generated. */
+  isGenerating: boolean;
+  /** Current generation stage identifier. */
+  generationStage?: string;
+}
+
+const ThreadContentRootContext =
+  React.createContext<ThreadContentRootContextValue | null>(null);
+
+/**
+ * Hook to optionally access the thread content context.
+ * Returns null if not within a ThreadContent.Root component.
+ * @internal This hook is for internal use by base components only.
+ * @returns The thread content context value or null
+ */
+function useOptionalThreadContentRootContext(): ThreadContentRootContextValue | null {
+  return React.useContext(ThreadContentRootContext);
+}
+
+/**
+ * Hook to access the thread content context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The thread content context value
+ * @throws Error if used outside of ThreadContent.Root component
+ */
+function useThreadContentRootContext(): ThreadContentRootContextValue {
+  const context = React.useContext(ThreadContentRootContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: ThreadContentRootContext is missing. ThreadContent parts must be used within <ThreadContent.Root>",
+    );
+  }
+  return context;
+}
+
+export {
+  ThreadContentRootContext,
+  useOptionalThreadContentRootContext,
+  useThreadContentRootContext,
+};

--- a/packages/react-ui-base/src/thread-content/root/thread-content-root.tsx
+++ b/packages/react-ui-base/src/thread-content/root/thread-content-root.tsx
@@ -1,0 +1,75 @@
+import { Slot } from "@radix-ui/react-slot";
+import { TamboThreadMessage, useTambo } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { ThreadContentRootContext } from "./thread-content-root-context";
+
+export type ThreadContentRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /**
+     * Optional override for the thread messages.
+     * When not provided, messages are read from the Tambo thread context.
+     */
+    messages?: TamboThreadMessage[];
+    /**
+     * Optional override for the generating state.
+     * When not provided, derived from the Tambo idle state.
+     */
+    isGenerating?: boolean;
+    /**
+     * Optional override for the generation stage.
+     * When not provided, read from the Tambo context.
+     */
+    generationStage?: string;
+  }
+>;
+
+/**
+ * Root primitive for a thread content component.
+ * Provides context for child components using data from the Tambo hook
+ * or explicit prop overrides.
+ * @returns The thread content root element with context provider
+ */
+export const ThreadContentRoot = React.forwardRef<
+  HTMLDivElement,
+  ThreadContentRootProps
+>(function ThreadContentRoot(
+  {
+    children,
+    messages: messagesProp,
+    isGenerating: isGeneratingProp,
+    generationStage: generationStageProp,
+    asChild,
+    ...props
+  },
+  ref,
+) {
+  const { thread, generationStage: tamboGenerationStage, isIdle } = useTambo();
+
+  const isGenerating = isGeneratingProp ?? !isIdle;
+  const generationStage = generationStageProp ?? tamboGenerationStage;
+
+  const contextValue = React.useMemo(
+    () => ({
+      messages: messagesProp ?? thread?.messages ?? [],
+      isGenerating,
+      generationStage,
+    }),
+    [messagesProp, thread?.messages, isGenerating, generationStage],
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <ThreadContentRootContext.Provider value={contextValue}>
+      <Comp
+        ref={ref}
+        data-slot="thread-content-root"
+        data-generating={isGenerating || undefined}
+        {...props}
+      >
+        {children}
+      </Comp>
+    </ThreadContentRootContext.Provider>
+  );
+});

--- a/packages/react-ui-base/src/thread-dropdown/index.tsx
+++ b/packages/react-ui-base/src/thread-dropdown/index.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { ThreadDropdownMenu } from "./menu/thread-dropdown-menu";
+import { ThreadDropdownNewThreadItem } from "./new-thread-item/thread-dropdown-new-thread-item";
+import { ThreadDropdownRoot } from "./root/thread-dropdown-root";
+import { ThreadDropdownThreadItem } from "./thread-item/thread-dropdown-thread-item";
+import { ThreadDropdownTrigger } from "./trigger/thread-dropdown-trigger";
+
+/**
+ * ThreadDropdown namespace containing all thread dropdown base components.
+ */
+const ThreadDropdown = {
+  Root: ThreadDropdownRoot,
+  Trigger: ThreadDropdownTrigger,
+  Menu: ThreadDropdownMenu,
+  NewThreadItem: ThreadDropdownNewThreadItem,
+  ThreadItem: ThreadDropdownThreadItem,
+};
+
+export type { ThreadDropdownMenuProps } from "./menu/thread-dropdown-menu";
+export type {
+  ThreadDropdownNewThreadItemProps,
+  ThreadDropdownNewThreadItemRenderProps,
+} from "./new-thread-item/thread-dropdown-new-thread-item";
+export { useThreadDropdownContext } from "./root/thread-dropdown-context";
+export type {
+  ThreadDropdownContextValue,
+  ThreadDropdownThread,
+} from "./root/thread-dropdown-context";
+export type { ThreadDropdownRootProps } from "./root/thread-dropdown-root";
+export type {
+  ThreadDropdownThreadItemProps,
+  ThreadDropdownThreadItemRenderProps,
+} from "./thread-item/thread-dropdown-thread-item";
+export type { ThreadDropdownTriggerProps } from "./trigger/thread-dropdown-trigger";
+
+export { ThreadDropdown };

--- a/packages/react-ui-base/src/thread-dropdown/menu/thread-dropdown-menu.tsx
+++ b/packages/react-ui-base/src/thread-dropdown/menu/thread-dropdown-menu.tsx
@@ -1,0 +1,26 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+
+export type ThreadDropdownMenuProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Menu container primitive for the thread dropdown.
+ * Wraps the dropdown content area where menu items are rendered.
+ * @returns The menu container element
+ */
+export const ThreadDropdownMenu = React.forwardRef<
+  HTMLDivElement,
+  ThreadDropdownMenuProps
+>(({ asChild, children, ...props }, ref) => {
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp ref={ref} data-slot="thread-dropdown-menu" role="menu" {...props}>
+      {children}
+    </Comp>
+  );
+});
+ThreadDropdownMenu.displayName = "ThreadDropdown.Menu";

--- a/packages/react-ui-base/src/thread-dropdown/new-thread-item/thread-dropdown-new-thread-item.tsx
+++ b/packages/react-ui-base/src/thread-dropdown/new-thread-item/thread-dropdown-new-thread-item.tsx
@@ -1,0 +1,57 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useThreadDropdownContext } from "../root/thread-dropdown-context";
+
+/**
+ * Props passed to the render function of ThreadDropdownNewThreadItem.
+ */
+export interface ThreadDropdownNewThreadItemRenderProps {
+  /** The modifier key label for the current platform. */
+  modKey: string;
+  /** The full keyboard shortcut label (e.g. "Option+Shift+N" or "Alt+Shift+N"). */
+  shortcutLabel: string;
+  /** Handler to invoke when the item is selected. */
+  onSelect: () => void;
+}
+
+export type ThreadDropdownNewThreadItemProps =
+  BasePropsWithChildrenOrRenderFunction<
+    React.HTMLAttributes<HTMLDivElement>,
+    ThreadDropdownNewThreadItemRenderProps
+  >;
+
+/**
+ * Menu item primitive for creating a new thread.
+ * Provides keyboard shortcut metadata via render props.
+ * @returns The new thread menu item element
+ */
+export const ThreadDropdownNewThreadItem = React.forwardRef<
+  HTMLDivElement,
+  ThreadDropdownNewThreadItemProps
+>(({ asChild, ...props }, ref) => {
+  const { modKey, onNewThread } = useThreadDropdownContext();
+
+  const shortcutLabel = `${modKey}+\u21E7+N`;
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    modKey,
+    shortcutLabel,
+    onSelect: onNewThread,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      role="menuitem"
+      data-slot="thread-dropdown-new-thread-item"
+      {...componentProps}
+    >
+      {content}
+    </Comp>
+  );
+});
+ThreadDropdownNewThreadItem.displayName = "ThreadDropdown.NewThreadItem";

--- a/packages/react-ui-base/src/thread-dropdown/root/thread-dropdown-context.tsx
+++ b/packages/react-ui-base/src/thread-dropdown/root/thread-dropdown-context.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+
+/**
+ * Represents a thread item in the dropdown list.
+ */
+export interface ThreadDropdownThread {
+  id: string;
+}
+
+/**
+ * Context value shared among ThreadDropdown primitive sub-components.
+ */
+export interface ThreadDropdownContextValue {
+  /** The list of threads available in the dropdown. */
+  threads: ThreadDropdownThread[];
+  /** Whether the thread list is currently loading. */
+  isLoading: boolean;
+  /** Error from loading threads, if any. */
+  error: Error | null;
+  /** Whether the current platform is macOS (for keyboard shortcut labels). */
+  isMac: boolean;
+  /** The modifier key label for the current platform ("Option" on Mac, "Alt" otherwise). */
+  modKey: string;
+  /** Handler to create a new thread. */
+  onNewThread: () => void;
+  /** Handler to switch to an existing thread by ID. */
+  onSwitchThread: (threadId: string) => void;
+}
+
+const ThreadDropdownContext =
+  React.createContext<ThreadDropdownContextValue | null>(null);
+
+/**
+ * Hook to access the thread dropdown context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The thread dropdown context value
+ * @throws Error if used outside of ThreadDropdown.Root
+ */
+export function useThreadDropdownContext(): ThreadDropdownContextValue {
+  const context = React.useContext(ThreadDropdownContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: ThreadDropdownContext is missing. ThreadDropdown parts must be used within <ThreadDropdown.Root>",
+    );
+  }
+  return context;
+}
+
+export { ThreadDropdownContext };

--- a/packages/react-ui-base/src/thread-dropdown/root/thread-dropdown-root.tsx
+++ b/packages/react-ui-base/src/thread-dropdown/root/thread-dropdown-root.tsx
@@ -1,0 +1,113 @@
+import { Slot } from "@radix-ui/react-slot";
+import { useTamboThread, useTamboThreadList } from "@tambo-ai/react";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import {
+  ThreadDropdownContext,
+  type ThreadDropdownThread,
+} from "./thread-dropdown-context";
+
+export type ThreadDropdownRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** Optional callback function called when the current thread changes. */
+    onThreadChange?: () => void;
+  }
+>;
+
+/**
+ * Root primitive for the thread dropdown component.
+ * Provides context for child components including thread list data,
+ * platform detection, and thread management handlers.
+ * Registers the Alt+Shift+N keyboard shortcut for creating new threads.
+ * @returns The root container element with thread dropdown context
+ */
+export const ThreadDropdownRoot = React.forwardRef<
+  HTMLDivElement,
+  ThreadDropdownRootProps
+>(function ThreadDropdownRoot(
+  { children, asChild, onThreadChange, ...props },
+  ref,
+) {
+  const { data: threads, isLoading, error, refetch } = useTamboThreadList();
+  const { switchCurrentThread, startNewThread } = useTamboThread();
+
+  const isMac =
+    typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
+  const modKey = isMac ? "\u2325" : "Alt";
+
+  const handleNewThread = React.useCallback(async () => {
+    try {
+      await startNewThread();
+      await refetch();
+      onThreadChange?.();
+    } catch (err) {
+      console.error("Failed to create new thread:", err);
+    }
+  }, [onThreadChange, startNewThread, refetch]);
+
+  const handleSwitchThread = React.useCallback(
+    (threadId: string) => {
+      try {
+        switchCurrentThread(threadId);
+        onThreadChange?.();
+      } catch (err) {
+        console.error("Failed to switch thread:", err);
+      }
+    },
+    [switchCurrentThread, onThreadChange],
+  );
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.altKey && event.shiftKey && event.key === "n") {
+        event.preventDefault();
+        void handleNewThread();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleNewThread]);
+
+  const threadItems: ThreadDropdownThread[] = React.useMemo(
+    () => threads?.items ?? [],
+    [threads],
+  );
+
+  const contextValue = React.useMemo(
+    () => ({
+      threads: threadItems,
+      isLoading,
+      error,
+      isMac,
+      modKey,
+      onNewThread: () => {
+        void handleNewThread();
+      },
+      onSwitchThread: handleSwitchThread,
+    }),
+    [
+      threadItems,
+      isLoading,
+      error,
+      isMac,
+      modKey,
+      handleNewThread,
+      handleSwitchThread,
+    ],
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <ThreadDropdownContext.Provider value={contextValue}>
+      <Comp ref={ref} data-slot="thread-dropdown" {...props}>
+        {children}
+      </Comp>
+    </ThreadDropdownContext.Provider>
+  );
+});
+ThreadDropdownRoot.displayName = "ThreadDropdown.Root";

--- a/packages/react-ui-base/src/thread-dropdown/thread-item/thread-dropdown-thread-item.tsx
+++ b/packages/react-ui-base/src/thread-dropdown/thread-item/thread-dropdown-thread-item.tsx
@@ -1,0 +1,68 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import {
+  useThreadDropdownContext,
+  type ThreadDropdownThread,
+} from "../root/thread-dropdown-context";
+
+/**
+ * Props passed to the render function of ThreadDropdownThreadItem.
+ */
+export interface ThreadDropdownThreadItemRenderProps {
+  /** The thread data for this item. */
+  thread: ThreadDropdownThread;
+  /** A truncated display label for the thread. */
+  threadLabel: string;
+  /** Handler to invoke when this thread item is selected. */
+  onSelect: () => void;
+}
+
+export type ThreadDropdownThreadItemProps =
+  BasePropsWithChildrenOrRenderFunction<
+    React.HTMLAttributes<HTMLDivElement> & {
+      /** The thread to render for this item. */
+      thread: ThreadDropdownThread;
+    },
+    ThreadDropdownThreadItemRenderProps
+  >;
+
+/**
+ * Menu item primitive for switching to an existing thread.
+ * Provides thread data and a selection handler via render props.
+ * @returns The thread menu item element
+ */
+export const ThreadDropdownThreadItem = React.forwardRef<
+  HTMLDivElement,
+  ThreadDropdownThreadItemProps
+>(({ asChild, thread, ...props }, ref) => {
+  const { onSwitchThread } = useThreadDropdownContext();
+
+  const threadLabel = `Thread ${thread.id.substring(0, 8)}`;
+
+  const handleSelect = React.useCallback(() => {
+    onSwitchThread(thread.id);
+  }, [onSwitchThread, thread.id]);
+
+  const Comp = asChild ? Slot : "div";
+
+  const { content, componentProps } = useRender(props, {
+    thread,
+    threadLabel,
+    onSelect: handleSelect,
+  });
+
+  return (
+    <Comp
+      ref={ref}
+      role="menuitem"
+      data-slot="thread-dropdown-thread-item"
+      data-thread-id={thread.id}
+      {...componentProps}
+    >
+      {content}
+    </Comp>
+  );
+});
+ThreadDropdownThreadItem.displayName = "ThreadDropdown.ThreadItem";

--- a/packages/react-ui-base/src/thread-dropdown/trigger/thread-dropdown-trigger.tsx
+++ b/packages/react-ui-base/src/thread-dropdown/trigger/thread-dropdown-trigger.tsx
@@ -1,0 +1,32 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+
+export type ThreadDropdownTriggerProps = BaseProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>;
+
+/**
+ * Trigger button primitive for the thread dropdown.
+ * Renders a button element (or a Slot when asChild is true) that can be
+ * used to open the dropdown menu.
+ * @returns The trigger button element
+ */
+export const ThreadDropdownTrigger = React.forwardRef<
+  HTMLButtonElement,
+  ThreadDropdownTriggerProps
+>(({ asChild, children, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      type="button"
+      data-slot="thread-dropdown-trigger"
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});
+ThreadDropdownTrigger.displayName = "ThreadDropdown.Trigger";

--- a/packages/react-ui-base/src/thread-history/collapse-toggle/thread-history-collapse-toggle.tsx
+++ b/packages/react-ui-base/src/thread-history/collapse-toggle/thread-history-collapse-toggle.tsx
@@ -1,0 +1,42 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../types/component-render-or-children";
+import { useThreadHistoryRootContext } from "../root/thread-history-root-context";
+
+export type ThreadHistoryCollapseToggleProps = BaseProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>;
+
+/**
+ * Collapse toggle primitive for the thread history sidebar.
+ * Toggles the collapsed state when clicked.
+ * Provides data attributes for collapsed state and position to enable styling.
+ * @returns A button element that toggles the sidebar collapsed state
+ */
+export const ThreadHistoryCollapseToggle = React.forwardRef<
+  HTMLButtonElement,
+  ThreadHistoryCollapseToggleProps
+>(function ThreadHistoryCollapseToggle({ children, asChild, ...props }, ref) {
+  const { isCollapsed, setIsCollapsed, position } =
+    useThreadHistoryRootContext();
+
+  const handleToggle = React.useCallback(() => {
+    setIsCollapsed((prev) => !prev);
+  }, [setIsCollapsed]);
+
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="thread-history-collapse-toggle"
+      data-collapsed={isCollapsed || undefined}
+      data-position={position}
+      onClick={handleToggle}
+      aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/thread-history/header/thread-history-header.tsx
+++ b/packages/react-ui-base/src/thread-history/header/thread-history-header.tsx
@@ -1,0 +1,57 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { useThreadHistoryRootContext } from "../root/thread-history-root-context";
+
+/**
+ * Props passed to the Header render function.
+ */
+export interface ThreadHistoryHeaderRenderProps {
+  /** Whether the sidebar is collapsed. */
+  isCollapsed: boolean;
+  /** Position of the sidebar. */
+  position: "left" | "right";
+}
+
+export interface ThreadHistoryHeaderProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  /** When true, renders as a Slot, merging props into the child element. */
+  asChild?: boolean;
+  /** Children as ReactNode or render function receiving header state. */
+  children?:
+    | React.ReactNode
+    | ((props: ThreadHistoryHeaderRenderProps) => React.ReactNode);
+}
+
+/**
+ * Header primitive for the thread history sidebar.
+ * Provides data attributes for collapsed state and position to enable styling.
+ * Accepts children as a render function to access isCollapsed and position state.
+ * @returns The header element with data attributes for styling
+ */
+export const ThreadHistoryHeader = React.forwardRef<
+  HTMLDivElement,
+  ThreadHistoryHeaderProps
+>(function ThreadHistoryHeader({ children, asChild, ...props }, ref) {
+  const { isCollapsed, position } = useThreadHistoryRootContext();
+
+  const Comp = asChild ? Slot : "div";
+
+  const renderedChildren =
+    typeof children === "function"
+      ? children({ isCollapsed, position: position ?? "left" })
+      : children;
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="thread-history-header"
+      data-collapsed={isCollapsed || undefined}
+      data-position={position}
+      {...props}
+    >
+      {renderedChildren}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/thread-history/index.tsx
+++ b/packages/react-ui-base/src/thread-history/index.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ThreadHistoryCollapseToggle } from "./collapse-toggle/thread-history-collapse-toggle";
+import { ThreadHistoryHeader } from "./header/thread-history-header";
+import { ThreadHistoryItem } from "./item/thread-history-item";
+import { ThreadHistoryList } from "./list/thread-history-list";
+import { ThreadHistoryNewThreadButton } from "./new-thread-button/thread-history-new-thread-button";
+import { ThreadHistoryRoot } from "./root/thread-history-root";
+import { ThreadHistorySearchInput } from "./search-input/thread-history-search-input";
+
+/**
+ * ThreadHistory namespace containing all thread history base components.
+ */
+const ThreadHistory = {
+  Root: ThreadHistoryRoot,
+  Header: ThreadHistoryHeader,
+  CollapseToggle: ThreadHistoryCollapseToggle,
+  NewThreadButton: ThreadHistoryNewThreadButton,
+  SearchInput: ThreadHistorySearchInput,
+  List: ThreadHistoryList,
+  Item: ThreadHistoryItem,
+};
+
+export type { ThreadHistoryCollapseToggleProps } from "./collapse-toggle/thread-history-collapse-toggle";
+export type {
+  ThreadHistoryHeaderProps,
+  ThreadHistoryHeaderRenderProps,
+} from "./header/thread-history-header";
+export type {
+  ThreadHistoryItemProps,
+  ThreadHistoryItemRenderProps,
+} from "./item/thread-history-item";
+export type {
+  ThreadHistoryListProps,
+  ThreadHistoryListRenderProps,
+} from "./list/thread-history-list";
+export type {
+  ThreadHistoryNewThreadButtonProps,
+  ThreadHistoryNewThreadButtonRenderProps,
+} from "./new-thread-button/thread-history-new-thread-button";
+export type {
+  ThreadHistoryRootProps,
+  ThreadHistoryRootRenderProps,
+} from "./root/thread-history-root";
+export type { ThreadHistoryRootContextValue } from "./root/thread-history-root-context";
+export type {
+  ThreadHistorySearchInputProps,
+  ThreadHistorySearchInputRenderProps,
+} from "./search-input/thread-history-search-input";
+
+export { ThreadHistory };

--- a/packages/react-ui-base/src/thread-history/item/thread-history-item.tsx
+++ b/packages/react-ui-base/src/thread-history/item/thread-history-item.tsx
@@ -1,0 +1,69 @@
+import { Slot } from "@radix-ui/react-slot";
+import type { TamboThread } from "@tambo-ai/react";
+import * as React from "react";
+import { useThreadHistoryRootContext } from "../root/thread-history-root-context";
+
+/**
+ * Props passed to the Item render function.
+ */
+export interface ThreadHistoryItemRenderProps {
+  /** Whether this thread is the currently active thread. */
+  isActive: boolean;
+}
+
+export interface ThreadHistoryItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  /** When true, renders as a Slot, merging props into the child element. */
+  asChild?: boolean;
+  /** The thread to display. */
+  thread: TamboThread;
+  /** Children as ReactNode or render function receiving item state. */
+  children?:
+    | React.ReactNode
+    | ((props: ThreadHistoryItemRenderProps) => React.ReactNode);
+}
+
+/**
+ * Item primitive for a single thread entry in the thread history list.
+ * Handles click-to-switch and provides data attributes for active state.
+ * Accepts children as a render function to access isActive state.
+ * @returns A clickable thread item element
+ */
+export const ThreadHistoryItem = React.forwardRef<
+  HTMLDivElement,
+  ThreadHistoryItemProps
+>(function ThreadHistoryItem({ thread, children, asChild, ...props }, ref) {
+  const { currentThread, switchCurrentThread, onThreadChange } =
+    useThreadHistoryRootContext();
+
+  const isActive = currentThread?.id === thread.id;
+
+  const handleClick = React.useCallback(async () => {
+    try {
+      switchCurrentThread(thread.id);
+      onThreadChange?.();
+    } catch (error) {
+      console.error("Failed to switch thread:", error);
+    }
+  }, [switchCurrentThread, thread.id, onThreadChange]);
+
+  const Comp = asChild ? Slot : "div";
+
+  const renderedChildren =
+    typeof children === "function" ? children({ isActive }) : children;
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="thread-history-item"
+      data-active={isActive || undefined}
+      data-thread-id={thread.id}
+      onClick={handleClick}
+      {...props}
+    >
+      {renderedChildren}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/thread-history/list/thread-history-list.tsx
+++ b/packages/react-ui-base/src/thread-history/list/thread-history-list.tsx
@@ -1,0 +1,72 @@
+import { Slot } from "@radix-ui/react-slot";
+import type { TamboThread } from "@tambo-ai/react";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../types/component-render-or-children";
+import { useRender } from "../../use-render/use-render";
+import { useThreadHistoryRootContext } from "../root/thread-history-root-context";
+
+/**
+ * Props passed to the render function for the thread list.
+ */
+export interface ThreadHistoryListRenderProps {
+  /** The filtered list of threads. */
+  filteredThreads: TamboThread[];
+  /** Whether threads are currently loading. */
+  isLoading: boolean;
+  /** Error from loading threads, if any. */
+  error: Error | null;
+  /** The current search query. */
+  searchQuery: string;
+  /** Whether the sidebar is collapsed. */
+  isCollapsed: boolean;
+}
+
+export type ThreadHistoryListProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+>;
+
+/**
+ * List primitive for the thread history.
+ * Provides the filtered thread list and loading/error state to children
+ * via a render prop. Hides content when the sidebar is collapsed.
+ * @returns A container for the thread list with data attributes for styling
+ */
+export const ThreadHistoryList = React.forwardRef<
+  HTMLDivElement,
+  BasePropsWithChildrenOrRenderFunction<
+    ThreadHistoryListProps,
+    ThreadHistoryListRenderProps
+  >
+>(function ThreadHistoryList(props, ref) {
+  const { filteredThreads, isLoading, error, searchQuery, isCollapsed } =
+    useThreadHistoryRootContext();
+
+  const { asChild, ...restForRender } = props as typeof props & {
+    asChild?: boolean;
+  };
+
+  const { content, componentProps } = useRender(restForRender, {
+    filteredThreads,
+    isLoading,
+    error,
+    searchQuery,
+    isCollapsed,
+  });
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="thread-history-list"
+      data-collapsed={isCollapsed || undefined}
+      data-loading={isLoading || undefined}
+      data-error={!!error || undefined}
+      data-empty={filteredThreads.length === 0 || undefined}
+      {...componentProps}
+    >
+      {content}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/thread-history/new-thread-button/thread-history-new-thread-button.tsx
+++ b/packages/react-ui-base/src/thread-history/new-thread-button/thread-history-new-thread-button.tsx
@@ -1,0 +1,82 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { useThreadHistoryRootContext } from "../root/thread-history-root-context";
+
+/**
+ * Props passed to the NewThreadButton render function.
+ */
+export interface ThreadHistoryNewThreadButtonRenderProps {
+  /** Whether the sidebar is collapsed. */
+  isCollapsed: boolean;
+}
+
+export interface ThreadHistoryNewThreadButtonProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "children"
+> {
+  /** When true, renders as a Slot, merging props into the child element. */
+  asChild?: boolean;
+  /** Children as ReactNode or render function receiving button state. */
+  children?:
+    | React.ReactNode
+    | ((props: ThreadHistoryNewThreadButtonRenderProps) => React.ReactNode);
+}
+
+/**
+ * New thread button primitive for the thread history sidebar.
+ * Creates a new thread when clicked and supports Alt+Shift+N keyboard shortcut.
+ * Accepts children as a render function to access isCollapsed state.
+ * @returns A button element that creates a new thread on click
+ */
+export const ThreadHistoryNewThreadButton = React.forwardRef<
+  HTMLButtonElement,
+  ThreadHistoryNewThreadButtonProps
+>(function ThreadHistoryNewThreadButton({ children, asChild, ...props }, ref) {
+  const { isCollapsed, startNewThread, refetch, onThreadChange } =
+    useThreadHistoryRootContext();
+
+  const handleNewThread = React.useCallback(
+    async (e?: React.MouseEvent) => {
+      if (e) e.stopPropagation();
+
+      try {
+        await startNewThread();
+        await refetch();
+        onThreadChange?.();
+      } catch (error) {
+        console.error("Failed to create new thread:", error);
+      }
+    },
+    [startNewThread, refetch, onThreadChange],
+  );
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.altKey && event.shiftKey && event.key === "n") {
+        event.preventDefault();
+        void handleNewThread();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleNewThread]);
+
+  const Comp = asChild ? Slot : "button";
+
+  const renderedChildren =
+    typeof children === "function" ? children({ isCollapsed }) : children;
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="thread-history-new-thread-button"
+      data-collapsed={isCollapsed || undefined}
+      onClick={handleNewThread}
+      title="New thread"
+      {...props}
+    >
+      {renderedChildren}
+    </Comp>
+  );
+});

--- a/packages/react-ui-base/src/thread-history/root/thread-history-root-context.tsx
+++ b/packages/react-ui-base/src/thread-history/root/thread-history-root-context.tsx
@@ -1,0 +1,61 @@
+import type { TamboThread } from "@tambo-ai/react";
+import * as React from "react";
+
+/**
+ * Context value shared among ThreadHistory primitive sub-components.
+ */
+export interface ThreadHistoryRootContextValue {
+  /** The thread list data from useTamboThreadList. */
+  threads: { items?: TamboThread[] } | null | undefined;
+  /** Whether thread data is currently loading. */
+  isLoading: boolean;
+  /** Error from loading threads, if any. */
+  error: Error | null;
+  /** Refetch the thread list. */
+  refetch: () => Promise<unknown>;
+  /** The current active thread. */
+  currentThread: TamboThread;
+  /** Switch to a different thread by ID. */
+  switchCurrentThread: (threadId: string) => void;
+  /** Start a new thread. */
+  startNewThread: () => void;
+  /** The current search query for filtering threads. */
+  searchQuery: string;
+  /** Set the search query. */
+  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
+  /** Whether the sidebar is collapsed. */
+  isCollapsed: boolean;
+  /** Set the collapsed state. */
+  setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+  /** Callback invoked when the active thread changes. */
+  onThreadChange?: () => void;
+  /** Position of the sidebar. */
+  position?: "left" | "right";
+  /** Update a thread's name. */
+  updateThreadName: (newName: string, threadId?: string) => Promise<void>;
+  /** Generate a thread name via AI. */
+  generateThreadName: (threadId: string) => Promise<TamboThread>;
+  /** Threads filtered by the current search query. */
+  filteredThreads: TamboThread[];
+}
+
+const ThreadHistoryRootContext =
+  React.createContext<ThreadHistoryRootContextValue | null>(null);
+
+/**
+ * Hook to access the thread history context.
+ * @internal This hook is for internal use by base components only.
+ * @returns The thread history context value
+ * @throws Error if used outside of ThreadHistory.Root component
+ */
+function useThreadHistoryRootContext(): ThreadHistoryRootContextValue {
+  const context = React.useContext(ThreadHistoryRootContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: ThreadHistoryRootContext is missing. ThreadHistory parts must be used within <ThreadHistory.Root>",
+    );
+  }
+  return context;
+}
+
+export { ThreadHistoryRootContext, useThreadHistoryRootContext };

--- a/packages/react-ui-base/src/thread-history/root/thread-history-root.tsx
+++ b/packages/react-ui-base/src/thread-history/root/thread-history-root.tsx
@@ -1,0 +1,148 @@
+import { Slot } from "@radix-ui/react-slot";
+import { useTamboThread, useTamboThreadList } from "@tambo-ai/react";
+import * as React from "react";
+import {
+  ThreadHistoryRootContext,
+  type ThreadHistoryRootContextValue,
+} from "./thread-history-root-context";
+
+/**
+ * Props passed to the Root render function.
+ */
+export interface ThreadHistoryRootRenderProps {
+  /** Whether the sidebar is collapsed. */
+  isCollapsed: boolean;
+  /** Position of the sidebar. */
+  position: "left" | "right";
+}
+
+export interface ThreadHistoryRootProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  /** When true, renders as a Slot, merging props into the child element. */
+  asChild?: boolean;
+  /** Callback invoked when the active thread changes. */
+  onThreadChange?: () => void;
+  /** Whether the sidebar should start collapsed. */
+  defaultCollapsed?: boolean;
+  /** Position of the sidebar. */
+  position?: "left" | "right";
+  /** Children as ReactNode or render function receiving root state. */
+  children?:
+    | React.ReactNode
+    | ((props: ThreadHistoryRootRenderProps) => React.ReactNode);
+}
+
+/**
+ * Root primitive for the thread history component.
+ * Provides context for all child ThreadHistory sub-components including
+ * thread list data, search/filter state, and collapse state.
+ * @returns The root thread history element with context provider
+ */
+export const ThreadHistoryRoot = React.forwardRef<
+  HTMLDivElement,
+  ThreadHistoryRootProps
+>(function ThreadHistoryRoot(
+  {
+    children,
+    asChild,
+    onThreadChange,
+    defaultCollapsed = true,
+    position = "left",
+    ...props
+  },
+  ref,
+) {
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const [isCollapsed, setIsCollapsed] = React.useState(defaultCollapsed);
+
+  const { data: threads, isLoading, error, refetch } = useTamboThreadList();
+
+  const {
+    switchCurrentThread,
+    startNewThread,
+    thread: currentThread,
+    updateThreadName,
+    generateThreadName,
+  } = useTamboThread();
+
+  // Update CSS variable when sidebar collapses/expands
+  React.useEffect(() => {
+    const sidebarWidth = isCollapsed ? "3rem" : "16rem";
+    document.documentElement.style.setProperty("--sidebar-width", sidebarWidth);
+  }, [isCollapsed]);
+
+  // Filter threads based on search query
+  const filteredThreads = React.useMemo(() => {
+    if (isCollapsed) return [];
+    if (!threads?.items) return [];
+
+    const query = searchQuery.toLowerCase();
+    return threads.items.filter((thread) => {
+      const nameMatches = thread.name?.toLowerCase().includes(query) ?? false;
+      const idMatches = thread.id.toLowerCase().includes(query);
+      return idMatches ? true : nameMatches;
+    });
+  }, [isCollapsed, threads, searchQuery]);
+
+  const contextValue = React.useMemo(
+    () => ({
+      threads,
+      isLoading,
+      error,
+      refetch,
+      currentThread,
+      switchCurrentThread,
+      startNewThread,
+      searchQuery,
+      setSearchQuery,
+      isCollapsed,
+      setIsCollapsed,
+      onThreadChange,
+      position,
+      updateThreadName,
+      generateThreadName,
+      filteredThreads,
+    }),
+    [
+      threads,
+      isLoading,
+      error,
+      refetch,
+      currentThread,
+      switchCurrentThread,
+      startNewThread,
+      searchQuery,
+      isCollapsed,
+      onThreadChange,
+      position,
+      updateThreadName,
+      generateThreadName,
+      filteredThreads,
+    ],
+  );
+
+  const Comp = asChild ? Slot : "div";
+
+  const renderedChildren =
+    typeof children === "function"
+      ? children({ isCollapsed, position })
+      : children;
+
+  return (
+    <ThreadHistoryRootContext.Provider
+      value={contextValue as ThreadHistoryRootContextValue}
+    >
+      <Comp
+        ref={ref}
+        data-slot="thread-history-root"
+        data-collapsed={isCollapsed || undefined}
+        data-position={position}
+        {...props}
+      >
+        {renderedChildren}
+      </Comp>
+    </ThreadHistoryRootContext.Provider>
+  );
+});

--- a/packages/react-ui-base/src/thread-history/search-input/thread-history-search-input.tsx
+++ b/packages/react-ui-base/src/thread-history/search-input/thread-history-search-input.tsx
@@ -1,0 +1,79 @@
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { useThreadHistoryRootContext } from "../root/thread-history-root-context";
+
+/**
+ * Props passed to the SearchInput render function.
+ */
+export interface ThreadHistorySearchInputRenderProps {
+  /** Whether the sidebar is collapsed. */
+  isCollapsed: boolean;
+  /** The current search query string. */
+  searchQuery: string;
+  /** Set the search query. */
+  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
+  /** Expand the sidebar and focus the search input. */
+  expandOnSearch: () => void;
+  /** Ref for the search input element. */
+  searchInputRef: React.RefObject<HTMLInputElement>;
+}
+
+export interface ThreadHistorySearchInputProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  /** When true, renders as a Slot, merging props into the child element. */
+  asChild?: boolean;
+  /** Children as ReactNode or render function receiving search state. */
+  children?:
+    | React.ReactNode
+    | ((props: ThreadHistorySearchInputRenderProps) => React.ReactNode);
+}
+
+/**
+ * Search input primitive for filtering threads in the thread history.
+ * Manages input state and expands the sidebar when clicked while collapsed.
+ * Accepts children as a render function to access search state and refs.
+ * @returns A container with a search input for filtering threads
+ */
+export const ThreadHistorySearchInput = React.forwardRef<
+  HTMLDivElement,
+  ThreadHistorySearchInputProps
+>(function ThreadHistorySearchInput({ children, asChild, ...props }, ref) {
+  const { isCollapsed, setIsCollapsed, searchQuery, setSearchQuery } =
+    useThreadHistoryRootContext();
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  const expandOnSearch = React.useCallback(() => {
+    if (isCollapsed) {
+      setIsCollapsed(false);
+      setTimeout(() => {
+        searchInputRef.current?.focus();
+      }, 300);
+    }
+  }, [isCollapsed, setIsCollapsed]);
+
+  const Comp = asChild ? Slot : "div";
+
+  const renderedChildren =
+    typeof children === "function"
+      ? children({
+          isCollapsed,
+          searchQuery,
+          setSearchQuery,
+          expandOnSearch,
+          searchInputRef,
+        })
+      : children;
+
+  return (
+    <Comp
+      ref={ref}
+      data-slot="thread-history-search-input"
+      data-collapsed={isCollapsed || undefined}
+      {...props}
+    >
+      {renderedChildren}
+    </Comp>
+  );
+});

--- a/packages/ui-registry/jest.config.ts
+++ b/packages/ui-registry/jest.config.ts
@@ -22,6 +22,9 @@ const config: Config = {
     "^@tambo-ai/ui-registry/utils$": "<rootDir>/src/utils",
     "^@tambo-ai/ui-registry/lib/(.*)$": "<rootDir>/src/lib/$1",
     "^@tambo-ai/ui-registry/components/(.*)$": "<rootDir>/src/components/$1",
+    // Map @tambo-ai/react-ui-base subpath exports to source
+    "^@tambo-ai/react-ui-base/(.*)$":
+      "<rootDir>/../react-ui-base/src/$1/index.tsx",
     // Mock @tambo-ai/react
     "^@tambo-ai/react$": "<rootDir>/__tests__/__mocks__/@tambo-ai-react.ts",
     // Mock @tambo-ai/react/mcp

--- a/packages/ui-registry/src/components/canvas-space/canvas-space.tsx
+++ b/packages/ui-registry/src/components/canvas-space/canvas-space.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import type { TamboThreadMessage } from "@tambo-ai/react";
-import { useTamboThread } from "@tambo-ai/react";
+import {
+  CanvasSpace as CanvasSpaceBase,
+  type CanvasSpaceContentRenderProps,
+} from "@tambo-ai/react-ui-base/canvas-space";
 import { cn } from "@tambo-ai/ui-registry/utils";
-import * as React from "react";
-import { useEffect, useRef, useState } from "react";
 
 /**
  * Props for the CanvasSpace component
@@ -22,122 +22,21 @@ interface CanvasSpaceProps {
  * ```tsx
  * <CanvasSpace className="custom-styles" />
  * ```
+ * @returns The styled canvas space component
  */
 export function CanvasSpace({ className }: CanvasSpaceProps) {
-  // Access the current Tambo thread context
-  const { thread } = useTamboThread();
-
-  // State for managing the currently rendered component
-  const [renderedComponent, setRenderedComponent] =
-    useState<React.ReactNode | null>(null);
-
-  // Ref for the scrollable container to enable auto-scrolling
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-  // Track previous thread ID to handle thread changes
-  const previousThreadId = useRef<string | null>(null);
-
-  /**
-   * Effect to clear the canvas when switching between threads
-   * Prevents components from previous threads being displayed in new threads
-   */
-  useEffect(() => {
-    // If there's no thread, or if the thread ID changed, clear the canvas
-    if (
-      !thread ||
-      (previousThreadId.current && previousThreadId.current !== thread.id)
-    ) {
-      setRenderedComponent(null);
-    }
-
-    // Update the previous thread ID reference
-    previousThreadId.current = thread?.id ?? null;
-  }, [thread]);
-
-  /**
-   * Effect to handle custom 'tambo:showComponent' events
-   * Allows external triggers to update the rendered component
-   */
-  useEffect(() => {
-    const handleShowComponent = (
-      event: CustomEvent<{ messageId: string; component: React.ReactNode }>,
-    ) => {
-      try {
-        setRenderedComponent(event.detail.component);
-      } catch (error) {
-        console.error("Failed to render component:", error);
-        setRenderedComponent(null);
-      }
-    };
-
-    window.addEventListener(
-      "tambo:showComponent",
-      handleShowComponent as EventListener,
-    );
-
-    return () => {
-      window.removeEventListener(
-        "tambo:showComponent",
-        handleShowComponent as EventListener,
-      );
-    };
-  }, []);
-
-  /**
-   * Effect to automatically display the latest component from thread messages
-   * Updates when thread messages change or new components are added
-   */
-  useEffect(() => {
-    if (!thread?.messages) {
-      setRenderedComponent(null);
-      return;
-    }
-
-    const messagesWithComponents = thread.messages.filter(
-      (msg: TamboThreadMessage) => msg.renderedComponent,
-    );
-
-    if (messagesWithComponents.length > 0) {
-      const latestMessage =
-        messagesWithComponents[messagesWithComponents.length - 1];
-      setRenderedComponent(latestMessage.renderedComponent);
-    }
-  }, [thread?.messages]);
-
-  /**
-   * Effect to auto-scroll to bottom when new components are rendered
-   * Includes a small delay to ensure smooth scrolling
-   */
-  useEffect(() => {
-    if (scrollContainerRef.current && renderedComponent) {
-      const timeoutId = setTimeout(() => {
-        if (scrollContainerRef.current) {
-          scrollContainerRef.current.scrollTo({
-            top: scrollContainerRef.current.scrollHeight,
-            behavior: "smooth",
-          });
-        }
-      }, 100);
-
-      return () => clearTimeout(timeoutId);
-    }
-  }, [renderedComponent]);
-
   return (
-    <div
+    <CanvasSpaceBase.Root
       className={cn(
         "h-screen flex-1 flex flex-col bg-background/50 backdrop-blur-sm overflow-hidden border-l border-border",
         className,
       )}
-      data-canvas-space="true"
     >
-      <div
-        ref={scrollContainerRef}
-        className="w-full flex-1 overflow-y-auto [&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30"
-      >
+      <CanvasSpaceBase.Viewport className="w-full flex-1 overflow-y-auto [&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30">
         <div className="p-8 h-full flex flex-col">
-          {renderedComponent ? (
-            <div className="h-full space-y-6 pb-8 flex flex-col items-center justify-center w-full">
+          <CanvasSpaceBase.Content
+            className="h-full space-y-6 pb-8 flex flex-col items-center justify-center w-full"
+            render={({ renderedComponent }: CanvasSpaceContentRenderProps) => (
               <div
                 className={cn(
                   "w-full transition-all duration-200 ease-out transform flex justify-center",
@@ -146,21 +45,20 @@ export function CanvasSpace({ className }: CanvasSpaceProps) {
               >
                 {renderedComponent}
               </div>
+            )}
+          />
+          <CanvasSpaceBase.EmptyState className="flex-1 flex items-center justify-center text-center p-6">
+            <div className="space-y-2">
+              <p className="text-muted-foreground font-medium">
+                Canvas is empty
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Interactive components will appear here as they are generated
+              </p>
             </div>
-          ) : (
-            <div className="flex-1 flex items-center justify-center text-center p-6">
-              <div className="space-y-2">
-                <p className="text-muted-foreground font-medium">
-                  Canvas is empty
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  Interactive components will appear here as they are generated
-                </p>
-              </div>
-            </div>
-          )}
+          </CanvasSpaceBase.EmptyState>
         </div>
-      </div>
-    </div>
+      </CanvasSpaceBase.Viewport>
+    </CanvasSpaceBase.Root>
   );
 }

--- a/packages/ui-registry/src/components/canvas-space/config.json
+++ b/packages/ui-registry/src/components/canvas-space/config.json
@@ -2,7 +2,7 @@
   "name": "canvas-space",
   "description": "A canvas space component that displays rendered components from chat messages.",
   "componentName": "CanvasSpace",
-  "dependencies": ["@tambo-ai/react"],
+  "dependencies": ["@tambo-ai/react", "@tambo-ai/react-ui-base@next"],
   "devDependencies": [],
   "requires": [],
   "files": [

--- a/packages/ui-registry/src/components/edit-with-tambo-button/config.json
+++ b/packages/ui-registry/src/components/edit-with-tambo-button/config.json
@@ -4,6 +4,7 @@
   "componentName": "EditWithTamboButton",
   "dependencies": [
     "@tambo-ai/react",
+    "@tambo-ai/react-ui-base",
     "lucide-react",
     "@radix-ui/react-popover",
     "@radix-ui/react-tooltip"

--- a/packages/ui-registry/src/components/edit-with-tambo-button/edit-with-tambo-button.tsx
+++ b/packages/ui-registry/src/components/edit-with-tambo-button/edit-with-tambo-button.tsx
@@ -13,16 +13,14 @@ import {
   Trigger as TooltipTrigger,
 } from "@radix-ui/react-tooltip";
 import {
-  useTambo,
-  useTamboCurrentComponent,
-  useTamboThreadInput,
-} from "@tambo-ai/react";
+  EditWithTamboButtonBase,
+  useEditWithTamboButtonContext,
+} from "@tambo-ai/react-ui-base/edit-with-tambo-button";
 import { MessageGenerationStage } from "@tambo-ai/ui-registry/components/message-suggestions";
 import { cn } from "@tambo-ai/ui-registry/utils";
 import type { Editor } from "@tiptap/react";
 import { Bot, ChevronDown, X } from "lucide-react";
 import * as React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface EditWithTamboButtonProps {
   /** Custom icon component */
@@ -47,153 +45,20 @@ export interface EditWithTamboButtonProps {
 }
 
 /**
- * Inline "Edit with Tambo" button and floating popover for interactable components.
- * When clicked, opens a floating popover with a prompt input. Sends messages to Tambo
- * with the interactable component in context and displays only the latest reply.
- *
- * Must be used within a component wrapped with `withInteractable`.
- *
- * @example
- * ```tsx
- * const MyInteractableForm = withInteractable(MyForm, {
- *   componentName: "MyForm",
- *   description: "A form component",
- * });
- *
- * function MyForm() {
- *   return (
- *     <div>
- *       <EditWithTamboButton />
- *     </div>
- *   );
- * }
- * ```
+ * Styled trigger button with tooltip.
+ * @returns The trigger button with tooltip wrapping.
  */
-
-export function EditWithTamboButton({
+function StyledTrigger({
   icon,
-  tooltip = "Edit with tambo",
   description,
   className,
-  onOpenThread,
-  editorRef,
-}: EditWithTamboButtonProps) {
-  const component = useTamboCurrentComponent();
-  const { sendThreadMessage, isIdle, setInteractableSelected } = useTambo();
-  const { setValue: setThreadInputValue } = useTamboThreadInput();
-
-  const [prompt, setPrompt] = useState("");
-  // NOTE: Using isIdle from useTambo() instead of tracking error/pending state locally.
-  // The useTambo() hook already manages generation state and error handling through sendThreadMessage,
-  // so tracking them separately here would cause states to get out of sync or mask errors.
-  const [isOpen, setIsOpen] = useState(false);
-  const [sendMode, setSendMode] = useState<"send" | "thread">("send");
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const [shouldCloseOnComplete, setShouldCloseOnComplete] = useState(false);
-
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
-  const isGenerating = !isIdle;
-
-  // Close popover when generation completes
-  useEffect(() => {
-    if (shouldCloseOnComplete && !isGenerating) {
-      setShouldCloseOnComplete(false);
-      setIsOpen(false);
-      setPrompt("");
-    }
-  }, [shouldCloseOnComplete, isGenerating]);
-
-  const handleSend = useCallback(async () => {
-    if (!prompt.trim() || isGenerating || !component) {
-      return;
-    }
-
-    setShouldCloseOnComplete(true);
-
-    await sendThreadMessage(prompt.trim(), {
-      streamResponse: true,
-      additionalContext: {
-        inlineEdit: {
-          componentId: component.interactableId,
-          instruction:
-            "The user wants to edit this specific component inline. Please update the component's props to fulfill the user's request.",
-        },
-      },
-    });
-
-    // Clear the prompt after successful send
-    setPrompt("");
-  }, [prompt, isGenerating, component, sendThreadMessage]);
-
-  const handleSendInThread = useCallback(() => {
-    if (!prompt.trim()) {
-      return;
-    }
-
-    // Save the message before clearing
-    const messageToInsert = prompt.trim();
-
-    const interactableId = component?.interactableId ?? "";
-    if (interactableId) {
-      setInteractableSelected(interactableId, true);
-    }
-
-    // Open the thread panel if callback provided
-    if (onOpenThread) {
-      onOpenThread();
-    }
-
-    // Clear the prompt and close the modal
-    setPrompt("");
-    setIsOpen(false);
-
-    // Insert text into the editor if editorRef is provided
-    if (editorRef?.current) {
-      const editor = editorRef.current;
-      // Set the content of the editor
-      editor.commands.setContent(messageToInsert);
-      editor.commands.focus("end");
-    } else {
-      // Fallback: use thread input value setter
-      setThreadInputValue(messageToInsert);
-    }
-  }, [
-    prompt,
-    component,
-    onOpenThread,
-    editorRef,
-    setInteractableSelected,
-    setThreadInputValue,
-  ]);
-
-  const handleMainAction = useCallback(() => {
-    if (sendMode === "thread") {
-      handleSendInThread();
-    } else {
-      void handleSend();
-    }
-  }, [sendMode, handleSendInThread, handleSend]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        handleMainAction();
-      }
-    },
-    [handleMainAction],
-  );
-
-  // If no component, the current component is not an interactable - don't render.
-  if (!component) {
-    return null;
-  }
-
-  // If in a Tambo thread (message with threadId), don't show the button
-  if (component.threadId) {
-    return null;
-  }
+}: {
+  icon?: React.ReactNode;
+  description?: string;
+  className?: string;
+}) {
+  const { tooltip, isOpen, setIsOpen, component, textareaRef } =
+    useEditWithTamboButtonContext();
 
   return (
     <TooltipProvider>
@@ -201,8 +66,7 @@ export function EditWithTamboButton({
         <TooltipRoot delayDuration={300}>
           <TooltipTrigger asChild>
             <PopoverTrigger asChild>
-              <button
-                type="button"
+              <EditWithTamboButtonBase.Trigger
                 className={cn(
                   "inline-flex items-center justify-center ml-2 p-1 rounded-md",
                   "text-muted-foreground/60 hover:text-primary",
@@ -211,10 +75,9 @@ export function EditWithTamboButton({
                   isOpen && "text-primary bg-accent",
                   className,
                 )}
-                aria-label={tooltip}
               >
                 {icon ?? <Bot className="h-3.5 w-3.5" />}
-              </button>
+              </EditWithTamboButtonBase.Trigger>
             </PopoverTrigger>
           </TooltipTrigger>
           <TooltipContent
@@ -250,148 +113,195 @@ export function EditWithTamboButton({
               "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
             )}
           >
-            <div className="space-y-4">
-              {/* Header */}
-              <div className="flex items-center justify-between gap-4">
-                <div className="min-w-0 flex-1">
-                  <p className="font-medium text-sm">{tooltip}</p>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    {component.componentName}
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setIsOpen(false);
-                    setPrompt("");
-                  }}
-                  className="p-1 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground shrink-0"
-                  aria-label="Close"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-
-              {/* Prompt input */}
-              <div className="space-y-3">
-                <textarea
-                  ref={textareaRef}
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  placeholder="Describe what you want to change..."
-                  className={cn(
-                    "flex min-h-[80px] w-full rounded-md border border-input",
-                    "bg-transparent px-3 py-2 text-sm shadow-sm",
-                    "placeholder:text-muted-foreground resize-none",
-                    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                    "disabled:cursor-not-allowed disabled:opacity-50",
-                  )}
-                  disabled={isGenerating}
-                />
-                <div className="flex items-center justify-between">
-                  {/* Helper text or generation status */}
-                  {isGenerating && onOpenThread ? (
-                    <div className="flex items-center gap-2">
-                      <MessageGenerationStage className="px-0 py-0" />
-                      <button
-                        type="button"
-                        onClick={onOpenThread}
-                        className="text-xs text-primary hover:text-primary/80 underline transition-colors"
-                      >
-                        View in thread
-                      </button>
-                    </div>
-                  ) : (
-                    <p className="text-xs text-muted-foreground">
-                      Cmd/Ctrl + Enter to send
-                    </p>
-                  )}
-                  <div className="flex items-center">
-                    <button
-                      type="button"
-                      onClick={handleMainAction}
-                      disabled={!prompt.trim() || isGenerating}
-                      className={cn(
-                        "h-9 px-3 text-sm font-medium",
-                        "bg-primary text-primary-foreground",
-                        "hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed",
-                        "transition-colors flex items-center gap-1",
-                        "rounded-l-md border-r border-primary-foreground/20",
-                      )}
-                    >
-                      {isGenerating && <>Sending...</>}
-                      {!isGenerating &&
-                        (sendMode === "thread" ? "Send in Thread" : "Send")}
-                    </button>
-                    <PopoverRoot
-                      open={dropdownOpen}
-                      onOpenChange={setDropdownOpen}
-                    >
-                      <PopoverTrigger asChild>
-                        <button
-                          type="button"
-                          disabled={!prompt.trim() || isGenerating}
-                          className={cn(
-                            "h-9 px-2 text-sm font-medium",
-                            "bg-primary text-primary-foreground",
-                            "hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed",
-                            "transition-colors rounded-r-md",
-                            "flex items-center justify-center",
-                          )}
-                        >
-                          <ChevronDown className="h-3 w-3" />
-                        </button>
-                      </PopoverTrigger>
-                      <PopoverPortal>
-                        <PopoverContent
-                          align="end"
-                          side="bottom"
-                          sideOffset={4}
-                          className="z-50 w-40 rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
-                        >
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setSendMode("send");
-                              setDropdownOpen(false);
-                            }}
-                            className={cn(
-                              "w-full px-2 py-1.5 text-left text-sm rounded-sm",
-                              "hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer",
-                              "focus:bg-accent focus:text-accent-foreground outline-none",
-                              sendMode === "send" &&
-                                "bg-accent text-accent-foreground",
-                            )}
-                          >
-                            Send
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setSendMode("thread");
-                              setDropdownOpen(false);
-                            }}
-                            className={cn(
-                              "w-full px-2 py-1.5 text-left text-sm rounded-sm",
-                              "hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer",
-                              "focus:bg-accent focus:text-accent-foreground outline-none",
-                              sendMode === "thread" &&
-                                "bg-accent text-accent-foreground",
-                            )}
-                          >
-                            Send in Thread
-                          </button>
-                        </PopoverContent>
-                      </PopoverPortal>
-                    </PopoverRoot>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <StyledPopoverContent />
           </PopoverContent>
         </PopoverPortal>
       </PopoverRoot>
     </TooltipProvider>
+  );
+}
+
+/**
+ * Styled popover content with header, textarea, status, and send button.
+ * @returns The popover inner content.
+ */
+function StyledPopoverContent() {
+  const {
+    tooltip,
+    component,
+    closeAndReset,
+    sendMode,
+    isDropdownOpen,
+    setDropdownOpen,
+  } = useEditWithTamboButtonContext();
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-sm">{tooltip}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {component.componentName}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={closeAndReset}
+          className="p-1 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground shrink-0"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Prompt input */}
+      <div className="space-y-3">
+        <EditWithTamboButtonBase.Textarea
+          placeholder="Describe what you want to change..."
+          className={cn(
+            "flex min-h-[80px] w-full rounded-md border border-input",
+            "bg-transparent px-3 py-2 text-sm shadow-sm",
+            "placeholder:text-muted-foreground resize-none",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+          )}
+        />
+        <div className="flex items-center justify-between">
+          {/* Helper text or generation status */}
+          <EditWithTamboButtonBase.Status
+            render={({
+              isGenerating: generating,
+              onOpenThread: openThread,
+            }) => {
+              if (generating && openThread) {
+                return (
+                  <div className="flex items-center gap-2">
+                    <MessageGenerationStage className="px-0 py-0" />
+                    <button
+                      type="button"
+                      onClick={openThread}
+                      className="text-xs text-primary hover:text-primary/80 underline transition-colors"
+                    >
+                      View in thread
+                    </button>
+                  </div>
+                );
+              }
+              return (
+                <p className="text-xs text-muted-foreground">
+                  Cmd/Ctrl + Enter to send
+                </p>
+              );
+            }}
+          />
+          <div className="flex items-center">
+            <EditWithTamboButtonBase.SendButton
+              className={cn(
+                "h-9 px-3 text-sm font-medium",
+                "bg-primary text-primary-foreground",
+                "hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed",
+                "transition-colors flex items-center gap-1",
+                "rounded-l-md border-r border-primary-foreground/20",
+              )}
+            />
+            <PopoverRoot open={isDropdownOpen} onOpenChange={setDropdownOpen}>
+              <PopoverTrigger asChild>
+                <EditWithTamboButtonBase.SendModeDropdown
+                  className={cn(
+                    "h-9 px-2 text-sm font-medium",
+                    "bg-primary text-primary-foreground",
+                    "hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed",
+                    "transition-colors rounded-r-md",
+                    "flex items-center justify-center",
+                  )}
+                >
+                  <ChevronDown className="h-3 w-3" />
+                </EditWithTamboButtonBase.SendModeDropdown>
+              </PopoverTrigger>
+              <PopoverPortal>
+                <PopoverContent
+                  align="end"
+                  side="bottom"
+                  sideOffset={4}
+                  className="z-50 w-40 rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+                >
+                  <EditWithTamboButtonBase.SendModeOption
+                    mode="send"
+                    className={cn(
+                      "w-full px-2 py-1.5 text-left text-sm rounded-sm",
+                      "hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer",
+                      "focus:bg-accent focus:text-accent-foreground outline-none",
+                      sendMode === "send" && "bg-accent text-accent-foreground",
+                    )}
+                  >
+                    Send
+                  </EditWithTamboButtonBase.SendModeOption>
+                  <EditWithTamboButtonBase.SendModeOption
+                    mode="thread"
+                    className={cn(
+                      "w-full px-2 py-1.5 text-left text-sm rounded-sm",
+                      "hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer",
+                      "focus:bg-accent focus:text-accent-foreground outline-none",
+                      sendMode === "thread" &&
+                        "bg-accent text-accent-foreground",
+                    )}
+                  >
+                    Send in Thread
+                  </EditWithTamboButtonBase.SendModeOption>
+                </PopoverContent>
+              </PopoverPortal>
+            </PopoverRoot>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Inline "Edit with Tambo" button and floating popover for interactable components.
+ * When clicked, opens a floating popover with a prompt input. Sends messages to Tambo
+ * with the interactable component in context and displays only the latest reply.
+ *
+ * Must be used within a component wrapped with `withInteractable`.
+ *
+ * @example
+ * ```tsx
+ * const MyInteractableForm = withInteractable(MyForm, {
+ *   componentName: "MyForm",
+ *   description: "A form component",
+ * });
+ *
+ * function MyForm() {
+ *   return (
+ *     <div>
+ *       <EditWithTamboButton />
+ *     </div>
+ *   );
+ * }
+ * ```
+ * @returns The edit-with-tambo button with popover, or null if not in an interactable context.
+ */
+export function EditWithTamboButton({
+  icon,
+  tooltip = "Edit with tambo",
+  description,
+  className,
+  onOpenThread,
+  editorRef,
+}: EditWithTamboButtonProps) {
+  return (
+    <EditWithTamboButtonBase.Root
+      tooltip={tooltip}
+      onOpenThread={onOpenThread}
+      editorRef={editorRef}
+    >
+      <StyledTrigger
+        icon={icon}
+        description={description}
+        className={className}
+      />
+    </EditWithTamboButtonBase.Root>
   );
 }

--- a/packages/ui-registry/src/components/elicitation-ui/config.json
+++ b/packages/ui-registry/src/components/elicitation-ui/config.json
@@ -2,7 +2,7 @@
   "name": "elicitation-ui",
   "description": "MCP elicitation UI component for handling user input requests from MCP servers",
   "componentName": "ElicitationUI",
-  "dependencies": ["@tambo-ai/react"],
+  "dependencies": ["@tambo-ai/react", "@tambo-ai/react-ui-base"],
   "devDependencies": [],
   "requires": [],
   "files": [

--- a/packages/ui-registry/src/components/elicitation-ui/elicitation-ui.tsx
+++ b/packages/ui-registry/src/components/elicitation-ui/elicitation-ui.tsx
@@ -1,437 +1,290 @@
 "use client";
 
-import { cn } from "@tambo-ai/ui-registry/utils";
 import {
-  type TamboElicitationRequest,
-  type TamboElicitationResponse,
+  ElicitationUIBase,
+  type ElicitationUIActionsRenderProps,
+  type ElicitationUIBooleanFieldRenderProps,
+  type ElicitationUIEnumFieldRenderProps,
+  type ElicitationUINumberFieldRenderProps,
+  type ElicitationUIStringFieldRenderProps,
+} from "@tambo-ai/react-ui-base/elicitation-ui";
+import type {
+  TamboElicitationRequest,
+  TamboElicitationResponse,
 } from "@tambo-ai/react/mcp";
+import { cn } from "@tambo-ai/ui-registry/utils";
 import * as React from "react";
-import { useMemo, useState } from "react";
-
-type FieldSchema =
-  TamboElicitationRequest["requestedSchema"]["properties"][string];
 
 /**
- * Props for individual field components
+ * Styled boolean field using render props from the base component.
+ * @returns A styled yes/no button group
  */
-interface FieldProps {
+const StyledBooleanField: React.FC<{
   name: string;
-  schema: FieldSchema;
-  value: unknown;
-  onChange: (value: unknown) => void;
-  required: boolean;
   autoFocus?: boolean;
-  validationError?: string | null;
-}
-
-/**
- * Boolean field component - renders yes/no buttons
- */
-const BooleanField: React.FC<FieldProps> = ({
-  name,
-  schema,
-  value,
-  onChange,
-  required,
-  autoFocus,
-}) => {
-  const boolValue = value as boolean | undefined;
-
-  return (
-    <div className="space-y-2">
-      <label className="text-sm font-medium text-foreground">
-        {schema.description ?? name}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </label>
-      <div className="flex gap-2">
-        <button
-          type="button"
-          autoFocus={autoFocus}
-          onClick={() => onChange(true)}
-          className={cn(
-            "flex-1 px-4 py-2 rounded-lg border transition-colors",
-            boolValue === true
-              ? "bg-accent text-accent-foreground border-accent"
-              : "bg-background border-border hover:bg-muted",
-          )}
-        >
-          Yes
-        </button>
-        <button
-          type="button"
-          onClick={() => onChange(false)}
-          className={cn(
-            "flex-1 px-4 py-2 rounded-lg border transition-colors",
-            boolValue === false
-              ? "bg-accent text-accent-foreground border-accent"
-              : "bg-background border-border hover:bg-muted",
-          )}
-        >
-          No
-        </button>
-      </div>
-    </div>
-  );
-};
-
-/**
- * Enum field component - renders button for each choice
- */
-const EnumField: React.FC<FieldProps> = ({
-  name,
-  schema,
-  value,
-  onChange,
-  required,
-  autoFocus,
-}) => {
-  if (schema.type !== "string" || !("enum" in schema)) {
-    return null;
-  }
-  const options = schema.enum ?? [];
-  const optionNames =
-    "enumNames" in schema ? (schema.enumNames ?? []) : options;
-  const stringValue = value as string | undefined;
-
-  return (
-    <div className="space-y-2">
-      <label className="text-sm font-medium text-foreground">
-        {schema.description ?? name}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </label>
-      <div className="flex flex-wrap gap-2">
-        {options.map((option, index) => (
+}> = ({ name, autoFocus }) => (
+  <ElicitationUIBase.BooleanField
+    name={name}
+    autoFocus={autoFocus}
+    render={(props: ElicitationUIBooleanFieldRenderProps) => (
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-foreground">
+          {props.label}
+          {props.required && <span className="text-destructive ml-1">*</span>}
+        </label>
+        <div className="flex gap-2">
           <button
-            key={option}
             type="button"
-            autoFocus={autoFocus && index === 0}
-            onClick={() => onChange(option)}
+            autoFocus={props.autoFocus}
+            onClick={props.onSelectYes}
             className={cn(
-              "px-4 py-2 rounded-lg border transition-colors",
-              stringValue === option
+              "flex-1 px-4 py-2 rounded-lg border transition-colors",
+              props.isYesSelected
                 ? "bg-accent text-accent-foreground border-accent"
                 : "bg-background border-border hover:bg-muted",
             )}
           >
-            {optionNames[index] ?? option}
+            Yes
           </button>
-        ))}
+          <button
+            type="button"
+            onClick={props.onSelectNo}
+            className={cn(
+              "flex-1 px-4 py-2 rounded-lg border transition-colors",
+              props.isNoSelected
+                ? "bg-accent text-accent-foreground border-accent"
+                : "bg-background border-border hover:bg-muted",
+            )}
+          >
+            No
+          </button>
+        </div>
       </div>
-    </div>
-  );
-};
+    )}
+  />
+);
 
 /**
- * String field component - renders text input with validation
+ * Styled enum field using render props from the base component.
+ * @returns A styled button group for enum options
  */
-const StringField: React.FC<FieldProps> = ({
-  name,
-  schema,
-  value,
-  onChange,
-  required,
-  autoFocus,
-  validationError,
-}) => {
-  const inputId = React.useId();
+const StyledEnumField: React.FC<{
+  name: string;
+  autoFocus?: boolean;
+}> = ({ name, autoFocus }) => (
+  <ElicitationUIBase.EnumField
+    name={name}
+    autoFocus={autoFocus}
+    render={(props: ElicitationUIEnumFieldRenderProps) => (
+      <div className="space-y-2">
+        <label className="text-sm font-medium text-foreground">
+          {props.label}
+          {props.required && <span className="text-destructive ml-1">*</span>}
+        </label>
+        <div className="flex flex-wrap gap-2">
+          {props.options.map((option, index) => (
+            <button
+              key={option.value}
+              type="button"
+              autoFocus={props.autoFocus && index === 0}
+              onClick={option.onSelect}
+              className={cn(
+                "px-4 py-2 rounded-lg border transition-colors",
+                option.isSelected
+                  ? "bg-accent text-accent-foreground border-accent"
+                  : "bg-background border-border hover:bg-muted",
+              )}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    )}
+  />
+);
 
-  if (schema.type !== "string") {
-    return null;
-  }
-  const stringValue = (value as string | undefined) ?? "";
-
-  // Map JSON Schema format to HTML5 input type
-  const getInputType = (): string => {
-    const format = "format" in schema ? schema.format : undefined;
-    switch (format) {
-      case "email":
-        return "email";
-      case "uri":
-        return "url";
-      case "date":
-        return "date";
-      case "date-time":
-        return "datetime-local";
-      default:
-        return "text";
-    }
-  };
-
-  const inputType = getInputType();
-  const hasError = !!validationError;
-  const errorId = `${inputId}-error`;
-
-  return (
-    <div className="space-y-2">
-      <label htmlFor={inputId} className="text-sm font-medium text-foreground">
-        {schema.description ?? name}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </label>
-      <input
-        id={inputId}
-        type={inputType}
-        autoFocus={autoFocus}
-        value={stringValue}
-        onChange={(e) => onChange(e.target.value)}
-        className={cn(
-          "w-full px-3 py-2 rounded-lg border bg-background text-foreground focus:outline-none focus:ring-2",
-          hasError
-            ? "border-destructive focus:ring-destructive"
-            : "border-border focus:ring-accent",
+/**
+ * Styled string field using render props from the base component.
+ * @returns A styled text input with validation feedback
+ */
+const StyledStringField: React.FC<{
+  name: string;
+  autoFocus?: boolean;
+}> = ({ name, autoFocus }) => (
+  <ElicitationUIBase.StringField
+    name={name}
+    autoFocus={autoFocus}
+    render={(props: ElicitationUIStringFieldRenderProps) => (
+      <div className="space-y-2">
+        <label
+          htmlFor={props.inputId}
+          className="text-sm font-medium text-foreground"
+        >
+          {props.label}
+          {props.required && <span className="text-destructive ml-1">*</span>}
+        </label>
+        <input
+          id={props.inputId}
+          type={props.inputType}
+          autoFocus={props.autoFocus}
+          value={props.value}
+          onChange={(e) => props.onChange(e.target.value)}
+          className={cn(
+            "w-full px-3 py-2 rounded-lg border bg-background text-foreground focus:outline-none focus:ring-2",
+            props.hasError
+              ? "border-destructive focus:ring-destructive"
+              : "border-border focus:ring-accent",
+          )}
+          placeholder={props.label}
+          minLength={props.minLength}
+          maxLength={props.maxLength}
+          required={props.required}
+          aria-invalid={props.hasError || undefined}
+          aria-describedby={props.hasError ? props.errorId : undefined}
+        />
+        {props.validationError && (
+          <p
+            id={props.errorId}
+            className="text-xs text-destructive"
+            aria-live="polite"
+          >
+            {props.validationError}
+          </p>
         )}
-        placeholder={schema.description ?? name}
-        minLength={"minLength" in schema ? schema.minLength : undefined}
-        maxLength={"maxLength" in schema ? schema.maxLength : undefined}
-        required={required}
-        aria-invalid={hasError || undefined}
-        aria-describedby={hasError ? errorId : undefined}
-      />
-      {validationError && (
-        <p id={errorId} className="text-xs text-destructive" aria-live="polite">
-          {validationError}
-        </p>
-      )}
-    </div>
-  );
-};
+      </div>
+    )}
+  />
+);
 
 /**
- * Number field component - renders number input with validation
+ * Styled number field using render props from the base component.
+ * @returns A styled number input with validation feedback
  */
-const NumberField: React.FC<FieldProps> = ({
-  name,
-  schema,
-  value,
-  onChange,
-  required,
-  autoFocus,
-  validationError,
-}) => {
-  const inputId = React.useId();
-
-  if (schema.type !== "number" && schema.type !== "integer") {
-    return null;
-  }
-  const numberSchema = schema;
-  const numberValue = value as number | undefined;
-  const hasError = !!validationError;
-  const errorId = `${inputId}-error`;
-
-  return (
-    <div className="space-y-2">
-      <label htmlFor={inputId} className="text-sm font-medium text-foreground">
-        {schema.description ?? name}
-        {required && <span className="text-destructive ml-1">*</span>}
-      </label>
-      <input
-        id={inputId}
-        type="number"
-        autoFocus={autoFocus}
-        value={numberValue ?? ""}
-        onChange={(e) => {
-          const { value, valueAsNumber } = e.currentTarget;
-          onChange(
-            value === "" || Number.isNaN(valueAsNumber)
-              ? undefined
-              : valueAsNumber,
-          );
-        }}
-        className={cn(
-          "w-full px-3 py-2 rounded-lg border bg-background text-foreground focus:outline-none focus:ring-2",
-          hasError
-            ? "border-destructive focus:ring-destructive"
-            : "border-border focus:ring-accent",
+const StyledNumberField: React.FC<{
+  name: string;
+  autoFocus?: boolean;
+}> = ({ name, autoFocus }) => (
+  <ElicitationUIBase.NumberField
+    name={name}
+    autoFocus={autoFocus}
+    render={(props: ElicitationUINumberFieldRenderProps) => (
+      <div className="space-y-2">
+        <label
+          htmlFor={props.inputId}
+          className="text-sm font-medium text-foreground"
+        >
+          {props.label}
+          {props.required && <span className="text-destructive ml-1">*</span>}
+        </label>
+        <input
+          id={props.inputId}
+          type="number"
+          autoFocus={props.autoFocus}
+          value={props.value ?? ""}
+          onChange={(e) => {
+            const { value, valueAsNumber } = e.currentTarget;
+            props.onChange(
+              value === "" || Number.isNaN(valueAsNumber)
+                ? undefined
+                : valueAsNumber,
+            );
+          }}
+          className={cn(
+            "w-full px-3 py-2 rounded-lg border bg-background text-foreground focus:outline-none focus:ring-2",
+            props.hasError
+              ? "border-destructive focus:ring-destructive"
+              : "border-border focus:ring-accent",
+          )}
+          placeholder={props.label}
+          min={props.min}
+          max={props.max}
+          step={props.step}
+          required={props.required}
+          aria-invalid={props.hasError || undefined}
+          aria-describedby={props.hasError ? props.errorId : undefined}
+        />
+        {props.validationError && (
+          <p
+            id={props.errorId}
+            className="text-xs text-destructive"
+            aria-live="polite"
+          >
+            {props.validationError}
+          </p>
         )}
-        placeholder={schema.description ?? name}
-        min={numberSchema.minimum}
-        max={numberSchema.maximum}
-        step={numberSchema.type === "integer" ? 1 : "any"}
-        required={required}
-        aria-invalid={hasError || undefined}
-        aria-describedby={hasError ? errorId : undefined}
-      />
-      {validationError && (
-        <p id={errorId} className="text-xs text-destructive" aria-live="polite">
-          {validationError}
-        </p>
-      )}
-    </div>
-  );
-};
+      </div>
+    )}
+  />
+);
 
 /**
- * Generic field component that renders the appropriate input based on schema type
+ * Styled field dispatcher that delegates to the correct styled field type.
+ * @returns The appropriate styled field component
  */
-const Field: React.FC<FieldProps> = (props) => {
-  const { schema } = props;
-
+const StyledField: React.FC<{
+  name: string;
+  schema: { type: string; enum?: unknown };
+  autoFocus?: boolean;
+}> = ({ name, schema, autoFocus }) => {
   if (schema.type === "boolean") {
-    return <BooleanField {...props} />;
+    return <StyledBooleanField name={name} autoFocus={autoFocus} />;
   }
 
   if (schema.type === "string" && "enum" in schema) {
-    return <EnumField {...props} />;
+    return <StyledEnumField name={name} autoFocus={autoFocus} />;
   }
 
   if (schema.type === "string") {
-    return <StringField {...props} />;
+    return <StyledStringField name={name} autoFocus={autoFocus} />;
   }
 
   if (schema.type === "number" || schema.type === "integer") {
-    return <NumberField {...props} />;
+    return <StyledNumberField name={name} autoFocus={autoFocus} />;
   }
 
   return null;
 };
 
 /**
- * Determines if the elicitation should use single-entry mode
- * (one field that is boolean or enum)
+ * Styled actions bar using render props from the base component.
+ * @returns A styled action button container with cancel, decline, and optional submit
  */
-function isSingleEntryMode(request: TamboElicitationRequest): boolean {
-  const fields = Object.entries(request.requestedSchema.properties);
-
-  if (fields.length !== 1) {
-    return false;
-  }
-
-  const [, schema] = fields[0];
-
-  return (
-    schema.type === "boolean" || (schema.type === "string" && "enum" in schema)
-  );
-}
+const StyledActions: React.FC = () => (
+  <ElicitationUIBase.Actions
+    render={(props: ElicitationUIActionsRenderProps) => (
+      <div className="flex justify-end gap-2 pt-2">
+        <button
+          type="button"
+          onClick={props.onCancel}
+          className="px-4 py-2 text-sm rounded-lg border border-destructive text-destructive hover:bg-destructive/10 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={props.onDecline}
+          className="px-4 py-2 text-sm rounded-lg border border-border bg-background hover:bg-muted transition-colors"
+        >
+          Decline
+        </button>
+        {!props.isSingleEntry && (
+          <button
+            type="button"
+            onClick={props.onAccept}
+            disabled={!props.isValid}
+            className="px-6 py-2 text-sm rounded-lg bg-foreground text-background hover:bg-foreground/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            Submit
+          </button>
+        )}
+      </div>
+    )}
+  />
+);
 
 /**
- * Unified validation function that returns both validity and a user-facing message.
- * Avoids drift between boolean validation and error computation.
- */
-function validateField(
-  value: unknown,
-  schema: FieldSchema,
-  required: boolean,
-): { valid: boolean; error: string | null } {
-  // Required
-  if (required && (value === undefined || value === "" || value === null)) {
-    return { valid: false, error: "This field is required" };
-  }
-
-  // If empty and not required, it's valid
-  if (!required && (value === undefined || value === "" || value === null)) {
-    return { valid: true, error: null };
-  }
-
-  // String validation
-  if (schema.type === "string") {
-    const stringSchema = schema;
-    const stringValue = String(value);
-
-    if (
-      "minLength" in stringSchema &&
-      stringSchema.minLength !== undefined &&
-      stringValue.length < stringSchema.minLength
-    ) {
-      return {
-        valid: false,
-        error: `Minimum length is ${stringSchema.minLength} characters`,
-      };
-    }
-
-    if (
-      "maxLength" in stringSchema &&
-      stringSchema.maxLength !== undefined &&
-      stringValue.length > stringSchema.maxLength
-    ) {
-      return {
-        valid: false,
-        error: `Maximum length is ${stringSchema.maxLength} characters`,
-      };
-    }
-
-    if ("pattern" in stringSchema && stringSchema.pattern) {
-      try {
-        const regex = new RegExp(stringSchema.pattern as string);
-        if (!regex.test(stringValue)) {
-          return {
-            valid: false,
-            error: "Value does not match required pattern",
-          };
-        }
-      } catch {
-        // Invalid regex pattern, skip validation
-      }
-    }
-
-    // Format validation
-    if ("format" in stringSchema && stringSchema.format) {
-      switch (stringSchema.format) {
-        case "email":
-          if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(stringValue)) {
-            return {
-              valid: false,
-              error: "Please enter a valid email address",
-            };
-          }
-          break;
-        case "uri":
-          try {
-            new URL(stringValue);
-          } catch {
-            return { valid: false, error: "Please enter a valid URL" };
-          }
-          break;
-      }
-    }
-  }
-
-  // Number validation
-  if (schema.type === "number" || schema.type === "integer") {
-    const numberSchema = schema;
-    const numberValue = Number(value);
-
-    if (Number.isNaN(numberValue)) {
-      return { valid: false, error: "Please enter a valid number" };
-    }
-
-    if (
-      numberSchema.minimum !== undefined &&
-      numberValue < numberSchema.minimum
-    ) {
-      return {
-        valid: false,
-        error: `Minimum value is ${numberSchema.minimum}`,
-      };
-    }
-
-    if (
-      numberSchema.maximum !== undefined &&
-      numberValue > numberSchema.maximum
-    ) {
-      return {
-        valid: false,
-        error: `Maximum value is ${numberSchema.maximum}`,
-      };
-    }
-
-    if (schema.type === "integer" && !Number.isInteger(numberValue)) {
-      return { valid: false, error: "Please enter a whole number" };
-    }
-  }
-
-  return { valid: true, error: null };
-}
-
-// Backwards-compatible helpers that delegate to the unified validator
-function getValidationError(
-  value: unknown,
-  schema: FieldSchema,
-  required: boolean,
-): string | null {
-  return validateField(value, schema, required).error;
-}
-
-/**
- * Props for the ElicitationUI component
+ * Props for the ElicitationUI component.
  */
 export interface ElicitationUIProps {
   request: TamboElicitationRequest;
@@ -440,185 +293,38 @@ export interface ElicitationUIProps {
 }
 
 /**
- * Main elicitation UI component
- * Handles both single-entry and multiple-entry modes
+ * Styled elicitation UI component.
+ * Handles both single-entry and multiple-entry modes for MCP elicitation requests.
+ * @returns A styled elicitation form with fields and action buttons
  */
 export const ElicitationUI: React.FC<ElicitationUIProps> = ({
   request,
   onResponse,
   className,
 }) => {
-  const singleEntry = isSingleEntryMode(request);
-  const fields = useMemo(
-    () => Object.entries(request.requestedSchema.properties),
-    [request.requestedSchema.properties],
-  );
-  const requiredFields = useMemo(
-    () => request.requestedSchema.required ?? [],
-    [request.requestedSchema.required],
-  );
-  const [formData, setFormData] = useState<Record<string, unknown>>(() => {
-    const initial: Record<string, unknown> = {};
-    fields.forEach(([name, schema]) => {
-      if (schema.default !== undefined) {
-        initial[name] = schema.default;
-      }
-    });
-    return initial;
-  });
+  const fields = Object.entries(request.requestedSchema.properties);
 
-  // Initialize form data with defaults
-  const [touchedFields, setTouchedFields] = useState<Set<string>>(new Set());
-
-  const handleFieldChange = (name: string, value: unknown) => {
-    setFormData((prev) => ({ ...prev, [name]: value }));
-    // Mark field as touched so we can show validation errors
-    setTouchedFields((prev) => new Set(prev).add(name));
-  };
-
-  const handleAccept = () => {
-    // Check if valid before submitting
-    if (!isValid) {
-      // Mark all fields as touched to show validation errors
-      setTouchedFields(new Set(fields.map(([name]) => name)));
-      return;
-    }
-    onResponse({ action: "accept", content: formData });
-  };
-
-  const handleDecline = () => {
-    onResponse({ action: "decline" });
-  };
-
-  const handleCancel = () => {
-    onResponse({ action: "cancel" });
-  };
-
-  // For single-entry mode with boolean/enum, clicking the option submits immediately
-  const handleSingleEntryChange = (name: string, value: unknown) => {
-    const updatedData = { ...formData, [name]: value };
-    setFormData(updatedData);
-    // Mark as touched for consistency/future-proofing
-    setTouchedFields((prev) => new Set(prev).add(name));
-    // Submit immediately
-    onResponse({ action: "accept", content: updatedData });
-  };
-
-  // Check if form is valid (all fields pass validation)
-  const isValid = fields.every(([fieldName, fieldSchema]) => {
-    const value = formData[fieldName];
-    const isRequired = requiredFields.includes(fieldName);
-    return validateField(value, fieldSchema, isRequired).valid;
-  });
-
-  if (singleEntry) {
-    const [fieldName, fieldSchema] = fields[0];
-    const validationError = touchedFields.has(fieldName)
-      ? getValidationError(
-          formData[fieldName],
-          fieldSchema,
-          requiredFields.includes(fieldName),
-        )
-      : null;
-
-    return (
-      <div
-        className={cn(
-          "flex flex-col rounded-xl bg-background border border-border p-4 space-y-3",
-          className,
-        )}
-      >
-        <div className="text-base font-semibold text-foreground mb-2">
-          {request.message}
-        </div>
-        <Field
-          name={fieldName}
-          schema={fieldSchema}
-          value={formData[fieldName]}
-          onChange={(value) => handleSingleEntryChange(fieldName, value)}
-          required={requiredFields.includes(fieldName)}
-          autoFocus
-          validationError={validationError}
-        />
-        <div className="flex justify-end gap-2 pt-2">
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="px-4 py-2 text-sm rounded-lg border border-destructive text-destructive hover:bg-destructive/10 transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={handleDecline}
-            className="px-4 py-2 text-sm rounded-lg border border-border bg-background hover:bg-muted transition-colors"
-          >
-            Decline
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  // Multiple-entry mode
   return (
-    <div
+    <ElicitationUIBase.Root
+      request={request}
+      onResponse={onResponse}
       className={cn(
         "flex flex-col rounded-xl bg-background border border-border p-4 space-y-4",
         className,
       )}
     >
-      <div className="text-base font-semibold text-foreground">
-        {request.message}
-      </div>
+      <ElicitationUIBase.Title className="text-base font-semibold text-foreground" />
       <div className="space-y-3">
-        {fields.map(([name, schema], index) => {
-          const validationError = touchedFields.has(name)
-            ? getValidationError(
-                formData[name],
-                schema,
-                requiredFields.includes(name),
-              )
-            : null;
-
-          return (
-            <Field
-              key={name}
-              name={name}
-              schema={schema}
-              value={formData[name]}
-              onChange={(value) => handleFieldChange(name, value)}
-              required={requiredFields.includes(name)}
-              autoFocus={index === 0}
-              validationError={validationError}
-            />
-          );
-        })}
+        {fields.map(([name, schema], index) => (
+          <StyledField
+            key={name}
+            name={name}
+            schema={schema}
+            autoFocus={index === 0}
+          />
+        ))}
       </div>
-      <div className="flex justify-end gap-2 pt-2">
-        <button
-          type="button"
-          onClick={handleCancel}
-          className="px-4 py-2 text-sm rounded-lg border border-destructive text-destructive hover:bg-destructive/10 transition-colors"
-        >
-          Cancel
-        </button>
-        <button
-          type="button"
-          onClick={handleDecline}
-          className="px-4 py-2 text-sm rounded-lg border border-border bg-background hover:bg-muted transition-colors"
-        >
-          Decline
-        </button>
-        <button
-          type="button"
-          onClick={handleAccept}
-          disabled={!isValid}
-          className="px-6 py-2 text-sm rounded-lg bg-foreground text-background hover:bg-foreground/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          Submit
-        </button>
-      </div>
-    </div>
+      <StyledActions />
+    </ElicitationUIBase.Root>
   );
 };

--- a/packages/ui-registry/src/components/form/config.json
+++ b/packages/ui-registry/src/components/form/config.json
@@ -5,7 +5,8 @@
   "dependencies": [
     "class-variance-authority",
     "lucide-react",
-    "@tambo-ai/react"
+    "@tambo-ai/react",
+    "@tambo-ai/react-ui-base@next"
   ],
   "devDependencies": [],
   "requires": [],

--- a/packages/ui-registry/src/components/form/form.tsx
+++ b/packages/ui-registry/src/components/form/form.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { cn } from "@tambo-ai/ui-registry/utils";
-import { useTambo, useTamboComponentState } from "@tambo-ai/react";
+import {
+  Form as FormBase,
+  type FormFieldDefinition,
+  type FormRootProps,
+  type FormSubmitRenderProps,
+} from "@tambo-ai/react-ui-base/form";
 import { cva } from "class-variance-authority";
 import { Loader2Icon } from "lucide-react";
 import * as React from "react";
@@ -133,6 +138,153 @@ export interface FormState {
 export type FormProps = z.infer<typeof formSchema>;
 
 /**
+ * Styled text/number input classes.
+ */
+const inputClassName =
+  "w-full px-3 py-2 rounded-lg bg-background border border-border focus:ring-2 focus:ring-accent focus:border-input placeholder:text-muted-foreground transition-colors duration-200";
+
+/**
+ * Renders a styled field based on field type, using base component data attributes for structure.
+ * @returns The rendered styled field element
+ */
+function StyledField({ field }: { field: FormFieldDefinition }) {
+  return (
+    <FormBase.Field field={field} className="space-y-2">
+      <FormBase.FieldLabel
+        field={field}
+        className="block text-sm font-medium text-foreground"
+      >
+        {field.label}
+        {field.required && <span className="text-red-500 ml-1">*</span>}
+      </FormBase.FieldLabel>
+
+      <FormBase.FieldDescription
+        field={field}
+        className="text-sm text-muted-foreground"
+      />
+
+      <StyledFieldInput field={field} />
+    </FormBase.Field>
+  );
+}
+
+/**
+ * Renders the styled input for a specific field type.
+ * @returns The rendered styled input element
+ */
+function StyledFieldInput({ field }: { field: FormFieldDefinition }) {
+  switch (field.type) {
+    case "text":
+      return <StyledTextInput field={field} />;
+    case "number":
+      return <StyledNumberInput field={field} />;
+    case "textarea":
+      return <StyledTextareaInput field={field} />;
+    case "select":
+      return <StyledSelectInput field={field} />;
+    case "radio":
+      return <StyledRadioInput field={field} />;
+    case "checkbox":
+      return <StyledCheckboxInput field={field} />;
+    case "slider":
+      return <StyledSliderInput field={field} />;
+    case "yes-no":
+      return <StyledYesNoInput field={field} />;
+  }
+}
+
+/**
+ * Styled text input using the base FormFieldInput.
+ */
+function StyledTextInput({ field }: { field: FormFieldDefinition }) {
+  return (
+    <FormBase.FieldInput field={field}>
+      <input
+        type="text"
+        id={field.id}
+        name={field.id}
+        placeholder={field.placeholder}
+        required={field.required}
+        className={inputClassName}
+      />
+    </FormBase.FieldInput>
+  );
+}
+
+/**
+ * Styled number input using the base FormFieldInput.
+ */
+function StyledNumberInput({ field }: { field: FormFieldDefinition }) {
+  return (
+    <FormBase.FieldInput field={field}>
+      <input
+        type="number"
+        id={field.id}
+        name={field.id}
+        placeholder={field.placeholder}
+        required={field.required}
+        className={inputClassName}
+      />
+    </FormBase.FieldInput>
+  );
+}
+
+/**
+ * Styled textarea using the base FormFieldInput.
+ */
+function StyledTextareaInput({ field }: { field: FormFieldDefinition }) {
+  return (
+    <FormBase.FieldInput field={field}>
+      <textarea
+        id={field.id}
+        name={field.id}
+        placeholder={field.placeholder}
+        required={field.required}
+        rows={4}
+        className={cn(inputClassName, "resize-y")}
+      />
+    </FormBase.FieldInput>
+  );
+}
+
+/**
+ * Styled select dropdown using the base FormFieldInput with context-driven state.
+ */
+function StyledSelectInput({ field }: { field: FormFieldDefinition }) {
+  // We render FormFieldInput with custom children that use the base component's
+  // internal sub-components for the dropdown behavior.
+  return <FormBase.FieldInput field={field} />;
+}
+
+/**
+ * Styled radio group using the base FormFieldInput.
+ */
+function StyledRadioInput({ field }: { field: FormFieldDefinition }) {
+  return <FormBase.FieldInput field={field} />;
+}
+
+/**
+ * Styled checkbox group using the base FormFieldInput.
+ */
+function StyledCheckboxInput({ field }: { field: FormFieldDefinition }) {
+  return <FormBase.FieldInput field={field} />;
+}
+
+/**
+ * Styled slider using the base FormFieldInput.
+ */
+function StyledSliderInput({ field }: { field: FormFieldDefinition }) {
+  return <FormBase.FieldInput field={field} />;
+}
+
+/**
+ * Styled yes/no toggle using the base FormFieldInput.
+ */
+function StyledYesNoInput({ field }: { field: FormFieldDefinition }) {
+  return <FormBase.FieldInput field={field} />;
+}
+
+/**
  * A flexible form component that supports various field types and layouts
  * @component
  * @example
@@ -172,554 +324,50 @@ export const FormComponent = React.forwardRef<HTMLFormElement, FormProps>(
     },
     ref,
   ) => {
-    const { isIdle } = useTambo();
-    const isGenerating = !isIdle;
-
-    const baseId = React.useId();
-    const formId = React.useMemo(() => {
-      const ids = (fields ?? [])
-        .map((f) => f.id)
-        .filter(Boolean)
-        .join("-");
-      return ids ? `form-${baseId}-${ids}` : `form-${baseId}`;
-    }, [baseId, fields]);
-
-    /**
-     * Component state managed by Tambo
-     * Stores all form values, dropdown states, selections, and other UI state
-     */
-    const [state, setState] = useTamboComponentState<FormState>(formId, {
-      values: {},
-      openDropdowns: {},
-      selectedValues: {},
-      yesNoSelections: {},
-      checkboxSelections: {},
-    });
-
-    /**
-     * References to dropdown DOM elements for handling click-outside behavior
-     */
-    const dropdownRefs = React.useRef<Record<string, HTMLDivElement | null>>(
-      {},
-    );
-
-    /**
-     * Filtered list of valid form fields
-     * Removes any fields with missing/invalid data and provides type safety
-     */
-    const validFields = React.useMemo(() => {
-      return fields.filter((field): field is FormField => {
-        if (!field || typeof field !== "object") {
-          console.warn("Invalid field object detected");
-          return false;
-        }
-        if (!field.id || typeof field.id !== "string") {
-          console.warn("Field missing required id property");
-          return false;
-        }
-        return true;
-      });
-    }, [fields]);
-
-    /**
-     * Handles form submission
-     * @param {React.FormEvent} e - The form submission event
-     */
-    const handleSubmit = (e: React.FormEvent) => {
-      e.preventDefault();
-      const formData = new FormData(e.target as HTMLFormElement);
-      const data = Object.fromEntries(
-        Array.from(formData.entries()).map(([k, v]) => [k, v.toString()]),
-      );
-      onSubmit(data);
-    };
-
-    /**
-     * Handles dropdown toggle events
-     * @param {string} fieldId - The ID of the dropdown field
-     */
-    const handleDropdownToggle = (fieldId: string) => {
-      if (!state) return;
-      setState({
-        ...state,
-        openDropdowns: {
-          ...state.openDropdowns,
-          [fieldId]: !state.openDropdowns[fieldId],
-        },
-      });
-    };
-
-    /**
-     * Handles selection from dropdown options
-     * @param {string} fieldId - The ID of the dropdown field
-     * @param {string} option - The selected option value
-     */
-    const handleOptionSelect = (fieldId: string, option: string) => {
-      if (!state) return;
-      setState({
-        ...state,
-        selectedValues: {
-          ...state.selectedValues,
-          [fieldId]: option,
-        },
-        openDropdowns: {
-          ...state.openDropdowns,
-          [fieldId]: false,
-        },
-      });
-    };
-
-    /**
-     * Handles yes/no selection for yes-no field type
-     * @param {string} fieldId - The ID of the yes-no field
-     * @param {string} value - The selected value ("Yes" or "No")
-     */
-    const handleYesNoSelection = (fieldId: string, value: string) => {
-      if (!state) return;
-      setState({
-        ...state,
-        yesNoSelections: {
-          ...state.yesNoSelections,
-          [fieldId]: value,
-        },
-        values: {
-          ...state.values,
-          [fieldId]: value,
-        },
-      });
-    };
-
-    /**
-     * Handles checkbox selection changes
-     * @param {string} fieldId - The ID of the field being updated
-     * @param {string} option - The option value that was clicked
-     * @param {boolean} checked - Whether the checkbox is now checked
-     */
-    const handleCheckboxChange = (
-      fieldId: string,
-      option: string,
-      checked: boolean,
-    ) => {
-      if (!state) return;
-
-      // Get current selections or initialize empty array
-      const currentSelections = state.checkboxSelections[fieldId] ?? [];
-
-      // Update selections based on checked state
-      let newSelections: string[];
-      if (checked) {
-        newSelections = [...currentSelections, option];
-      } else {
-        newSelections = currentSelections.filter((item) => item !== option);
-      }
-
-      // Update state with new selections
-      setState({
-        ...state,
-        checkboxSelections: {
-          ...state.checkboxSelections,
-          [fieldId]: newSelections,
-        },
-        // Also update values with comma-separated string for form submission
-        values: {
-          ...state.values,
-          [fieldId]: newSelections.join(","),
-        },
-      });
-    };
-
-    /**
-     * Handles slider value changes
-     * @param {string} fieldId - The ID of the slider field
-     * @param {string} value - The new slider value
-     * @param {FormField} field - The field definition with possible labels
-     */
-    const handleSliderChange = (
-      fieldId: string,
-      value: string,
-      field: FormField,
-    ) => {
-      if (!state) return;
-
-      // Format the display value
-      const label =
-        field.sliderLabels && field.sliderLabels.length > 0
-          ? field.sliderLabels[parseInt(value)]
-          : value;
-
-      // Store as "value : label" format
-      setState({
-        ...state,
-        values: {
-          ...state.values,
-          [fieldId]: `${value} : ${label}`,
-        },
-      });
-    };
-
-    /**
-     * Calculates the default value for a slider field
-     * @param {FormField} field - The slider field to generate a default value for
-     * @returns {string} The formatted default value in "value : label" format
-     */
-    const getDefaultSliderValue = (field: FormField): string => {
-      const defaultVal =
-        field.sliderDefault?.toString() ??
-        (field.sliderLabels && field.sliderLabels.length > 0
-          ? Math.floor((field.sliderLabels.length - 1) / 2).toString()
-          : "5");
-
-      const defaultLabel =
-        field.sliderLabels && field.sliderLabels.length > 0
-          ? field.sliderLabels[parseInt(defaultVal)]
-          : defaultVal;
-
-      return `${defaultVal} : ${defaultLabel}`;
-    };
-
-    /**
-     * Keeps track of latest state for event handlers
-     */
-    const stateRef = React.useRef(state);
-    React.useEffect(() => {
-      stateRef.current = state;
-    }, [state]);
-
-    /**
-     * Handles closing dropdowns when clicking outside their containing elements
-     */
-    React.useEffect(() => {
-      const handleClickOutside = (event: MouseEvent) => {
-        Object.entries(dropdownRefs.current).forEach(([fieldId, ref]) => {
-          if (ref && !ref.contains(event.target as Node) && stateRef.current) {
-            setState({
-              ...stateRef.current,
-              openDropdowns: {
-                ...stateRef.current.openDropdowns,
-                [fieldId]: false,
-              },
-            });
-          }
-        });
-      };
-
-      document.addEventListener("mousedown", handleClickOutside);
-      return () =>
-        document.removeEventListener("mousedown", handleClickOutside);
-    }, [setState]);
-
-    if (!state) return null;
-
     return (
-      <form
+      <FormBase.Root
         ref={ref}
         className={cn(formVariants({ variant, layout }), className)}
-        onSubmit={handleSubmit}
-        {...props}
+        fields={fields as FormFieldDefinition[]}
+        onSubmit={onSubmit}
+        errorMessage={onError}
+        submitText={submitText}
+        {...(props as Omit<
+          FormRootProps,
+          "fields" | "onSubmit" | "errorMessage" | "submitText"
+        >)}
       >
         <div className="p-6 space-y-6">
-          {onError && (
-            <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/30">
-              <p className="text-sm text-destructive">{onError}</p>
-            </div>
-          )}
+          <FormBase.Error className="p-3 rounded-lg bg-destructive/10 border border-destructive/30">
+            <p className="text-sm text-destructive">{onError}</p>
+          </FormBase.Error>
 
-          {validFields.map((field) => (
-            <div key={field.id} className="space-y-2">
-              <label
-                className="block text-sm font-medium text-foreground"
-                htmlFor={field.id}
-              >
-                {field.label}
-                {field.required && <span className="text-red-500 ml-1">*</span>}
-              </label>
+          <FormBase.Fields
+            render={({ fields: validFields }) =>
+              validFields.map((field) => (
+                <StyledField key={field.id} field={field} />
+              ))
+            }
+          />
 
-              {field.description && (
-                <p className="text-sm text-muted-foreground">
-                  {field.description}
-                </p>
-              )}
-
-              {field.type === "text" && (
-                <input
-                  type="text"
-                  id={field.id}
-                  name={field.id}
-                  placeholder={field.placeholder}
-                  required={field.required}
-                  className="w-full px-3 py-2 rounded-lg 
-                            bg-background border border-border
-                            focus:ring-2 focus:ring-accent focus:border-input
-                            placeholder:text-muted-foreground
-                            transition-colors duration-200"
-                />
-              )}
-
-              {field.type === "number" && (
-                <input
-                  type="number"
-                  id={field.id}
-                  name={field.id}
-                  placeholder={field.placeholder}
-                  required={field.required}
-                  className="w-full px-3 py-2 rounded-lg
-                            bg-background border border-border
-                            focus:ring-2 focus:ring-accent focus:border-input
-                            placeholder:text-muted-foreground
-                            transition-colors duration-200"
-                />
-              )}
-
-              {field.type === "textarea" && (
-                <textarea
-                  id={field.id}
-                  name={field.id}
-                  placeholder={field.placeholder}
-                  required={field.required}
-                  rows={4}
-                  className="w-full px-3 py-2 rounded-lg
-                            bg-background border border-border
-                            focus:ring-2 focus:ring-accent focus:border-input
-                            placeholder:text-muted-foreground
-                            transition-colors duration-200 resize-y"
-                />
-              )}
-
-              {field.type === "select" && field.options && (
-                <div
-                  className="relative"
-                  ref={(el) => {
-                    dropdownRefs.current[field.id] = el;
-                  }}
-                >
-                  <button
-                    type="button"
-                    onClick={() => handleDropdownToggle(field.id)}
-                    className="w-full px-3 py-2 rounded-lg border border-border
-                              bg-background text-foreground
-                              focus:ring-2 focus:ring-accent focus:border-input
-                              hover:bg-muted/50
-                              transition-colors duration-200
-                              text-left flex items-center justify-between"
-                  >
-                    <span
-                      className={
-                        state.selectedValues[field.id]
-                          ? "text-foreground"
-                          : "text-muted-foreground"
-                      }
-                    >
-                      {state.selectedValues[field.id] ?? field.placeholder}
-                    </span>
-                    <svg
-                      className={cn(
-                        "h-4 w-4 text-muted-foreground transition-transform duration-200",
-                        state.openDropdowns[field.id] && "transform rotate-180",
-                      )}
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                    >
-                      <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" />
-                    </svg>
-                  </button>
-
-                  {state.openDropdowns[field.id] && (
-                    <div
-                      className="absolute z-10 w-full mt-1 py-1 rounded-lg border border-border
-                                  bg-background shadow-lg
-                                  max-h-60 overflow-auto"
-                    >
-                      {field.options.map((option) => (
-                        <button
-                          key={option}
-                          type="button"
-                          onClick={() => handleOptionSelect(field.id, option)}
-                          className={cn(
-                            "w-full px-3 py-2 text-left text-foreground",
-                            "hover:bg-muted focus:bg-muted outline-none",
-                            "transition-colors duration-200",
-                            state.selectedValues[field.id] === option &&
-                              "bg-muted/50 font-medium",
-                          )}
-                        >
-                          {option}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                  <input
-                    type="hidden"
-                    name={field.id}
-                    value={state.selectedValues[field.id] ?? ""}
-                    required={field.required}
-                  />
+          <FormBase.Submit
+            className="w-full px-4 py-2.5 bg-accent text-accent-foreground rounded-lg hover:bg-accent/90 focus:ring-2 focus:ring-accent disabled:opacity-50 disabled:pointer-events-none font-medium transition-colors duration-200"
+            render={({
+              isGenerating,
+              submitText: text,
+            }: FormSubmitRenderProps) =>
+              isGenerating ? (
+                <div className="flex items-center justify-center gap-2">
+                  <Loader2Icon className="h-4 w-4 animate-spin" />
+                  <span>Updating form...</span>
                 </div>
-              )}
-
-              {field.type === "radio" && field.options && (
-                <div className="space-y-2">
-                  {field.options.map((option) => (
-                    <label key={option} className="flex items-center space-x-2">
-                      <input
-                        type="radio"
-                        id={`${field.id}-${option}`}
-                        name={field.id}
-                        value={option}
-                        required={field.required}
-                        className="h-4 w-4 border-border focus:ring-accent accent-accent"
-                      />
-                      <span>{option}</span>
-                    </label>
-                  ))}
-                </div>
-              )}
-
-              {field.type === "checkbox" && field.options && (
-                <div className="space-y-2">
-                  {field.options.map((option) => {
-                    // Initialize selections array if it doesn't exist
-                    const selections = state.checkboxSelections[field.id] ?? [];
-                    const isChecked = selections.includes(option);
-
-                    return (
-                      <label
-                        key={option}
-                        className="flex items-center space-x-2"
-                      >
-                        <input
-                          type="checkbox"
-                          id={`${field.id}-${option}`}
-                          checked={isChecked}
-                          value={option}
-                          className="h-4 w-4 border-border focus:ring-accent accent-accent"
-                          onChange={(e) =>
-                            handleCheckboxChange(
-                              field.id,
-                              option,
-                              e.target.checked,
-                            )
-                          }
-                        />
-                        <span>{option}</span>
-                      </label>
-                    );
-                  })}
-                  <input
-                    type="hidden"
-                    name={field.id}
-                    value={state.checkboxSelections[field.id]?.join(",") ?? ""}
-                  />
-                </div>
-              )}
-
-              {field.type === "slider" && (
-                <div className="space-y-3">
-                  <input
-                    type="range"
-                    id={`${field.id}-range`}
-                    min="0"
-                    max={
-                      field.sliderLabels && field.sliderLabels.length > 0
-                        ? (field.sliderLabels.length - 1).toString()
-                        : (field.sliderMax ?? 10).toString()
-                    }
-                    step="1"
-                    value={
-                      state.values[field.id]?.split(" : ")[0] ??
-                      field.sliderDefault?.toString() ??
-                      (field.sliderLabels && field.sliderLabels.length > 0
-                        ? Math.floor(
-                            (field.sliderLabels.length - 1) / 2,
-                          ).toString()
-                        : "5")
-                    }
-                    required={field.required}
-                    className="w-full h-2 bg-muted rounded-lg cursor-pointer accent-accent"
-                    onChange={(e) =>
-                      handleSliderChange(field.id, e.target.value, field)
-                    }
-                  />
-                  <input
-                    type="hidden"
-                    name={field.id}
-                    value={
-                      state.values[field.id] ?? getDefaultSliderValue(field)
-                    }
-                  />
-                  {field.sliderLabels && field.sliderLabels.length > 0 ? (
-                    <div className="flex justify-between text-xs text-muted-foreground">
-                      {field.sliderLabels.map((label, index) => (
-                        <span key={index}>{label}</span>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="flex justify-between text-xs text-muted-foreground">
-                      <span>Min</span>
-                      <span>Mid</span>
-                      <span>Max</span>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {field.type === "yes-no" && (
-                <div className="flex gap-3">
-                  <button
-                    type="button"
-                    onClick={() => handleYesNoSelection(field.id, "Yes")}
-                    className={cn(
-                      "flex-1 px-4 py-2 border border-border rounded-lg cursor-pointer transition-colors",
-                      state.yesNoSelections[field.id] === "Yes"
-                        ? "bg-backdrop border-border text-container font-medium"
-                        : "hover:bg-container",
-                    )}
-                  >
-                    Yes
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleYesNoSelection(field.id, "No")}
-                    className={cn(
-                      "flex-1 px-4 py-2 border border-border rounded-lg cursor-pointer transition-colors",
-                      state.yesNoSelections[field.id] === "No"
-                        ? "bg-backdrop border-border text-container font-medium"
-                        : "hover:bg-container",
-                    )}
-                  >
-                    No
-                  </button>
-                  <input
-                    type="hidden"
-                    id={field.id}
-                    name={field.id}
-                    value={state.yesNoSelections[field.id] ?? ""}
-                    required={field.required}
-                  />
-                </div>
-              )}
-            </div>
-          ))}
-
-          <button
-            type="submit"
-            disabled={isGenerating}
-            className="w-full px-4 py-2.5 bg-accent text-accent-foreground rounded-lg
-                     hover:bg-accent/90 focus:ring-2 focus:ring-accent
-                     disabled:opacity-50 disabled:pointer-events-none
-                     font-medium transition-colors duration-200"
-          >
-            {isGenerating ? (
-              <div className="flex items-center justify-center gap-2">
-                <Loader2Icon className="h-4 w-4 animate-spin" />
-                <span>Updating form...</span>
-              </div>
-            ) : (
-              submitText
-            )}
-          </button>
+              ) : (
+                text
+              )
+            }
+          />
         </div>
-      </form>
+      </FormBase.Root>
     );
   },
 );

--- a/packages/ui-registry/src/components/graph/graph.tsx
+++ b/packages/ui-registry/src/components/graph/graph.tsx
@@ -1,20 +1,15 @@
 "use client";
 
+import {
+  Graph as GraphBase,
+  type GraphChartRenderProps,
+  type GraphLoadingStatus,
+} from "@tambo-ai/react-ui-base/graph";
 import { cn } from "@tambo-ai/ui-registry/utils";
 import { cva } from "class-variance-authority";
 import * as React from "react";
 import * as RechartsCore from "recharts";
 import { z } from "zod/v3";
-
-/**
- * Type for graph variant
- */
-type GraphVariant = "default" | "solid" | "bordered";
-
-/**
- * Type for graph size
- */
-type GraphSize = "default" | "sm" | "lg";
 
 /**
  * Variants for the Graph component
@@ -43,64 +38,6 @@ export const graphVariants = cva(
     },
   },
 );
-
-/**
- * Props for the error boundary
- */
-interface GraphErrorBoundaryProps {
-  children: React.ReactNode;
-  className?: string;
-  variant?: GraphVariant;
-  size?: GraphSize;
-}
-
-/**
- * Error boundary for catching rendering errors in the Graph component
- */
-class GraphErrorBoundary extends React.Component<
-  GraphErrorBoundaryProps,
-  { hasError: boolean; error?: Error }
-> {
-  constructor(props: GraphErrorBoundaryProps) {
-    super(props);
-    this.state = { hasError: false };
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
-
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error("Error rendering chart:", error, errorInfo);
-  }
-
-  render(): React.ReactNode {
-    if (this.state.hasError) {
-      return (
-        <div
-          className={cn(
-            graphVariants({
-              variant: this.props.variant,
-              size: this.props.size,
-            }),
-            this.props.className,
-          )}
-        >
-          <div className="p-4 flex items-center justify-center h-full">
-            <div className="text-destructive text-center">
-              <p className="font-medium">Error loading chart</p>
-              <p className="text-sm mt-1">
-                An error occurred while rendering. Please try again.
-              </p>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    return this.props.children;
-  }
-}
 
 /**
  * Zod schema for GraphData
@@ -171,6 +108,255 @@ const defaultColors = [
 ];
 
 /**
+ * Maps loading status to user-facing messages.
+ * @param status - The loading status from the base component
+ * @returns The display message for the given status
+ */
+function getLoadingMessage(status: GraphLoadingStatus): string {
+  switch (status) {
+    case "no-data":
+      return "Awaiting data...";
+    case "invalid-structure":
+      return "Building chart...";
+    case "no-valid-datasets":
+      return "Preparing datasets...";
+  }
+}
+
+/**
+ * Styled loading indicator for the graph component.
+ * Renders bouncing dots animation for "no-data" status, or a text message for other states.
+ * @returns The loading indicator UI
+ */
+function GraphLoadingIndicator() {
+  return (
+    <GraphBase.Loading
+      className="p-4 h-full flex items-center justify-center"
+      render={({ status }) => {
+        if (status === "no-data") {
+          return (
+            <div className="flex flex-col items-center gap-2 text-muted-foreground">
+              <div className="flex items-center gap-1 h-4">
+                <span className="w-2 h-2 bg-current rounded-full animate-bounce [animation-delay:-0.3s]" />
+                <span className="w-2 h-2 bg-current rounded-full animate-bounce [animation-delay:-0.2s]" />
+                <span className="w-2 h-2 bg-current rounded-full animate-bounce [animation-delay:-0.1s]" />
+              </div>
+              <span className="text-sm">{getLoadingMessage(status)}</span>
+            </div>
+          );
+        }
+
+        return (
+          <div className="text-muted-foreground text-center">
+            <p className="text-sm">{getLoadingMessage(status)}</p>
+          </div>
+        );
+      }}
+    />
+  );
+}
+
+/**
+ * Renders a bar chart using Recharts.
+ * @returns The Recharts BarChart element
+ */
+function BarChartRenderer({
+  chartData,
+  validDatasets,
+  showLegend,
+}: Pick<GraphChartRenderProps, "chartData" | "validDatasets" | "showLegend">) {
+  return (
+    <RechartsCore.BarChart data={chartData}>
+      <RechartsCore.CartesianGrid
+        strokeDasharray="3 3"
+        vertical={false}
+        stroke="var(--border)"
+      />
+      <RechartsCore.XAxis
+        dataKey="name"
+        stroke="var(--muted-foreground)"
+        axisLine={false}
+        tickLine={false}
+      />
+      <RechartsCore.YAxis
+        stroke="var(--muted-foreground)"
+        axisLine={false}
+        tickLine={false}
+      />
+      <RechartsCore.Tooltip
+        cursor={{
+          fill: "var(--muted-foreground)",
+          fillOpacity: 0.1,
+          radius: 4,
+        }}
+        contentStyle={{
+          backgroundColor: "white",
+          border: "1px solid #e5e7eb",
+          borderRadius: "var(--radius)",
+          color: "var(--foreground)",
+        }}
+      />
+      {showLegend && (
+        <RechartsCore.Legend
+          wrapperStyle={{
+            color: "var(--foreground)",
+          }}
+        />
+      )}
+      {validDatasets.map((dataset, index) => (
+        <RechartsCore.Bar
+          key={dataset.label}
+          dataKey={dataset.label}
+          fill={dataset.color ?? defaultColors[index % defaultColors.length]}
+          radius={[4, 4, 0, 0]}
+        />
+      ))}
+    </RechartsCore.BarChart>
+  );
+}
+
+/**
+ * Renders a line chart using Recharts.
+ * @returns The Recharts LineChart element
+ */
+function LineChartRenderer({
+  chartData,
+  validDatasets,
+  showLegend,
+}: Pick<GraphChartRenderProps, "chartData" | "validDatasets" | "showLegend">) {
+  return (
+    <RechartsCore.LineChart data={chartData}>
+      <RechartsCore.CartesianGrid
+        strokeDasharray="3 3"
+        vertical={false}
+        stroke="var(--border)"
+      />
+      <RechartsCore.XAxis
+        dataKey="name"
+        stroke="var(--muted-foreground)"
+        axisLine={false}
+        tickLine={false}
+      />
+      <RechartsCore.YAxis
+        stroke="var(--muted-foreground)"
+        axisLine={false}
+        tickLine={false}
+      />
+      <RechartsCore.Tooltip
+        cursor={{
+          stroke: "var(--muted)",
+          strokeWidth: 2,
+          strokeOpacity: 0.3,
+        }}
+        contentStyle={{
+          backgroundColor: "white",
+          border: "1px solid #e5e7eb",
+          borderRadius: "var(--radius)",
+          color: "var(--foreground)",
+        }}
+      />
+      {showLegend && (
+        <RechartsCore.Legend
+          wrapperStyle={{
+            color: "var(--foreground)",
+          }}
+        />
+      )}
+      {validDatasets.map((dataset, index) => (
+        <RechartsCore.Line
+          key={dataset.label}
+          type="monotone"
+          dataKey={dataset.label}
+          stroke={dataset.color ?? defaultColors[index % defaultColors.length]}
+          dot={false}
+        />
+      ))}
+    </RechartsCore.LineChart>
+  );
+}
+
+/**
+ * Renders a pie chart using Recharts.
+ * @returns The Recharts PieChart element, or a message if no valid dataset
+ */
+function PieChartRenderer({
+  validDatasets,
+  maxDataPoints,
+  showLegend,
+  labels,
+}: Pick<
+  GraphChartRenderProps,
+  "validDatasets" | "maxDataPoints" | "showLegend" | "labels"
+>) {
+  const pieDataset = validDatasets[0];
+  if (!pieDataset) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="text-muted-foreground text-center">
+          <p className="text-sm">No valid dataset for pie chart</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <RechartsCore.PieChart>
+      <RechartsCore.Pie
+        data={pieDataset.data.slice(0, maxDataPoints).map((value, index) => ({
+          name: labels[index],
+          value,
+          fill: defaultColors[index % defaultColors.length],
+        }))}
+        dataKey="value"
+        nameKey="name"
+        cx="50%"
+        cy="50%"
+        labelLine={false}
+        outerRadius={80}
+        fill="#8884d8"
+      />
+      <RechartsCore.Tooltip
+        contentStyle={{
+          backgroundColor: "white",
+          border: "1px solid #e5e7eb",
+          borderRadius: "var(--radius)",
+          color: "var(--foreground)",
+          boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+        }}
+        itemStyle={{
+          color: "var(--foreground)",
+        }}
+        labelStyle={{
+          color: "var(--foreground)",
+        }}
+      />
+      {showLegend && (
+        <RechartsCore.Legend
+          wrapperStyle={{
+            color: "var(--foreground)",
+          }}
+        />
+      )}
+    </RechartsCore.PieChart>
+  );
+}
+
+/**
+ * Renders the appropriate chart type based on the chart data.
+ * @returns The Recharts chart element for the given chart type
+ */
+function ChartRenderer(props: GraphChartRenderProps) {
+  switch (props.chartType) {
+    case "bar":
+      return <BarChartRenderer {...props} />;
+    case "line":
+      return <LineChartRenderer {...props} />;
+    case "pie":
+      return <PieChartRenderer {...props} />;
+  }
+}
+
+/**
  * A component that renders various types of charts using Recharts
  * @component
  * @example
@@ -190,301 +376,50 @@ const defaultColors = [
  *   className="custom-styles"
  * />
  * ```
+ * @returns The styled graph component
  */
 export const Graph = React.forwardRef<HTMLDivElement, GraphProps>(
   (
     { className, variant, size, data, title, showLegend = true, ...props },
     ref,
   ) => {
-    // If no data received yet, show loading
-    if (!data) {
-      return (
-        <div
-          ref={ref}
-          className={cn(graphVariants({ variant, size }), className)}
-          {...props}
-        >
-          <div className="p-4 h-full flex items-center justify-center">
-            <div className="flex flex-col items-center gap-2 text-muted-foreground">
-              <div className="flex items-center gap-1 h-4">
-                <span className="w-2 h-2 bg-current rounded-full animate-bounce [animation-delay:-0.3s]"></span>
-                <span className="w-2 h-2 bg-current rounded-full animate-bounce [animation-delay:-0.2s]"></span>
-                <span className="w-2 h-2 bg-current rounded-full animate-bounce [animation-delay:-0.1s]"></span>
-              </div>
-              <span className="text-sm">Awaiting data...</span>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    // Check if we have the minimum viable data structure
-    const hasValidStructure =
-      data.type &&
-      data.labels &&
-      data.datasets &&
-      Array.isArray(data.labels) &&
-      Array.isArray(data.datasets) &&
-      data.labels.length > 0 &&
-      data.datasets.length > 0;
-
-    if (!hasValidStructure) {
-      return (
-        <div
-          ref={ref}
-          className={cn(graphVariants({ variant, size }), className)}
-          {...props}
-        >
-          <div className="p-4 h-full flex items-center justify-center">
-            <div className="text-muted-foreground text-center">
-              <p className="text-sm">Building chart...</p>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    // Filter datasets to only include those with valid data
-    const validDatasets = data.datasets.filter(
-      (dataset) =>
-        dataset.label &&
-        dataset.data &&
-        Array.isArray(dataset.data) &&
-        dataset.data.length > 0,
-    );
-
-    if (validDatasets.length === 0) {
-      return (
-        <div
-          ref={ref}
-          className={cn(graphVariants({ variant, size }), className)}
-          {...props}
-        >
-          <div className="p-4 h-full flex items-center justify-center">
-            <div className="text-muted-foreground text-center">
-              <p className="text-sm">Preparing datasets...</p>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    // Use the minimum length between labels and the shortest dataset
-    const maxDataPoints = Math.min(
-      data.labels.length,
-      Math.min(...validDatasets.map((d) => d.data.length)),
-    );
-
-    // Transform data for Recharts using only available data points
-    const chartData = data.labels
-      .slice(0, maxDataPoints)
-      .map((label, index) => ({
-        name: label,
-        ...Object.fromEntries(
-          validDatasets.map((dataset) => [
-            dataset.label,
-            dataset.data[index] ?? 0,
-          ]),
-        ),
-      }));
-
-    const renderChart = () => {
-      if (!["bar", "line", "pie"].includes(data.type)) {
-        return (
-          <div className="h-full flex items-center justify-center">
-            <div className="text-muted-foreground text-center">
-              <p className="text-sm">Unsupported chart type: {data.type}</p>
-            </div>
-          </div>
-        );
-      }
-
-      switch (data.type) {
-        case "bar":
-          return (
-            <RechartsCore.BarChart data={chartData}>
-              <RechartsCore.CartesianGrid
-                strokeDasharray="3 3"
-                vertical={false}
-                stroke="var(--border)"
-              />
-              <RechartsCore.XAxis
-                dataKey="name"
-                stroke="var(--muted-foreground)"
-                axisLine={false}
-                tickLine={false}
-              />
-              <RechartsCore.YAxis
-                stroke="var(--muted-foreground)"
-                axisLine={false}
-                tickLine={false}
-              />
-              <RechartsCore.Tooltip
-                cursor={{
-                  fill: "var(--muted-foreground)",
-                  fillOpacity: 0.1,
-                  radius: 4,
-                }}
-                contentStyle={{
-                  backgroundColor: "white",
-                  border: "1px solid #e5e7eb",
-                  borderRadius: "var(--radius)",
-                  color: "var(--foreground)",
-                }}
-              />
-              {showLegend && (
-                <RechartsCore.Legend
-                  wrapperStyle={{
-                    color: "var(--foreground)",
-                  }}
-                />
-              )}
-              {validDatasets.map((dataset, index) => (
-                <RechartsCore.Bar
-                  key={dataset.label}
-                  dataKey={dataset.label}
-                  fill={
-                    dataset.color ?? defaultColors[index % defaultColors.length]
-                  }
-                  radius={[4, 4, 0, 0]}
-                />
-              ))}
-            </RechartsCore.BarChart>
-          );
-
-        case "line":
-          return (
-            <RechartsCore.LineChart data={chartData}>
-              <RechartsCore.CartesianGrid
-                strokeDasharray="3 3"
-                vertical={false}
-                stroke="var(--border)"
-              />
-              <RechartsCore.XAxis
-                dataKey="name"
-                stroke="var(--muted-foreground)"
-                axisLine={false}
-                tickLine={false}
-              />
-              <RechartsCore.YAxis
-                stroke="var(--muted-foreground)"
-                axisLine={false}
-                tickLine={false}
-              />
-              <RechartsCore.Tooltip
-                cursor={{
-                  stroke: "var(--muted)",
-                  strokeWidth: 2,
-                  strokeOpacity: 0.3,
-                }}
-                contentStyle={{
-                  backgroundColor: "white",
-                  border: "1px solid #e5e7eb",
-                  borderRadius: "var(--radius)",
-                  color: "var(--foreground)",
-                }}
-              />
-              {showLegend && (
-                <RechartsCore.Legend
-                  wrapperStyle={{
-                    color: "var(--foreground)",
-                  }}
-                />
-              )}
-              {validDatasets.map((dataset, index) => (
-                <RechartsCore.Line
-                  key={dataset.label}
-                  type="monotone"
-                  dataKey={dataset.label}
-                  stroke={
-                    dataset.color ?? defaultColors[index % defaultColors.length]
-                  }
-                  dot={false}
-                />
-              ))}
-            </RechartsCore.LineChart>
-          );
-
-        case "pie": {
-          // For pie charts, use the first valid dataset
-          const pieDataset = validDatasets[0];
-          if (!pieDataset) {
-            return (
-              <div className="h-full flex items-center justify-center">
-                <div className="text-muted-foreground text-center">
-                  <p className="text-sm">No valid dataset for pie chart</p>
-                </div>
-              </div>
-            );
-          }
-
-          return (
-            <RechartsCore.PieChart>
-              <RechartsCore.Pie
-                data={pieDataset.data
-                  .slice(0, maxDataPoints)
-                  .map((value, index) => ({
-                    name: data.labels[index],
-                    value,
-                    fill: defaultColors[index % defaultColors.length],
-                  }))}
-                dataKey="value"
-                nameKey="name"
-                cx="50%"
-                cy="50%"
-                labelLine={false}
-                outerRadius={80}
-                fill="#8884d8"
-              />
-              <RechartsCore.Tooltip
-                contentStyle={{
-                  backgroundColor: "white",
-                  border: "1px solid #e5e7eb",
-                  borderRadius: "var(--radius)",
-                  color: "var(--foreground)",
-                  boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
-                }}
-                itemStyle={{
-                  color: "var(--foreground)",
-                }}
-                labelStyle={{
-                  color: "var(--foreground)",
-                }}
-              />
-              {showLegend && (
-                <RechartsCore.Legend
-                  wrapperStyle={{
-                    color: "var(--foreground)",
-                  }}
-                />
-              )}
-            </RechartsCore.PieChart>
-          );
-        }
-      }
-    };
-
     return (
-      <GraphErrorBoundary className={className} variant={variant} size={size}>
-        <div
-          ref={ref}
-          className={cn(graphVariants({ variant, size }), className)}
-          {...props}
-        >
-          <div className="p-4 h-full">
-            {title && (
-              <h3 className="text-lg font-medium mb-4 text-foreground">
-                {title}
-              </h3>
-            )}
-            <div className="w-full h-[calc(100%-2rem)]">
-              <RechartsCore.ResponsiveContainer width="100%" height="100%">
-                {renderChart()}
-              </RechartsCore.ResponsiveContainer>
+      <GraphBase.ErrorBoundary
+        renderError={() => (
+          <div className={cn(graphVariants({ variant, size }), className)}>
+            <div className="p-4 flex items-center justify-center h-full">
+              <div className="text-destructive text-center">
+                <p className="font-medium">Error loading chart</p>
+                <p className="text-sm mt-1">
+                  An error occurred while rendering. Please try again.
+                </p>
+              </div>
             </div>
           </div>
-        </div>
-      </GraphErrorBoundary>
+        )}
+      >
+        <GraphBase.Root
+          ref={ref}
+          className={cn(graphVariants({ variant, size }), className)}
+          data={data}
+          title={title}
+          showLegend={showLegend}
+          {...props}
+        >
+          <GraphLoadingIndicator />
+          <div className="p-4 h-full">
+            <GraphBase.Title className="text-lg font-medium mb-4 text-foreground" />
+            <GraphBase.Chart
+              className="w-full h-[calc(100%-2rem)]"
+              render={(chartProps) => (
+                <RechartsCore.ResponsiveContainer width="100%" height="100%">
+                  <ChartRenderer {...chartProps} />
+                </RechartsCore.ResponsiveContainer>
+              )}
+            />
+          </div>
+        </GraphBase.Root>
+      </GraphBase.ErrorBoundary>
     );
   },
 );

--- a/packages/ui-registry/src/components/input-fields/config.json
+++ b/packages/ui-registry/src/components/input-fields/config.json
@@ -2,7 +2,7 @@
   "name": "input-fields",
   "description": "Provides reusable input fields with various styles and validation options",
   "componentName": "InputFields",
-  "dependencies": ["class-variance-authority"],
+  "dependencies": ["class-variance-authority", "@tambo-ai/react-ui-base@next"],
   "devDependencies": [],
   "requires": [],
   "files": [

--- a/packages/ui-registry/src/components/input-fields/index.tsx
+++ b/packages/ui-registry/src/components/input-fields/index.tsx
@@ -4,4 +4,5 @@ export {
   inputFieldsSchema,
   type Field,
   type InputFieldsProps,
+  type InputFieldsState,
 } from "./input-fields";

--- a/packages/ui-registry/src/components/input-fields/input-fields.tsx
+++ b/packages/ui-registry/src/components/input-fields/input-fields.tsx
@@ -1,57 +1,16 @@
 "use client";
 
+import {
+  InputFields as InputFieldsBase,
+  type InputFieldsProps as InputFieldsBaseProps,
+  type InputFieldsRootProps,
+  fieldSchema,
+  inputFieldsSchema,
+  useInputFieldsRootContext,
+} from "@tambo-ai/react-ui-base/input-fields";
 import { cn } from "@tambo-ai/ui-registry/utils";
-import { useTambo, useTamboComponentState } from "@tambo-ai/react";
 import { cva } from "class-variance-authority";
 import * as React from "react";
-import { z } from "zod/v3";
-
-/**
- * Zod schema for Field
- */
-export const fieldSchema = z.object({
-  id: z.string().describe("Unique identifier for the field"),
-  type: z
-    .enum(["text", "number", "email", "password"])
-    .describe("Type of input field"),
-  label: z.string().describe("Display label for the field"),
-  placeholder: z.string().optional().describe("Optional placeholder text"),
-  required: z.boolean().optional().describe("Whether the field is required"),
-  description: z
-    .string()
-    .optional()
-    .describe("Additional description text for the field"),
-  disabled: z.boolean().optional().describe("Whether the field is disabled"),
-  maxLength: z.number().optional().describe("Maximum length of the field"),
-  minLength: z.number().optional().describe("Minimum length of the field"),
-  pattern: z
-    .string()
-    .optional()
-    .describe("Regular expression pattern for validation"),
-  autoComplete: z.string().optional().describe("Autocomplete attribute value"),
-  error: z.string().optional().describe("Error message for the field"),
-});
-
-/**
- * Zod schema for InputFields component props
- */
-export const inputFieldsSchema = z.object({
-  fields: z
-    .array(fieldSchema)
-    .describe("Array of field configurations to render"),
-  variant: z
-    .enum(["default", "solid", "bordered"])
-    .optional()
-    .describe("Visual style variant"),
-  layout: z
-    .enum(["default", "compact", "relaxed"])
-    .optional()
-    .describe("Spacing layout"),
-  className: z
-    .string()
-    .optional()
-    .describe("Additional CSS classes for styling"),
-});
 
 export const inputFieldsVariants = cva(
   "w-full rounded-lg transition-all duration-200",
@@ -78,25 +37,50 @@ export const inputFieldsVariants = cva(
   },
 );
 
-/**
- * Represents a field in an input fields component
- */
-export type Field = z.infer<typeof fieldSchema>;
+export type {
+  Field,
+  InputFieldsState,
+} from "@tambo-ai/react-ui-base/input-fields";
 
 /**
- * Interface representing the state of the InputFields component
+ * Props for the InputFields component type inferred from the Zod schema.
  */
-export interface InputFieldsState {
-  values: Record<string, string>;
+export type InputFieldsProps = InputFieldsBaseProps;
+
+/**
+ * Inner content that iterates over valid fields from context.
+ * Separated to access context provided by InputFields.Root.
+ * @returns The styled field list
+ */
+function InputFieldsContent() {
+  const { validFields } = useInputFieldsRootContext();
+
+  return (
+    <div className="p-6 space-y-6">
+      {validFields.map((field) => (
+        <InputFieldsBase.Field
+          key={field.id}
+          field={field}
+          className="space-y-2"
+        >
+          <InputFieldsBase.Label className="block text-sm font-medium text-foreground">
+            {field.label}
+            {field.required && <span className="text-red-500 ml-1">*</span>}
+          </InputFieldsBase.Label>
+
+          <InputFieldsBase.Description className="text-sm text-muted-foreground" />
+
+          <InputFieldsBase.Input className="w-full px-3 py-2 rounded-lg bg-background border border-border focus:ring-2 focus:ring-ring focus:border-input placeholder:text-muted-foreground transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed" />
+
+          <InputFieldsBase.Error className="text-sm text-destructive" />
+        </InputFieldsBase.Field>
+      ))}
+    </div>
+  );
 }
 
 /**
- * Props for the InputFields component type inferred from the Zod schema
- */
-export type InputFieldsProps = z.infer<typeof inputFieldsSchema>;
-
-/**
- * A component that renders a collection of form input fields with validation and accessibility features
+ * A component that renders a collection of form input fields with validation and accessibility features.
  * @component
  * @example
  * ```tsx
@@ -114,120 +98,23 @@ export type InputFieldsProps = z.infer<typeof inputFieldsSchema>;
  *   className="custom-styles"
  * />
  * ```
+ * @returns The styled input fields component
  */
-export const InputFields = React.forwardRef<HTMLDivElement, InputFieldsProps>(
-  ({ className, variant, layout, fields = [], ...props }, ref) => {
-    const { isIdle } = useTambo();
-    const isGenerating = !isIdle;
-
-    const baseId = React.useId();
-    const inputFieldsId = React.useMemo(() => {
-      const ids = (fields ?? [])
-        .map((f) => f.id)
-        .filter(Boolean)
-        .join("-");
-      return ids ? `input-fields-${baseId}-${ids}` : `input-fields-${baseId}`;
-    }, [baseId, fields]);
-
-    /**
-     * Component state managed by Tambo
-     * Stores all input field values
-     */
-    const [state, setState] = useTamboComponentState<InputFieldsState>(
-      inputFieldsId,
-      {
-        values: {},
-      },
-    );
-
-    /**
-     * Filtered list of valid input fields
-     * Removes any fields with missing/invalid data and provides type safety
-     */
-    const validFields = React.useMemo(() => {
-      return fields.filter((field): field is Field => {
-        if (!field || typeof field !== "object") {
-          console.warn("Invalid field object detected");
-          return false;
-        }
-        if (!field.id || typeof field.id !== "string") {
-          console.warn("Field missing required id property");
-          return false;
-        }
-        return true;
-      });
-    }, [fields]);
-
-    /**
-     * Handles input value changes
-     * @param {string} fieldId - The ID of the field being updated
-     * @param {string} value - The new value
-     */
-    const handleInputChange = (fieldId: string, value: string) => {
-      if (!state) return;
-      setState({
-        ...state,
-        values: {
-          ...state.values,
-          [fieldId]: value,
-        },
-      });
-    };
-
-    if (!state) return null;
-
-    return (
-      <div
-        ref={ref}
-        className={cn(inputFieldsVariants({ variant, layout }), className)}
-        {...props}
-      >
-        <div className="p-6 space-y-6">
-          {validFields.map((field) => (
-            <div key={field.id} className="space-y-2">
-              <label
-                className="block text-sm font-medium text-foreground"
-                htmlFor={field.id}
-              >
-                {field.label}
-                {field.required && <span className="text-red-500 ml-1">*</span>}
-              </label>
-
-              {field.description && (
-                <p className="text-sm text-muted-foreground">
-                  {field.description}
-                </p>
-              )}
-
-              <input
-                type={field.type}
-                id={field.id}
-                name={field.id}
-                value={state.values[field.id] ?? ""}
-                onChange={(e) => handleInputChange(field.id, e.target.value)}
-                placeholder={field.placeholder}
-                required={field.required}
-                disabled={field.disabled ?? isGenerating}
-                maxLength={field.maxLength}
-                minLength={field.minLength}
-                pattern={field.pattern}
-                autoComplete={field.autoComplete}
-                className="w-full px-3 py-2 rounded-lg 
-                          bg-background border border-border
-                          focus:ring-2 focus:ring-ring focus:border-input
-                          placeholder:text-muted-foreground
-                          transition-colors duration-200
-                          disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-
-              {field.error && (
-                <p className="text-sm text-destructive">{field.error}</p>
-              )}
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  },
-);
+export const InputFields = React.forwardRef<
+  HTMLDivElement,
+  InputFieldsProps & Pick<InputFieldsRootProps, "asChild">
+>(({ className, variant, layout, fields = [], ...props }, ref) => {
+  return (
+    <InputFieldsBase.Root
+      ref={ref}
+      className={cn(inputFieldsVariants({ variant, layout }), className)}
+      fields={fields}
+      {...props}
+    >
+      <InputFieldsContent />
+    </InputFieldsBase.Root>
+  );
+});
 InputFields.displayName = "InputFields";
+
+export { fieldSchema, inputFieldsSchema };

--- a/packages/ui-registry/src/components/map/config.json
+++ b/packages/ui-registry/src/components/map/config.json
@@ -9,7 +9,8 @@
     "leaflet",
     "leaflet.heat",
     "leaflet.markercluster",
-    "@tambo-ai/react"
+    "@tambo-ai/react",
+    "@tambo-ai/react-ui-base"
   ],
   "devDependencies": [],
   "requires": [],

--- a/packages/ui-registry/src/components/message-suggestions/message-suggestions.tsx
+++ b/packages/ui-registry/src/components/message-suggestions/message-suggestions.tsx
@@ -1,76 +1,27 @@
 "use client";
 
-import { MessageGenerationStage } from "./message-generation-stage";
-import { Tooltip, TooltipProvider } from "./suggestions-tooltip";
-import { cn } from "@tambo-ai/ui-registry/utils";
-import type { Suggestion, TamboThread } from "@tambo-ai/react";
 import {
-  GenerationStage,
-  useTambo,
-  useTamboSuggestions,
-} from "@tambo-ai/react";
+  MessageSuggestions as MessageSuggestionsBase,
+  type MessageSuggestionsGenerationStageRenderProps,
+  type MessageSuggestionsListRenderProps,
+  type MessageSuggestionsRootProps,
+  type MessageSuggestionsStatusProps as MessageSuggestionsBaseStatusProps,
+  useMessageSuggestionsContext,
+} from "@tambo-ai/react-ui-base/message-suggestions";
+import { cn } from "@tambo-ai/ui-registry/utils";
 import { Loader2Icon } from "lucide-react";
 import * as React from "react";
-import { useEffect, useRef } from "react";
-
-/**
- * @typedef MessageSuggestionsContextValue
- * @property {Array} suggestions - Array of suggestion objects
- * @property {string|null} selectedSuggestionId - ID of the currently selected suggestion
- * @property {function} accept - Function to accept a suggestion
- * @property {boolean} isGenerating - Whether suggestions are being generated
- * @property {Error|null} error - Any error from generation
- * @property {object} thread - The current Tambo thread
- */
-interface MessageSuggestionsContextValue {
-  suggestions: Suggestion[];
-  selectedSuggestionId: string | null;
-  accept: (options: { suggestion: Suggestion }) => Promise<void>;
-  isGenerating: boolean;
-  error: Error | null;
-  thread: TamboThread;
-  isMac: boolean;
-}
-
-/**
- * React Context for sharing suggestion data and functions among sub-components.
- * @internal
- */
-const MessageSuggestionsContext =
-  React.createContext<MessageSuggestionsContextValue | null>(null);
-
-/**
- * Hook to access the message suggestions context.
- * @returns {MessageSuggestionsContextValue} The message suggestions context value.
- * @throws {Error} If used outside of MessageSuggestions.
- * @internal
- */
-const useMessageSuggestionsContext = () => {
-  const context = React.useContext(MessageSuggestionsContext);
-  if (!context) {
-    throw new Error(
-      "MessageSuggestions sub-components must be used within a MessageSuggestions",
-    );
-  }
-  return context;
-};
+import { Tooltip, TooltipProvider } from "./suggestions-tooltip";
 
 /**
  * Props for the MessageSuggestions component.
- * Extends standard HTMLDivElement attributes.
+ * Extends the base root props.
  */
-export interface MessageSuggestionsProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** Maximum number of suggestions to display (default: 3) */
-  maxSuggestions?: number;
-  /** The child elements to render within the container. */
-  children?: React.ReactNode;
-  /** Pre-seeded suggestions to display initially */
-  initialSuggestions?: Suggestion[];
-}
+export type MessageSuggestionsProps = MessageSuggestionsRootProps;
 
 /**
  * The root container for message suggestions.
- * It establishes the context for its children and handles overall state management.
+ * Provides context for its children and handles overall state management.
  * @component MessageSuggestions
  * @example
  * ```tsx
@@ -79,151 +30,28 @@ export interface MessageSuggestionsProps extends React.HTMLAttributes<HTMLDivEle
  *   <MessageSuggestions.List />
  * </MessageSuggestions>
  * ```
+ * @returns The styled message suggestions container, or null if there is nothing to display.
  */
 const MessageSuggestions = React.forwardRef<
   HTMLDivElement,
   MessageSuggestionsProps
->(
-  (
-    {
-      children,
-      className,
-      maxSuggestions = 3,
-      initialSuggestions = [],
-      ...props
-    },
-    ref,
-  ) => {
-    const { thread } = useTambo();
-    const {
-      suggestions: generatedSuggestions,
-      selectedSuggestionId,
-      accept,
-      generateResult: { isPending: isGenerating, error },
-    } = useTamboSuggestions({ maxSuggestions });
-
-    // Combine initial and generated suggestions, but only use initial ones when thread is empty
-    const suggestions = React.useMemo(() => {
-      // Only use pre-seeded suggestions if thread is empty
-      if (!thread?.messages?.length && initialSuggestions.length > 0) {
-        return initialSuggestions.slice(0, maxSuggestions);
-      }
-      // Otherwise use generated suggestions
-      return generatedSuggestions;
-    }, [
-      thread?.messages?.length,
-      generatedSuggestions,
-      initialSuggestions,
-      maxSuggestions,
-    ]);
-
-    const isMac =
-      typeof navigator !== "undefined" && navigator.platform.startsWith("Mac");
-
-    // Track the last AI message ID to detect new messages
-    const lastAiMessageIdRef = useRef<string | null>(null);
-    const loadingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-    const contextValue = React.useMemo(
-      () => ({
-        suggestions,
-        selectedSuggestionId,
-        accept,
-        isGenerating,
-        error,
-        thread,
-        isMac,
-      }),
-      [
-        suggestions,
-        selectedSuggestionId,
-        accept,
-        isGenerating,
-        error,
-        thread,
-        isMac,
-      ],
-    );
-
-    // Find the last AI message
-    const lastAiMessage = thread?.messages
-      ? [...thread.messages].reverse().find((msg) => msg.role === "assistant")
-      : null;
-
-    // When a new AI message appears, update the reference
-    useEffect(() => {
-      if (lastAiMessage && lastAiMessage.id !== lastAiMessageIdRef.current) {
-        lastAiMessageIdRef.current = lastAiMessage.id;
-
-        if (loadingTimeoutRef.current) {
-          clearTimeout(loadingTimeoutRef.current);
-        }
-
-        loadingTimeoutRef.current = setTimeout(() => {}, 5000);
-      }
-
-      return () => {
-        if (loadingTimeoutRef.current) {
-          clearTimeout(loadingTimeoutRef.current);
-        }
-      };
-    }, [lastAiMessage, suggestions.length]);
-
-    // Handle keyboard shortcuts for selecting suggestions
-    useEffect(() => {
-      if (!suggestions || suggestions.length === 0) return;
-
-      const handleKeyDown = (event: KeyboardEvent) => {
-        const modifierPressed = isMac
-          ? event.metaKey && event.altKey
-          : event.ctrlKey && event.altKey;
-
-        if (modifierPressed) {
-          const keyNum = parseInt(event.key);
-          if (!isNaN(keyNum) && keyNum > 0 && keyNum <= suggestions.length) {
-            event.preventDefault();
-            const suggestionIndex = keyNum - 1;
-            void accept({ suggestion: suggestions[suggestionIndex] });
-          }
-        }
-      };
-
-      document.addEventListener("keydown", handleKeyDown);
-
-      return () => {
-        document.removeEventListener("keydown", handleKeyDown);
-      };
-    }, [suggestions, accept, isMac]);
-
-    // If we have no messages yet and no initial suggestions, render nothing
-    if (!thread?.messages?.length && initialSuggestions.length === 0) {
-      return null;
-    }
-
-    return (
-      <MessageSuggestionsContext.Provider value={contextValue}>
-        <TooltipProvider>
-          <div
-            ref={ref}
-            className={cn("px-4 pb-2", className)}
-            data-slot="message-suggestions-container"
-            {...props}
-          >
-            {children}
-          </div>
-        </TooltipProvider>
-      </MessageSuggestionsContext.Provider>
-    );
-  },
-);
+>(({ children, className, ...props }, ref) => {
+  return (
+    <MessageSuggestionsBase.Root
+      ref={ref}
+      className={cn("px-4 pb-2", className)}
+      {...props}
+    >
+      <TooltipProvider>{children}</TooltipProvider>
+    </MessageSuggestionsBase.Root>
+  );
+});
 MessageSuggestions.displayName = "MessageSuggestions";
 
 /**
  * Props for the MessageSuggestionsStatus component.
- * Extends standard HTMLDivElement attributes.
  */
-export type MessageSuggestionsStatusProps =
-  React.HTMLAttributes<HTMLDivElement>;
+export type MessageSuggestionsStatusProps = MessageSuggestionsBaseStatusProps;
 
 /**
  * Displays loading, error, or generation stage information.
@@ -236,61 +64,74 @@ export type MessageSuggestionsStatusProps =
  *   <MessageSuggestions.List />
  * </MessageSuggestions>
  * ```
+ * @returns The styled status display element.
  */
 const MessageSuggestionsStatus = React.forwardRef<
   HTMLDivElement,
   MessageSuggestionsStatusProps
 >(({ className, ...props }, ref) => {
-  const { error, isGenerating, thread } = useMessageSuggestionsContext();
-
   return (
-    <div
+    <MessageSuggestionsBase.Status
       ref={ref}
       className={cn(
         "p-2 rounded-md text-sm bg-transparent",
-        !error &&
-          !isGenerating &&
-          (!thread?.generationStage ||
-            thread.generationStage === GenerationStage.COMPLETE)
-          ? "p-0 min-h-0 mb-0"
-          : "",
+        "data-[idle]:p-0 data-[idle]:min-h-0 data-[idle]:mb-0",
         className,
       )}
-      data-slot="message-suggestions-status"
       {...props}
     >
-      {/* Error state */}
-      {error && (
-        <div className="p-2 rounded-md text-sm bg-red-50 text-red-500">
-          <p>{error.message}</p>
-        </div>
-      )}
-
-      {/* Always render a container for generation stage to prevent layout shifts */}
+      <StatusErrorContent />
       <div className="generation-stage-container">
-        <GenerationStageContent
-          generationStage={thread?.generationStage}
-          isGenerating={isGenerating}
-        />
+        <StatusGenerationContent />
       </div>
-    </div>
+    </MessageSuggestionsBase.Status>
   );
 });
 MessageSuggestionsStatus.displayName = "MessageSuggestions.Status";
 
 /**
- * Internal component to render generation stage content
+ * Internal component to render error content within the status area.
+ * @returns Error message display or null.
  */
-function GenerationStageContent({
-  generationStage,
-  isGenerating,
-}: {
-  generationStage?: string;
-  isGenerating: boolean;
-}) {
-  if (generationStage && generationStage !== GenerationStage.COMPLETE) {
-    return <MessageGenerationStage />;
+function StatusErrorContent() {
+  const { error } = useMessageSuggestionsContext();
+
+  if (!error) {
+    return null;
   }
+
+  return (
+    <div className="p-2 rounded-md text-sm bg-red-50 text-red-500">
+      <p>{error.message}</p>
+    </div>
+  );
+}
+
+/**
+ * Internal component to render generation stage or loading content.
+ * @returns Generation stage display, loading spinner, or null.
+ */
+function StatusGenerationContent() {
+  const { isGenerating, thread } = useMessageSuggestionsContext();
+  const generationStage = thread?.generationStage;
+
+  if (generationStage && generationStage !== "COMPLETE") {
+    return (
+      <MessageSuggestionsBase.GenerationStage
+        className="inline-flex items-center gap-2 px-2 py-1 text-xs rounded-md bg-transparent text-muted-foreground"
+        render={({
+          label,
+          showLabel,
+        }: MessageSuggestionsGenerationStageRenderProps) => (
+          <>
+            <Loader2Icon className="h-3 w-3 animate-spin" />
+            {showLabel && <span>{label}</span>}
+          </>
+        )}
+      />
+    );
+  }
+
   if (isGenerating) {
     return (
       <div className="flex items-center gap-2 text-muted-foreground">
@@ -299,99 +140,18 @@ function GenerationStageContent({
       </div>
     );
   }
+
   return null;
 }
 
 /**
  * Props for the MessageSuggestionsList component.
- * Extends standard HTMLDivElement attributes.
  */
 export type MessageSuggestionsListProps = React.HTMLAttributes<HTMLDivElement>;
 
 /**
- * Displays the list of suggestion buttons.
- * Automatically connects to the context to show the suggestions.
- * @component MessageSuggestions.List
- * @example
- * ```tsx
- * <MessageSuggestions>
- *   <MessageSuggestions.Status />
- *   <MessageSuggestions.List />
- * </MessageSuggestions>
- * ```
- */
-const MessageSuggestionsList = React.forwardRef<
-  HTMLDivElement,
-  MessageSuggestionsListProps
->(({ className, ...props }, ref) => {
-  const { suggestions, selectedSuggestionId, accept, isGenerating, isMac } =
-    useMessageSuggestionsContext();
-
-  const modKey = isMac ? "⌘" : "Ctrl";
-  const altKey = isMac ? "⌥" : "Alt";
-
-  // Create placeholder suggestions when there are no real suggestions
-  const placeholders = Array(3).fill(null);
-
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        "flex space-x-2 overflow-x-auto pb-2 rounded-md bg-transparent min-h-[2.5rem]",
-        isGenerating ? "opacity-70" : "",
-        className,
-      )}
-      data-slot="message-suggestions-list"
-      {...props}
-    >
-      {suggestions.length > 0
-        ? suggestions.map((suggestion, index) => (
-            <Tooltip
-              key={suggestion.id}
-              content={
-                <span suppressHydrationWarning>
-                  {modKey}+{altKey}+{index + 1}
-                </span>
-              }
-              side="top"
-            >
-              <button
-                className={cn(
-                  "py-2 px-2.5 rounded-2xl text-xs transition-colors",
-                  "border border-flat",
-                  getSuggestionButtonClassName({
-                    isGenerating,
-                    isSelected: selectedSuggestionId === suggestion.id,
-                  }),
-                )}
-                onClick={async () =>
-                  !isGenerating && (await accept({ suggestion }))
-                }
-                disabled={isGenerating}
-                data-suggestion-id={suggestion.id}
-                data-suggestion-index={index}
-              >
-                <span className="font-medium">{suggestion.title}</span>
-              </button>
-            </Tooltip>
-          ))
-        : // Render placeholder buttons when no suggestions are available
-          placeholders.map((_, index) => (
-            <div
-              key={`placeholder-${index}`}
-              className="py-2 px-2.5 rounded-2xl text-xs border border-flat bg-muted/20 text-transparent animate-pulse"
-              data-placeholder-index={index}
-            >
-              <span className="invisible">Placeholder</span>
-            </div>
-          ))}
-    </div>
-  );
-});
-MessageSuggestionsList.displayName = "MessageSuggestions.List";
-
-/**
- * Internal function to get className for suggestion button based on state
+ * Internal function to get className for suggestion button based on state.
+ * @returns The appropriate Tailwind class string.
  */
 function getSuggestionButtonClassName({
   isGenerating,
@@ -408,6 +168,83 @@ function getSuggestionButtonClassName({
   }
   return "bg-background hover:bg-accent hover:text-accent-foreground";
 }
+
+/**
+ * Displays the list of suggestion buttons.
+ * Automatically connects to the context to show the suggestions.
+ * @component MessageSuggestions.List
+ * @example
+ * ```tsx
+ * <MessageSuggestions>
+ *   <MessageSuggestions.Status />
+ *   <MessageSuggestions.List />
+ * </MessageSuggestions>
+ * ```
+ * @returns The styled suggestion list element.
+ */
+const MessageSuggestionsList = React.forwardRef<
+  HTMLDivElement,
+  MessageSuggestionsListProps
+>(({ className, ...props }, ref) => {
+  return (
+    <MessageSuggestionsBase.List
+      ref={ref}
+      className={cn(
+        "flex space-x-2 overflow-x-auto pb-2 rounded-md bg-transparent min-h-[2.5rem]",
+        "data-[generating]:opacity-70",
+        className,
+      )}
+      render={({
+        suggestions,
+        isGenerating,
+        selectedSuggestionId,
+        modKey,
+        altKey,
+      }: MessageSuggestionsListRenderProps) => (
+        <>
+          {suggestions.length > 0
+            ? suggestions.map((suggestion, index) => (
+                <Tooltip
+                  key={suggestion.id}
+                  content={
+                    <span suppressHydrationWarning>
+                      {modKey}+{altKey}+{index + 1}
+                    </span>
+                  }
+                  side="top"
+                >
+                  <MessageSuggestionsBase.Item
+                    suggestion={suggestion}
+                    index={index}
+                    className={cn(
+                      "py-2 px-2.5 rounded-2xl text-xs transition-colors",
+                      "border border-flat",
+                      getSuggestionButtonClassName({
+                        isGenerating,
+                        isSelected: selectedSuggestionId === suggestion.id,
+                      }),
+                    )}
+                  >
+                    <span className="font-medium">{suggestion.title}</span>
+                  </MessageSuggestionsBase.Item>
+                </Tooltip>
+              ))
+            : Array.from({ length: 3 }, (_, index) => (
+                <div
+                  key={`placeholder-${index}`}
+                  className="py-2 px-2.5 rounded-2xl text-xs border border-flat bg-muted/20 text-transparent animate-pulse"
+                  data-placeholder-index={index}
+                >
+                  <span className="invisible">Placeholder</span>
+                </div>
+              ))}
+        </>
+      )}
+      {...props}
+    />
+  );
+});
+MessageSuggestionsList.displayName = "MessageSuggestions.List";
 
 export {
   MessageSuggestions,

--- a/packages/ui-registry/src/components/scrollable-message-container/config.json
+++ b/packages/ui-registry/src/components/scrollable-message-container/config.json
@@ -2,13 +2,41 @@
   "name": "scrollable-message-container",
   "description": "A container that scrolls to the bottom when new messages are added",
   "componentName": "ScrollableMessageContainer",
-  "dependencies": ["@tambo-ai/react"],
+  "dependencies": ["@tambo-ai/react", "@tambo-ai/react-ui-base@next"],
   "devDependencies": [],
   "requires": [],
   "files": [
     {
       "name": "scrollable-message-container.tsx",
       "content": "src/registry/scrollable-message-container/scrollable-message-container.tsx"
+    },
+    {
+      "name": "base/scrollable-message-container/index.tsx",
+      "content": "src/registry/base/scrollable-message-container/index.tsx"
+    },
+    {
+      "name": "base/scrollable-message-container/root/scrollable-message-container-root.tsx",
+      "content": "src/registry/base/scrollable-message-container/root/scrollable-message-container-root.tsx"
+    },
+    {
+      "name": "base/scrollable-message-container/root/scrollable-message-container-root-context.tsx",
+      "content": "src/registry/base/scrollable-message-container/root/scrollable-message-container-root-context.tsx"
+    },
+    {
+      "name": "base/scrollable-message-container/viewport/scrollable-message-container-viewport.tsx",
+      "content": "src/registry/base/scrollable-message-container/viewport/scrollable-message-container-viewport.tsx"
+    },
+    {
+      "name": "base/scrollable-message-container/scroll-to-bottom/scrollable-message-container-scroll-to-bottom.tsx",
+      "content": "src/registry/base/scrollable-message-container/scroll-to-bottom/scrollable-message-container-scroll-to-bottom.tsx"
+    },
+    {
+      "name": "base/types/component-render-or-children.ts",
+      "content": "src/registry/base/types/component-render-or-children.ts"
+    },
+    {
+      "name": "base/use-render/use-render.ts",
+      "content": "src/registry/base/use-render/use-render.ts"
     }
   ]
 }

--- a/packages/ui-registry/src/components/scrollable-message-container/scrollable-message-container.tsx
+++ b/packages/ui-registry/src/components/scrollable-message-container/scrollable-message-container.tsx
@@ -1,19 +1,26 @@
 "use client";
 
-import { GenerationStage, useTambo } from "@tambo-ai/react";
+import {
+  ScrollableMessageContainer as ScrollableMessageContainerBase,
+  type ScrollableMessageContainerViewportProps,
+} from "@tambo-ai/react-ui-base/scrollable-message-container";
 import { cn } from "@tambo-ai/ui-registry/utils";
 import * as React from "react";
-import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 
 /**
- * Props for the ScrollableMessageContainer component
+ * Props for the ScrollableMessageContainer component.
  */
 export type ScrollableMessageContainerProps =
-  React.HTMLAttributes<HTMLDivElement>;
+  ScrollableMessageContainerViewportProps &
+    React.HTMLAttributes<HTMLDivElement>;
 
 /**
  * A scrollable container for message content with auto-scroll functionality.
  * Used across message thread components for consistent scrolling behavior.
+ *
+ * This is a styled wrapper around the base ScrollableMessageContainer compound
+ * component. It composes Root and Viewport into a single element for backwards
+ * compatibility with the original non-compound API.
  *
  * @example
  * ```tsx
@@ -23,97 +30,29 @@ export type ScrollableMessageContainerProps =
  *   </ThreadContent>
  * </ScrollableMessageContainer>
  * ```
+ * @returns A scrollable container element with auto-scroll behavior
  */
 export const ScrollableMessageContainer = React.forwardRef<
   HTMLDivElement,
   ScrollableMessageContainerProps
 >(({ className, children, ...props }, ref) => {
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const { thread } = useTambo();
-  const [shouldAutoscroll, setShouldAutoscroll] = useState(true);
-  const lastScrollTopRef = useRef(0);
-
-  // Handle forwarded ref
-  React.useImperativeHandle(ref, () => scrollContainerRef.current!, []);
-
-  // Create a dependency that represents all content that should trigger autoscroll
-  const messagesContent = useMemo(() => {
-    if (!thread.messages) return null;
-
-    return thread.messages.map((message) => ({
-      id: message.id,
-      content: message.content,
-      tool_calls: message.tool_calls,
-      component: message.component,
-      reasoning: message.reasoning,
-      componentState: message.componentState,
-    }));
-  }, [thread.messages]);
-
-  const generationStage = useMemo(
-    () => thread?.generationStage ?? GenerationStage.IDLE,
-    [thread?.generationStage],
-  );
-
-  // Handle scroll events to detect user scrolling
-  const handleScroll = useCallback(() => {
-    if (!scrollContainerRef.current) return;
-
-    const { scrollTop, scrollHeight, clientHeight } =
-      scrollContainerRef.current;
-    const isAtBottom = Math.abs(scrollHeight - scrollTop - clientHeight) < 8; // 8px tolerance for rounding
-
-    // If user scrolled up, disable autoscroll
-    if (scrollTop < lastScrollTopRef.current) {
-      setShouldAutoscroll(false);
-    }
-    // If user is at bottom, enable autoscroll
-    else if (isAtBottom) {
-      setShouldAutoscroll(true);
-    }
-
-    lastScrollTopRef.current = scrollTop;
-  }, []);
-
-  // Auto-scroll to bottom when message content changes
-  useEffect(() => {
-    if (scrollContainerRef.current && messagesContent && shouldAutoscroll) {
-      const scroll = () => {
-        if (scrollContainerRef.current) {
-          scrollContainerRef.current.scrollTo({
-            top: scrollContainerRef.current.scrollHeight,
-            behavior: "smooth",
-          });
-        }
-      };
-
-      if (generationStage === GenerationStage.STREAMING_RESPONSE) {
-        // During streaming, scroll immediately
-        requestAnimationFrame(scroll);
-      } else {
-        // For other updates, use a short delay to batch rapid changes
-        const timeoutId = setTimeout(scroll, 50);
-        return () => clearTimeout(timeoutId);
-      }
-    }
-  }, [messagesContent, generationStage, shouldAutoscroll]);
-
   return (
-    <div
-      ref={scrollContainerRef}
-      onScroll={handleScroll}
-      className={cn(
-        "flex-1 overflow-y-auto",
-        "[&::-webkit-scrollbar]:w-[6px]",
-        "[&::-webkit-scrollbar-thumb]:bg-muted-foreground/30",
-        "[&::-webkit-scrollbar:horizontal]:h-[4px]",
-        className,
-      )}
-      data-slot="scrollable-message-container"
-      {...props}
-    >
-      {children}
-    </div>
+    <ScrollableMessageContainerBase.Root asChild>
+      <ScrollableMessageContainerBase.Viewport
+        ref={ref}
+        className={cn(
+          "flex-1 overflow-y-auto",
+          "[&::-webkit-scrollbar]:w-[6px]",
+          "[&::-webkit-scrollbar-thumb]:bg-muted-foreground/30",
+          "[&::-webkit-scrollbar:horizontal]:h-[4px]",
+          className,
+        )}
+        data-slot="scrollable-message-container"
+        {...props}
+      >
+        {children}
+      </ScrollableMessageContainerBase.Viewport>
+    </ScrollableMessageContainerBase.Root>
   );
 });
 ScrollableMessageContainer.displayName = "ScrollableMessageContainer";

--- a/packages/ui-registry/src/components/thread-content/thread-content.tsx
+++ b/packages/ui-registry/src/components/thread-content/thread-content.tsx
@@ -10,52 +10,23 @@ import {
   type messageVariants,
 } from "@tambo-ai/ui-registry/components/message";
 import { cn } from "@tambo-ai/ui-registry/utils";
-import { type TamboThreadMessage, useTambo } from "@tambo-ai/react";
+import {
+  getMessageKey,
+  ThreadContent as ThreadContentBase,
+  type ThreadContentMessageListRenderProps,
+  type ThreadContentRootProps as ThreadContentBaseRootProps,
+} from "@tambo-ai/react-ui-base/thread-content";
 import { type VariantProps } from "class-variance-authority";
 import * as React from "react";
-
-/**
- * @typedef ThreadContentContextValue
- * @property {Array} messages - Array of message objects in the thread
- * @property {boolean} isGenerating - Whether a response is being generated
- * @property {string|undefined} generationStage - Current generation stage
- * @property {VariantProps<typeof messageVariants>["variant"]} [variant] - Optional styling variant for messages
- */
-interface ThreadContentContextValue {
-  messages: TamboThreadMessage[];
-  isGenerating: boolean;
-  generationStage?: string;
-  variant?: VariantProps<typeof messageVariants>["variant"];
-}
-
-/**
- * React Context for sharing thread data among sub-components.
- * @internal
- */
-const ThreadContentContext =
-  React.createContext<ThreadContentContextValue | null>(null);
-
-/**
- * Hook to access the thread content context.
- * @returns {ThreadContentContextValue} The thread content context value.
- * @throws {Error} If used outside of ThreadContent.
- * @internal
- */
-const useThreadContentContext = () => {
-  const context = React.useContext(ThreadContentContext);
-  if (!context) {
-    throw new Error(
-      "ThreadContent sub-components must be used within a ThreadContent",
-    );
-  }
-  return context;
-};
 
 /**
  * Props for the ThreadContent component.
  * Extends standard HTMLDivElement attributes.
  */
-export interface ThreadContentProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ThreadContentProps extends Omit<
+  ThreadContentBaseRootProps,
+  "asChild"
+> {
   /** Optional styling variant for the message container */
   variant?: VariantProps<typeof messageVariants>["variant"];
   /** The child elements to render within the container. */
@@ -72,37 +43,32 @@ export interface ThreadContentProps extends React.HTMLAttributes<HTMLDivElement>
  *   <ThreadContent.Messages />
  * </ThreadContent>
  * ```
+ * @returns The thread content root element
  */
 const ThreadContent = React.forwardRef<HTMLDivElement, ThreadContentProps>(
   ({ children, className, variant, ...props }, ref) => {
-    const { thread, generationStage, isIdle } = useTambo();
-    const isGenerating = !isIdle;
-
-    const contextValue = React.useMemo(
-      () => ({
-        messages: thread?.messages ?? [],
-        isGenerating,
-        generationStage,
-        variant,
-      }),
-      [thread?.messages, isGenerating, generationStage, variant],
-    );
-
     return (
-      <ThreadContentContext.Provider value={contextValue}>
-        <div
+      <ThreadContentVariantContext.Provider value={variant}>
+        <ThreadContentBase.Root
           ref={ref}
           className={cn("w-full", className)}
-          data-slot="thread-content-container"
           {...props}
         >
           {children}
-        </div>
-      </ThreadContentContext.Provider>
+        </ThreadContentBase.Root>
+      </ThreadContentVariantContext.Provider>
     );
   },
 );
 ThreadContent.displayName = "ThreadContent";
+
+/**
+ * Internal context to pass variant down to message list without
+ * coupling it to the base component's context.
+ */
+const ThreadContentVariantContext = React.createContext<
+  VariantProps<typeof messageVariants>["variant"] | undefined
+>(undefined);
 
 /**
  * Props for the ThreadContentMessages component.
@@ -120,32 +86,29 @@ export type ThreadContentMessagesProps = React.HTMLAttributes<HTMLDivElement>;
  *   <ThreadContent.Messages />
  * </ThreadContent>
  * ```
+ * @returns The message list element
  */
 const ThreadContentMessages = React.forwardRef<
   HTMLDivElement,
   ThreadContentMessagesProps
 >(({ className, ...props }, ref) => {
-  const { messages, isGenerating, variant } = useThreadContentContext();
-
-  const filteredMessages = messages.filter(
-    (message) => message.role !== "system" && !message.parentMessageId,
-  );
+  const variant = React.useContext(ThreadContentVariantContext);
 
   return (
-    <div
+    <ThreadContentBase.MessageList
       ref={ref}
       className={cn("flex flex-col gap-2", className)}
-      data-slot="thread-content-messages"
-      {...props}
-    >
-      {filteredMessages.map((message, index) => {
-        return (
-          <div
-            key={
-              message.id ??
-              `${message.role}-${message.createdAt ?? `${index}`}-${message.content?.toString().substring(0, 10)}`
-            }
-            data-slot="thread-content-item"
+      render={({
+        messages: filteredMessages,
+        isGenerating,
+      }: ThreadContentMessageListRenderProps) =>
+        filteredMessages.map((message, index) => (
+          <ThreadContentBase.Message
+            key={getMessageKey(message, index)}
+            message={message}
+            index={index}
+            total={filteredMessages.length}
+            isGenerating={isGenerating}
           >
             <Message
               role={message.role === "assistant" ? "assistant" : "user"}
@@ -176,10 +139,11 @@ const ThreadContentMessages = React.forwardRef<
                 <MessageRenderedComponentArea className="w-full" />
               </div>
             </Message>
-          </div>
-        );
-      })}
-    </div>
+          </ThreadContentBase.Message>
+        ))
+      }
+      {...props}
+    />
   );
 });
 ThreadContentMessages.displayName = "ThreadContent.Messages";

--- a/packages/ui-registry/src/components/thread-dropdown/config.json
+++ b/packages/ui-registry/src/components/thread-dropdown/config.json
@@ -3,8 +3,8 @@
   "description": "Displays and manages a dropdown menu for collapsible chat threads",
   "componentName": "ThreadDropdown",
   "dependencies": [
-    "class-variance-authority",
     "@tambo-ai/react",
+    "@tambo-ai/react-ui-base@next",
     "lucide-react",
     "radix-ui"
   ],

--- a/packages/ui-registry/src/components/thread-history/thread-history.tsx
+++ b/packages/ui-registry/src/components/thread-history/thread-history.tsx
@@ -2,11 +2,11 @@
 
 import { cn } from "@tambo-ai/ui-registry/utils";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { type TamboThread, useTamboThread } from "@tambo-ai/react";
 import {
-  type TamboThread,
-  useTamboThread,
-  useTamboThreadList,
-} from "@tambo-ai/react";
+  ThreadHistory as ThreadHistoryBase,
+  type ThreadHistoryListRenderProps,
+} from "@tambo-ai/react-ui-base/thread-history";
 import {
   ArrowLeftToLine,
   ArrowRightToLine,
@@ -16,44 +16,12 @@ import {
   SearchIcon,
   Sparkles,
 } from "lucide-react";
-import React, { useMemo } from "react";
+import React from "react";
 
 /**
- * Context for sharing thread history state and functions
- */
-interface ThreadHistoryContextValue {
-  threads: { items?: TamboThread[] } | null | undefined;
-  isLoading: boolean;
-  error: Error | null;
-  refetch: () => Promise<unknown>;
-  currentThread: TamboThread;
-  switchCurrentThread: (threadId: string) => void;
-  startNewThread: () => void;
-  searchQuery: string;
-  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
-  isCollapsed: boolean;
-  setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
-  onThreadChange?: () => void;
-  position?: "left" | "right";
-  updateThreadName: (newName: string, threadId?: string) => Promise<void>;
-  generateThreadName: (threadId: string) => Promise<TamboThread>;
-}
-
-const ThreadHistoryContext =
-  React.createContext<ThreadHistoryContextValue | null>(null);
-
-const useThreadHistoryContext = () => {
-  const context = React.useContext(ThreadHistoryContext);
-  if (!context) {
-    throw new Error(
-      "ThreadHistory components must be used within ThreadHistory",
-    );
-  }
-  return context;
-};
-
-/**
- * Root component that provides context for thread history
+ * Root component that provides context for thread history.
+ * Wraps the base ThreadHistory.Root with Tailwind styling.
+ * @returns A styled thread history sidebar
  */
 interface ThreadHistoryProps extends React.HTMLAttributes<HTMLDivElement> {
   onThreadChange?: () => void;
@@ -74,303 +42,191 @@ const ThreadHistory = React.forwardRef<HTMLDivElement, ThreadHistoryProps>(
     },
     ref,
   ) => {
-    const [searchQuery, setSearchQuery] = React.useState("");
-    const [isCollapsed, setIsCollapsed] = React.useState(defaultCollapsed);
-    const [shouldFocusSearch, setShouldFocusSearch] = React.useState(false);
-
-    const { data: threads, isLoading, error, refetch } = useTamboThreadList();
-
-    const {
-      switchCurrentThread,
-      startNewThread,
-      thread: currentThread,
-      updateThreadName,
-      generateThreadName,
-    } = useTamboThread();
-
-    // Update CSS variable when sidebar collapses/expands
-    React.useEffect(() => {
-      const sidebarWidth = isCollapsed ? "3rem" : "16rem";
-      document.documentElement.style.setProperty(
-        "--sidebar-width",
-        sidebarWidth,
-      );
-    }, [isCollapsed]);
-
-    // Focus search input when expanded from collapsed state
-    React.useEffect(() => {
-      if (!isCollapsed && shouldFocusSearch) {
-        setShouldFocusSearch(false);
-      }
-    }, [isCollapsed, shouldFocusSearch]);
-
-    const contextValue = React.useMemo(
-      () => ({
-        threads,
-        isLoading,
-        error,
-        refetch,
-        currentThread,
-        switchCurrentThread,
-        startNewThread,
-        searchQuery,
-        setSearchQuery,
-        isCollapsed,
-        setIsCollapsed,
-        onThreadChange,
-        position,
-        updateThreadName,
-        generateThreadName,
-      }),
-      [
-        threads,
-        isLoading,
-        error,
-        refetch,
-        currentThread,
-        switchCurrentThread,
-        startNewThread,
-        searchQuery,
-        isCollapsed,
-        onThreadChange,
-        position,
-        updateThreadName,
-        generateThreadName,
-      ],
-    );
-
     return (
-      <ThreadHistoryContext.Provider
-        value={contextValue as ThreadHistoryContextValue}
+      <ThreadHistoryBase.Root
+        ref={ref}
+        onThreadChange={onThreadChange}
+        defaultCollapsed={defaultCollapsed}
+        position={position}
+        className={cn(
+          "border-flat bg-container h-full transition-all duration-300 flex-none",
+          position === "left" ? "border-r" : "border-l",
+          className,
+        )}
+        {...props}
       >
-        <div
-          ref={ref}
-          className={cn(
-            "border-flat bg-container h-full transition-all duration-300 flex-none",
-            position === "left" ? "border-r" : "border-l",
-            isCollapsed ? "w-12" : "w-64",
-            className,
-          )}
-          {...props}
-        >
+        {({ isCollapsed }) => (
           <div
             className={cn(
               "flex flex-col h-full",
               isCollapsed ? "py-4 px-2" : "p-4",
-            )} // py-4 px-2 is for better alignment when isCollapsed
+            )}
           >
             {children}
           </div>
-        </div>
-      </ThreadHistoryContext.Provider>
+        )}
+      </ThreadHistoryBase.Root>
     );
   },
 );
 ThreadHistory.displayName = "ThreadHistory";
 
 /**
- * Header component with title and collapse toggle
+ * Header component with title and collapse toggle.
+ * @returns A styled header with collapse toggle button
  */
 const ThreadHistoryHeader = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const {
-    isCollapsed,
-    setIsCollapsed,
-    position = "left",
-  } = useThreadHistoryContext();
-
   return (
-    <div
+    <ThreadHistoryBase.Header
       ref={ref}
-      className={cn(
-        "flex items-center mb-4 relative",
-        isCollapsed ? "p-1" : "p-1",
-        className,
-      )}
+      className={cn("flex items-center mb-4 relative p-1", className)}
       {...props}
     >
-      <h2
-        className={cn(
-          "text-sm text-muted-foreground whitespace-nowrap ",
-          isCollapsed
-            ? "opacity-0 max-w-0 overflow-hidden "
-            : "opacity-100 max-w-none transition-all duration-300 delay-75",
-        )}
-      >
-        Tambo Conversations
-      </h2>
-      <button
-        onClick={() => setIsCollapsed(!isCollapsed)}
-        className={cn(
-          `bg-container p-1 hover:bg-backdrop transition-colors rounded-md cursor-pointer absolute flex items-center justify-center`,
-          position === "left" ? "right-1" : "left-0",
-        )}
-        aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-      >
-        {isCollapsed ? (
-          <ArrowRightToLine
-            className={cn("h-4 w-4", position === "right" && "rotate-180")}
-          />
-        ) : (
-          <ArrowLeftToLine
-            className={cn("h-4 w-4", position === "right" && "rotate-180")}
-          />
-        )}
-      </button>
-    </div>
+      {({ isCollapsed, position }) => (
+        <>
+          <h2
+            className={cn(
+              "text-sm text-muted-foreground whitespace-nowrap",
+              isCollapsed
+                ? "opacity-0 max-w-0 overflow-hidden"
+                : "opacity-100 max-w-none transition-all duration-300 delay-75",
+            )}
+          >
+            Tambo Conversations
+          </h2>
+          <ThreadHistoryBase.CollapseToggle
+            className={cn(
+              "bg-container p-1 hover:bg-backdrop transition-colors rounded-md cursor-pointer absolute flex items-center justify-center",
+              position === "left" ? "right-1" : "left-0",
+            )}
+          >
+            {isCollapsed ? (
+              <ArrowRightToLine
+                className={cn("h-4 w-4", position === "right" && "rotate-180")}
+              />
+            ) : (
+              <ArrowLeftToLine
+                className={cn("h-4 w-4", position === "right" && "rotate-180")}
+              />
+            )}
+          </ThreadHistoryBase.CollapseToggle>
+        </>
+      )}
+    </ThreadHistoryBase.Header>
   );
 });
 ThreadHistoryHeader.displayName = "ThreadHistory.Header";
 
 /**
- * Button to create a new thread
+ * Button to create a new thread.
+ * @returns A styled button that creates a new thread
  */
 const ThreadHistoryNewButton = React.forwardRef<
   HTMLButtonElement,
   React.ButtonHTMLAttributes<HTMLButtonElement>
 >(({ ...props }, ref) => {
-  const { isCollapsed, startNewThread, refetch, onThreadChange } =
-    useThreadHistoryContext();
-
-  const handleNewThread = React.useCallback(
-    async (e?: React.MouseEvent) => {
-      if (e) e.stopPropagation();
-
-      try {
-        await startNewThread();
-        await refetch();
-        onThreadChange?.();
-      } catch (error) {
-        console.error("Failed to create new thread:", error);
-      }
-    },
-    [startNewThread, refetch, onThreadChange],
-  );
-
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.altKey && event.shiftKey && event.key === "n") {
-        event.preventDefault();
-        void handleNewThread();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleNewThread]);
-
   return (
-    <button
+    <ThreadHistoryBase.NewThreadButton
       ref={ref}
-      onClick={handleNewThread}
       className={cn(
         "flex items-center rounded-md mb-4 hover:bg-backdrop transition-colors cursor-pointer relative",
-        isCollapsed ? "p-1 justify-center" : "p-2 gap-2",
       )}
-      title="New thread"
       {...props}
     >
-      <PlusIcon className="h-4 w-4 bg-green-600 rounded-full text-white" />
-      <span
-        className={cn(
-          "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px] ",
-          isCollapsed
-            ? "opacity-0 max-w-0 overflow-hidden pointer-events-none"
-            : "opacity-100 transition-all duration-300 delay-100",
-        )}
-      >
-        New thread
-      </span>
-    </button>
+      {({ isCollapsed }) => (
+        <>
+          <div className={cn(isCollapsed ? "p-1 mx-auto" : "p-2")}>
+            <PlusIcon className="h-4 w-4 bg-green-600 rounded-full text-white" />
+          </div>
+          <span
+            className={cn(
+              "text-sm font-medium whitespace-nowrap absolute left-8 pb-[2px]",
+              isCollapsed
+                ? "opacity-0 max-w-0 overflow-hidden pointer-events-none"
+                : "opacity-100 transition-all duration-300 delay-100",
+            )}
+          >
+            New thread
+          </span>
+        </>
+      )}
+    </ThreadHistoryBase.NewThreadButton>
   );
 });
 ThreadHistoryNewButton.displayName = "ThreadHistory.NewButton";
 
 /**
- * Search input for filtering threads
+ * Search input for filtering threads.
+ * @returns A styled search input container
  */
 const ThreadHistorySearch = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const { isCollapsed, setIsCollapsed, searchQuery, setSearchQuery } =
-    useThreadHistoryContext();
-  const searchInputRef = React.useRef<HTMLInputElement>(null);
-
-  const expandOnSearch = () => {
-    if (isCollapsed) {
-      setIsCollapsed(false);
-      setTimeout(() => {
-        searchInputRef.current?.focus();
-      }, 300); // Wait for animation
-    }
-  };
-
   return (
-    <div ref={ref} className={cn("mb-4 relative", className)} {...props}>
-      {/*visible when collapsed */}
-      <button
-        onClick={expandOnSearch}
-        className={cn(
-          "p-1 hover:bg-backdrop rounded-md cursor-pointer absolute left-1/2 -translate-x-1/2",
-          isCollapsed
-            ? "opacity-100 pointer-events-auto transition-all duration-300"
-            : "opacity-0 pointer-events-none",
-        )}
-        title="Search threads"
-      >
-        <SearchIcon className="h-4 w-4 text-gray-400" />
-      </button>
-
-      {/*visible when expanded with delay */}
-
-      <div
-        className={cn(
-          //using this as wrapper
-          isCollapsed
-            ? "opacity-0 pointer-events-none"
-            : "opacity-100 delay-100 transition-all duration-500",
-        )}
-      >
-        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-          <SearchIcon className="h-4 w-4 text-gray-400" />
-        </div>
-        <input
-          ref={searchInputRef}
-          type="text"
-          className="pl-10 pr-4 py-2 w-full text-sm rounded-md bg-container focus:outline-none"
-          placeholder="Search..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
-      </div>
-    </div>
+    <ThreadHistoryBase.SearchInput
+      ref={ref}
+      className={cn("mb-4 relative", className)}
+      {...props}
+    >
+      {({
+        isCollapsed,
+        searchQuery,
+        setSearchQuery,
+        expandOnSearch,
+        searchInputRef,
+      }) => (
+        <>
+          <button
+            onClick={expandOnSearch}
+            className={cn(
+              "p-1 hover:bg-backdrop rounded-md cursor-pointer absolute left-1/2 -translate-x-1/2",
+              isCollapsed
+                ? "opacity-100 pointer-events-auto transition-all duration-300"
+                : "opacity-0 pointer-events-none",
+            )}
+            title="Search threads"
+          >
+            <SearchIcon className="h-4 w-4 text-gray-400" />
+          </button>
+          <div
+            className={cn(
+              isCollapsed
+                ? "opacity-0 pointer-events-none"
+                : "opacity-100 delay-100 transition-all duration-500",
+            )}
+          >
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <SearchIcon className="h-4 w-4 text-gray-400" />
+            </div>
+            <input
+              ref={searchInputRef}
+              type="text"
+              className="pl-10 pr-4 py-2 w-full text-sm rounded-md bg-container focus:outline-none"
+              placeholder="Search..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+          </div>
+        </>
+      )}
+    </ThreadHistoryBase.SearchInput>
   );
 });
 ThreadHistorySearch.displayName = "ThreadHistory.Search";
 
 /**
- * List of thread items
+ * List of thread items.
+ * @returns A styled list of thread items with loading/error/empty states
  */
 const ThreadHistoryList = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const {
-    threads,
-    isLoading,
-    error,
-    isCollapsed,
-    searchQuery,
-    currentThread,
-    switchCurrentThread,
-    onThreadChange,
-    updateThreadName,
-    generateThreadName,
-    refetch,
-  } = useThreadHistoryContext();
+  const { updateThreadName, generateThreadName } = useTamboThread();
 
   const [editingThread, setEditingThread] = React.useState<TamboThread | null>(
     null,
@@ -412,183 +268,160 @@ const ThreadHistoryList = React.forwardRef<
     }
   };
 
-  // Filter threads based on search query
-  const filteredThreads = useMemo(() => {
-    // While collapsed we do not need the list, avoid extra work.
-    if (isCollapsed) return [];
-
-    if (!threads?.items) return [];
-
-    const query = searchQuery.toLowerCase();
-    return threads.items.filter((thread: TamboThread) => {
-      const nameMatches = thread.name?.toLowerCase().includes(query) ?? false;
-      const idMatches = thread.id.toLowerCase().includes(query);
-
-      return idMatches ? true : nameMatches;
-    });
-  }, [isCollapsed, threads, searchQuery]);
-
-  const handleSwitchThread = async (threadId: string, e?: React.MouseEvent) => {
-    if (e) e.stopPropagation();
-
-    try {
-      switchCurrentThread(threadId);
-      onThreadChange?.();
-    } catch (error) {
-      console.error("Failed to switch thread:", error);
-    }
-  };
-
-  const handleRename = (thread: TamboThread) => {
-    setEditingThread(thread);
-    setNewName(thread.name ?? "");
-  };
-
-  const handleGenerateName = async (thread: TamboThread) => {
-    try {
-      await generateThreadName(thread.id);
-      await refetch();
-    } catch (error) {
-      console.error("Failed to generate name:", error);
-    }
-  };
-
-  const handleNameSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!editingThread) return;
-
-    try {
-      await updateThreadName(newName, editingThread.id);
-      await refetch();
-      setEditingThread(null);
-    } catch (error) {
-      console.error("Failed to rename thread:", error);
-    }
-  };
-
-  // Content to show
-  let content;
-  if (isLoading) {
-    content = (
-      <div
-        ref={ref}
-        className={cn("text-sm text-muted-foreground p-2", className)}
-        {...props}
-      >
-        Loading threads...
-      </div>
-    );
-  } else if (error) {
-    content = (
-      <div
-        ref={ref}
-        className={cn(
-          `text-sm text-destructive p-2 whitespace-nowrap ${isCollapsed ? "opacity-0 max-w-0 overflow-hidden" : "opacity-100"}`,
-          className,
-        )}
-        {...props}
-      >
-        Error loading threads
-      </div>
-    );
-  } else if (filteredThreads.length === 0) {
-    content = (
-      <div
-        ref={ref}
-        className={cn(
-          `text-sm text-muted-foreground p-2 whitespace-nowrap ${isCollapsed ? "opacity-0 max-w-0 overflow-hidden" : "opacity-100"}`,
-          className,
-        )}
-        {...props}
-      >
-        {searchQuery ? "No matching threads" : "No previous threads"}
-      </div>
-    );
-  } else {
-    content = (
-      <div className="space-y-1">
-        {filteredThreads.map((thread: TamboThread) => (
-          <div
-            key={thread.id}
-            onClick={async () => await handleSwitchThread(thread.id)}
-            className={cn(
-              "p-2 rounded-md hover:bg-backdrop cursor-pointer group flex items-center justify-between",
-              currentThread?.id === thread.id ? "bg-muted" : "",
-              editingThread?.id === thread.id ? "bg-muted" : "",
-            )}
-          >
-            <div className="text-sm flex-1">
-              {editingThread?.id === thread.id ? (
-                <form
-                  onSubmit={handleNameSubmit}
-                  className="flex flex-col gap-1"
-                >
-                  <input
-                    ref={inputRef}
-                    type="text"
-                    value={newName}
-                    onChange={(e) => setNewName(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                    className="w-full bg-background px-1 text-sm font-medium focus:outline-none rounded-sm"
-                    onClick={(e) => e.stopPropagation()}
-                    placeholder="Thread name..."
-                  />
-                  <p className="text-xs text-muted-foreground truncate">
-                    {new Date(thread.createdAt).toLocaleString(undefined, {
-                      month: "short",
-                      day: "numeric",
-                      hour: "numeric",
-                      minute: "2-digit",
-                    })}
-                  </p>
-                </form>
-              ) : (
-                <>
-                  <span className="font-medium line-clamp-1">
-                    {thread.name ?? `Thread ${thread.id.substring(0, 8)}`}
-                  </span>
-                  <p className="text-xs text-muted-foreground truncate mt-1">
-                    {new Date(thread.createdAt).toLocaleString(undefined, {
-                      month: "short",
-                      day: "numeric",
-                      hour: "numeric",
-                      minute: "2-digit",
-                    })}
-                  </p>
-                </>
-              )}
-            </div>
-            <ThreadOptionsDropdown
-              thread={thread}
-              onRename={handleRename}
-              onGenerateName={handleGenerateName}
-            />
-          </div>
-        ))}
-      </div>
-    );
-  }
-
   return (
-    <div
+    <ThreadHistoryBase.List
       ref={ref}
       className={cn(
         "overflow-y-auto flex-1 transition-all duration-300 ease-in-out",
-        isCollapsed
-          ? "opacity-0 max-h-0 overflow-hidden pointer-events-none"
-          : "opacity-100 max-h-full pointer-events-auto",
         className,
       )}
       {...props}
-    >
-      {content}
-    </div>
+      render={({
+        filteredThreads,
+        isLoading,
+        error,
+        searchQuery,
+        isCollapsed,
+      }: ThreadHistoryListRenderProps) => {
+        if (isCollapsed) {
+          return null;
+        }
+
+        const handleRename = (thread: TamboThread) => {
+          setEditingThread(thread);
+          setNewName(thread.name ?? "");
+        };
+
+        const handleGenerateName = async (thread: TamboThread) => {
+          try {
+            await generateThreadName(thread.id);
+          } catch (err) {
+            console.error("Failed to generate name:", err);
+          }
+        };
+
+        const handleNameSubmit = async (e: React.FormEvent) => {
+          e.preventDefault();
+          if (!editingThread) return;
+
+          try {
+            await updateThreadName(newName, editingThread.id);
+            setEditingThread(null);
+          } catch (err) {
+            console.error("Failed to rename thread:", err);
+          }
+        };
+
+        if (isLoading) {
+          return (
+            <div className="text-sm text-muted-foreground p-2">
+              Loading threads...
+            </div>
+          );
+        }
+
+        if (error) {
+          return (
+            <div className="text-sm text-destructive p-2 whitespace-nowrap">
+              Error loading threads
+            </div>
+          );
+        }
+
+        if (filteredThreads.length === 0) {
+          return (
+            <div className="text-sm text-muted-foreground p-2 whitespace-nowrap">
+              {searchQuery ? "No matching threads" : "No previous threads"}
+            </div>
+          );
+        }
+
+        return (
+          <div className="space-y-1">
+            {filteredThreads.map((thread: TamboThread) => (
+              <ThreadHistoryBase.Item
+                key={thread.id}
+                thread={thread}
+                className={cn(
+                  "p-2 rounded-md hover:bg-backdrop cursor-pointer group flex items-center justify-between",
+                  editingThread?.id === thread.id ? "bg-muted" : "",
+                )}
+              >
+                {({ isActive }) => (
+                  <div
+                    className={cn(
+                      "flex items-center justify-between w-full",
+                      isActive ? "bg-muted rounded-md" : "",
+                    )}
+                  >
+                    <div className="text-sm flex-1">
+                      {editingThread?.id === thread.id ? (
+                        <form
+                          onSubmit={handleNameSubmit}
+                          className="flex flex-col gap-1"
+                        >
+                          <input
+                            ref={inputRef}
+                            type="text"
+                            value={newName}
+                            onChange={(e) => setNewName(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            className="w-full bg-background px-1 text-sm font-medium focus:outline-none rounded-sm"
+                            onClick={(e) => e.stopPropagation()}
+                            placeholder="Thread name..."
+                          />
+                          <p className="text-xs text-muted-foreground truncate">
+                            {new Date(thread.createdAt).toLocaleString(
+                              undefined,
+                              {
+                                month: "short",
+                                day: "numeric",
+                                hour: "numeric",
+                                minute: "2-digit",
+                              },
+                            )}
+                          </p>
+                        </form>
+                      ) : (
+                        <>
+                          <span className="font-medium line-clamp-1">
+                            {thread.name ??
+                              `Thread ${thread.id.substring(0, 8)}`}
+                          </span>
+                          <p className="text-xs text-muted-foreground truncate mt-1">
+                            {new Date(thread.createdAt).toLocaleString(
+                              undefined,
+                              {
+                                month: "short",
+                                day: "numeric",
+                                hour: "numeric",
+                                minute: "2-digit",
+                              },
+                            )}
+                          </p>
+                        </>
+                      )}
+                    </div>
+                    <ThreadOptionsDropdown
+                      thread={thread}
+                      onRename={handleRename}
+                      onGenerateName={handleGenerateName}
+                    />
+                  </div>
+                )}
+              </ThreadHistoryBase.Item>
+            ))}
+          </div>
+        );
+      }}
+    />
   );
 });
 ThreadHistoryList.displayName = "ThreadHistory.List";
 
 /**
- * Dropdown menu component for thread actions
+ * Dropdown menu component for thread actions.
+ * @returns A dropdown menu with rename and generate name options
  */
 const ThreadOptionsDropdown = ({
   thread,


### PR DESCRIPTION
## Summary

Refactors 12 components to use the compound component pattern, adding unstyled base primitives in `@tambo-ai/react-ui-base`:

- **canvas-space** (TAM-1047)
- **edit-with-tambo-button** (TAM-1049)
- **elicitation-ui** (TAM-1050)
- **form** (TAM-1051)
- **graph** (TAM-1052)
- **input-fields** (TAM-1053)
- **map** (TAM-1054)
- **message-suggestions** (TAM-1057)
- **scrollable-message-container** (TAM-1061)
- **thread-content** (TAM-1062)
- **thread-dropdown** (TAM-1063)
- **thread-history** (TAM-1064)

### Pattern Applied

Each component now follows the compound component architecture:

**Base Components** (`packages/react-ui-base/src/{component}/`):
- Root component with context provider
- Sub-components using `useRender` hook for render props
- `asChild` support via `@radix-ui/react-slot`
- `data-slot` attributes for styling hooks
- Subpath exports (e.g., `@tambo-ai/react-ui-base/canvas-space`)

**Styled Wrappers** (`packages/ui-registry/src/components/{component}/`):
- Import and compose base components
- Apply Tailwind styling
- Re-export with same API

### Changes

- Added 12 new compound component directories in `react-ui-base`
- Updated styled wrappers in `ui-registry` to use base components
- Added subpath exports to `package.json`
- Updated `index.ts` exports
- Added Jest `moduleNameMapper` for subpath resolution

## Test plan

- [x] `npm run check-types` passes
- [x] `npm run lint` passes (only pre-existing warnings)
- [x] `npm test` passes

## Next Steps

The following dependent components will be refactored in stacking PRs:
- control-bar (TAM-1048)
- mcp-components (TAM-1055)
- message-thread-collapsible (TAM-1058)
- message-thread-full (TAM-1059)
- message-thread-panel (TAM-1060)

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes TAM-1047, TAM-1049, TAM-1050, TAM-1051, TAM-1052, TAM-1053, TAM-1054, TAM-1057, TAM-1061, TAM-1062, TAM-1063, TAM-1064