### PR TITLE
feat(react-ui-base): add mcp-components compound component primitives

### DIFF
--- a/packages/react-ui-base/package.json
+++ b/packages/react-ui-base/package.json
@@ -63,6 +63,16 @@
         "default": "./dist/cjs/toolcall-info/index.cjs"
       }
     },
+    "./mcp-components": {
+      "import": {
+        "types": "./dist/esm/mcp-components/index.d.ts",
+        "default": "./dist/esm/mcp-components/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/mcp-components/index.d.ts",
+        "default": "./dist/cjs/mcp-components/index.cjs"
+      }
+    },
     "./types": {
       "import": {
         "types": "./dist/esm/types/index.d.ts",

--- a/packages/react-ui-base/src/index.ts
+++ b/packages/react-ui-base/src/index.ts
@@ -80,6 +80,43 @@ export type {
   ToolcallInfoTriggerProps,
 } from "./toolcall-info";
 
+// MCP Components
+export { McpPromptButton, McpResourceButton } from "./mcp-components";
+export {
+  extractPromptText,
+  isValidPromptData,
+  useMcpPromptButtonContext,
+  useMcpResourceButtonContext,
+  useOptionalMcpPromptButtonContext,
+  useOptionalMcpResourceButtonContext,
+} from "./mcp-components";
+export type {
+  McpPromptButtonContextValue,
+  McpPromptButtonItemProps,
+  McpPromptButtonItemRenderProps,
+  McpPromptButtonListProps,
+  McpPromptButtonListRenderProps,
+  McpPromptButtonMenuProps,
+  McpPromptButtonRootProps,
+  McpPromptButtonTriggerProps,
+  McpPromptButtonTriggerRenderProps,
+  McpPromptEntry,
+  McpResourceButtonContextValue,
+  McpResourceButtonItemProps,
+  McpResourceButtonItemRenderProps,
+  McpResourceButtonListProps,
+  McpResourceButtonListRenderProps,
+  McpResourceButtonMenuProps,
+  McpResourceButtonRootProps,
+  McpResourceButtonSearchInputProps,
+  McpResourceButtonSearchInputRenderProps,
+  McpResourceButtonTriggerProps,
+  McpResourceEntry,
+  PromptMessage,
+  PromptMessageContent,
+} from "./mcp-components";
+
+
 // Types
 export type {
   BaseProps,

--- a/packages/react-ui-base/src/mcp-components/index.tsx
+++ b/packages/react-ui-base/src/mcp-components/index.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+export { McpPromptButton } from "./prompt-button";
+export type {
+  McpPromptButtonContextValue,
+  McpPromptButtonItemProps,
+  McpPromptButtonItemRenderProps,
+  McpPromptButtonListProps,
+  McpPromptButtonListRenderProps,
+  McpPromptButtonMenuProps,
+  McpPromptButtonRootProps,
+  McpPromptButtonTriggerProps,
+  McpPromptButtonTriggerRenderProps,
+  McpPromptEntry,
+  PromptMessage,
+  PromptMessageContent,
+} from "./prompt-button";
+export {
+  extractPromptText,
+  isValidPromptData,
+  useMcpPromptButtonContext,
+  useOptionalMcpPromptButtonContext,
+} from "./prompt-button";
+
+export { McpResourceButton } from "./resource-button";
+export type {
+  McpResourceButtonContextValue,
+  McpResourceButtonItemProps,
+  McpResourceButtonItemRenderProps,
+  McpResourceButtonListProps,
+  McpResourceButtonListRenderProps,
+  McpResourceButtonMenuProps,
+  McpResourceButtonRootProps,
+  McpResourceButtonSearchInputProps,
+  McpResourceButtonSearchInputRenderProps,
+  McpResourceButtonTriggerProps,
+  McpResourceEntry,
+} from "./resource-button";
+export {
+  useMcpResourceButtonContext,
+  useOptionalMcpResourceButtonContext,
+} from "./resource-button";

--- a/packages/react-ui-base/src/mcp-components/prompt-button/index.tsx
+++ b/packages/react-ui-base/src/mcp-components/prompt-button/index.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { McpPromptButtonItem } from "./item/mcp-prompt-button-item";
+import { McpPromptButtonList } from "./list/mcp-prompt-button-list";
+import { McpPromptButtonMenu } from "./menu/mcp-prompt-button-menu";
+import { McpPromptButtonRoot } from "./root/mcp-prompt-button-root";
+import { McpPromptButtonTrigger } from "./trigger/mcp-prompt-button-trigger";
+
+/**
+ * McpPromptButton namespace containing all MCP prompt button base components.
+ */
+const McpPromptButton = {
+  Root: McpPromptButtonRoot,
+  Trigger: McpPromptButtonTrigger,
+  Menu: McpPromptButtonMenu,
+  List: McpPromptButtonList,
+  Item: McpPromptButtonItem,
+};
+
+export type {
+  McpPromptButtonItemProps,
+  McpPromptButtonItemRenderProps,
+} from "./item/mcp-prompt-button-item";
+export type {
+  McpPromptButtonListProps,
+  McpPromptButtonListRenderProps,
+} from "./list/mcp-prompt-button-list";
+export type { McpPromptButtonMenuProps } from "./menu/mcp-prompt-button-menu";
+export type {
+  McpPromptButtonContextValue,
+  McpPromptEntry,
+  PromptMessage,
+  PromptMessageContent,
+} from "./root/mcp-prompt-button-context";
+export {
+  useMcpPromptButtonContext,
+  useOptionalMcpPromptButtonContext,
+} from "./root/mcp-prompt-button-context";
+export type { McpPromptButtonRootProps } from "./root/mcp-prompt-button-root";
+export type {
+  McpPromptButtonTriggerProps,
+  McpPromptButtonTriggerRenderProps,
+} from "./trigger/mcp-prompt-button-trigger";
+export { extractPromptText, isValidPromptData } from "./utils";
+
+export { McpPromptButton };

--- a/packages/react-ui-base/src/mcp-components/prompt-button/item/mcp-prompt-button-item.tsx
+++ b/packages/react-ui-base/src/mcp-components/prompt-button/item/mcp-prompt-button-item.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import {
+  useMcpPromptButtonContext,
+  type McpPromptEntry,
+} from "../root/mcp-prompt-button-context";
+
+export interface McpPromptButtonItemRenderProps {
+  /** The prompt entry data */
+  prompt: McpPromptEntry;
+  /** The prompt name */
+  name: string;
+  /** The prompt description, if any */
+  description: string | undefined;
+}
+
+export interface McpPromptButtonItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "onClick" | "children"
+> {
+  /** When true, renders as a Slot, merging props into the child element. */
+  asChild?: boolean;
+  /** The prompt entry to render */
+  prompt: McpPromptEntry;
+  /** Optional click handler override (defaults to selecting the prompt) */
+  onSelect?: () => void;
+  /** Children as ReactNode or render function */
+  children?:
+    | React.ReactNode
+    | ((props: McpPromptButtonItemRenderProps) => React.ReactNode);
+}
+
+/**
+ * Item primitive for displaying a single prompt option.
+ * Renders a clickable item that selects the prompt when clicked.
+ * @returns The prompt item element
+ */
+export const McpPromptButtonItem = React.forwardRef<
+  HTMLDivElement,
+  McpPromptButtonItemProps
+>(({ prompt, onSelect, asChild, children, ...props }, ref) => {
+  const { onSelectPrompt } = useMcpPromptButtonContext();
+
+  const renderProps: McpPromptButtonItemRenderProps = {
+    prompt,
+    name: prompt.prompt.name,
+    description: prompt.prompt.description,
+  };
+
+  const handleClick = () => {
+    if (onSelect) {
+      onSelect();
+    } else {
+      onSelectPrompt(prompt.prompt.name);
+    }
+  };
+
+  const Comp = asChild ? Slot : "div";
+  const content =
+    typeof children === "function" ? children(renderProps) : children;
+
+  return (
+    <Comp
+      ref={ref}
+      role="menuitem"
+      tabIndex={0}
+      data-slot="mcp-prompt-button-item"
+      onClick={handleClick}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      {...props}
+    >
+      {content}
+    </Comp>
+  );
+});
+McpPromptButtonItem.displayName = "McpPromptButton.Item";

--- a/packages/react-ui-base/src/mcp-components/prompt-button/list/mcp-prompt-button-list.tsx
+++ b/packages/react-ui-base/src/mcp-components/prompt-button/list/mcp-prompt-button-list.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../../types/component-render-or-children";
+import { useRender } from "../../../use-render/use-render";
+import {
+  useMcpPromptButtonContext,
+  type McpPromptEntry,
+} from "../root/mcp-prompt-button-context";
+
+export interface McpPromptButtonListRenderProps {
+  /** List of available prompts */
+  promptList: McpPromptEntry[] | undefined;
+  /** Whether the list is loading */
+  isLoading: boolean;
+  /** Whether there are no prompts available */
+  isEmpty: boolean;
+}
+
+export type McpPromptButtonListProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLDivElement>,
+  McpPromptButtonListRenderProps
+>;
+
+/**
+ * List container primitive for prompt items.
+ * Provides render props with prompt list data for custom rendering.
+ * @returns The list container element
+ */
+export const McpPromptButtonList = React.forwardRef<
+  HTMLDivElement,
+  McpPromptButtonListProps
+>((props, ref) => {
+  const { promptList, isLoading } = useMcpPromptButtonContext();
+
+  const renderProps: McpPromptButtonListRenderProps = {
+    promptList,
+    isLoading,
+    isEmpty: !promptList || promptList.length === 0,
+  };
+
+  const { content, componentProps } = useRender(props, renderProps);
+  const { asChild, ...rest } = componentProps;
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp ref={ref} role="menu" data-slot="mcp-prompt-button-list" {...rest}>
+      {content}
+    </Comp>
+  );
+});
+McpPromptButtonList.displayName = "McpPromptButton.List";

--- a/packages/react-ui-base/src/mcp-components/prompt-button/menu/mcp-prompt-button-menu.tsx
+++ b/packages/react-ui-base/src/mcp-components/prompt-button/menu/mcp-prompt-button-menu.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../../types/component-render-or-children";
+
+export type McpPromptButtonMenuProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Menu container primitive for the MCP prompt button.
+ * Renders a container for the dropdown content.
+ * Typically used with a dropdown library like Radix DropdownMenu.
+ * @returns The menu container element
+ */
+export const McpPromptButtonMenu = React.forwardRef<
+  HTMLDivElement,
+  McpPromptButtonMenuProps
+>(({ asChild, children, ...props }, ref) => {
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp ref={ref} data-slot="mcp-prompt-button-menu" {...props}>
+      {children}
+    </Comp>
+  );
+});
+McpPromptButtonMenu.displayName = "McpPromptButton.Menu";

--- a/packages/react-ui-base/src/mcp-components/prompt-button/root/mcp-prompt-button-context.tsx
+++ b/packages/react-ui-base/src/mcp-components/prompt-button/root/mcp-prompt-button-context.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Represents a single message content item from an MCP prompt.
+ */
+export interface PromptMessageContent {
+  type?: string;
+  text?: string;
+}
+
+/**
+ * Represents a single message from an MCP prompt.
+ */
+export interface PromptMessage {
+  content?: PromptMessageContent;
+}
+
+/**
+ * Represents an entry in the prompt list from MCP servers.
+ */
+export interface McpPromptEntry {
+  server: { url: string };
+  prompt: { name: string; description?: string };
+}
+
+/**
+ * Context value for the MCP prompt button compound component.
+ */
+export interface McpPromptButtonContextValue {
+  /** List of available prompts from MCP servers */
+  promptList: McpPromptEntry[] | undefined;
+  /** Whether the prompt list is loading */
+  isLoading: boolean;
+  /** Currently selected prompt name */
+  selectedPromptName: string | null;
+  /** Error message for display */
+  promptError: string | null;
+  /** Handler to select a prompt by name */
+  onSelectPrompt: (name: string) => void;
+}
+
+const McpPromptButtonContext =
+  React.createContext<McpPromptButtonContextValue | null>(null);
+
+/**
+ * Hook to access the MCP prompt button context.
+ * @throws Error if used outside of McpPromptButton.Root
+ * @returns The MCP prompt button context value
+ */
+export function useMcpPromptButtonContext(): McpPromptButtonContextValue {
+  const context = React.useContext(McpPromptButtonContext);
+  if (!context) {
+    throw new Error(
+      "useMcpPromptButtonContext must be used within McpPromptButton.Root",
+    );
+  }
+  return context;
+}
+
+/**
+ * Hook to optionally access the MCP prompt button context.
+ * Returns null if used outside of McpPromptButton.Root.
+ * @returns The MCP prompt button context value or null
+ */
+export function useOptionalMcpPromptButtonContext(): McpPromptButtonContextValue | null {
+  return React.useContext(McpPromptButtonContext);
+}
+
+export { McpPromptButtonContext };

--- a/packages/react-ui-base/src/mcp-components/prompt-button/root/mcp-prompt-button-root.tsx
+++ b/packages/react-ui-base/src/mcp-components/prompt-button/root/mcp-prompt-button-root.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import { useTamboMcpPrompt, useTamboMcpPromptList } from "@tambo-ai/react/mcp";
+import * as React from "react";
+import { BaseProps } from "../../../types/component-render-or-children";
+import { extractPromptText, isValidPromptData } from "../utils";
+import { McpPromptButtonContext } from "./mcp-prompt-button-context";
+
+export type McpPromptButtonRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** Callback to insert text into the input */
+    onInsertText: (text: string) => void;
+    /** Current input value */
+    value: string;
+  }
+>;
+
+/**
+ * Root primitive for the MCP prompt button compound component.
+ * Provides context for child components including prompt list data,
+ * selection state, and error handling.
+ * Renders nothing if no prompts are available.
+ * @returns The root container element with MCP prompt button context, or null if no prompts
+ */
+export const McpPromptButtonRoot = React.forwardRef<
+  HTMLDivElement,
+  McpPromptButtonRootProps
+>(function McpPromptButtonRoot(
+  { children, asChild, onInsertText, value, ...props },
+  ref,
+) {
+  const { data: promptList, isLoading } = useTamboMcpPromptList();
+  const [selectedPromptName, setSelectedPromptName] = React.useState<
+    string | null
+  >(null);
+  const [promptError, setPromptError] = React.useState<string | null>(null);
+  const { data: promptData, error: fetchError } = useTamboMcpPrompt(
+    selectedPromptName ?? "",
+  );
+
+  // When prompt data is fetched, validate and insert it into the input
+  React.useEffect(() => {
+    if (selectedPromptName && promptData) {
+      // Validate prompt data structure
+      if (!isValidPromptData(promptData)) {
+        setPromptError("Invalid prompt format received");
+        setSelectedPromptName(null);
+        return;
+      }
+
+      // Extract text with safe access
+      const promptText = extractPromptText(promptData.messages);
+
+      if (!promptText) {
+        setPromptError("Prompt contains no text content");
+        setSelectedPromptName(null);
+        return;
+      }
+
+      // Clear any previous errors
+      setPromptError(null);
+
+      // Insert the prompt text, appending to existing value if any
+      const newValue = value ? `${value}\n\n${promptText}` : promptText;
+      onInsertText(newValue);
+
+      // Reset the selected prompt
+      setSelectedPromptName(null);
+    }
+  }, [promptData, selectedPromptName, onInsertText, value]);
+
+  // Handle fetch errors
+  React.useEffect(() => {
+    if (fetchError) {
+      setPromptError("Failed to load prompt");
+      setSelectedPromptName(null);
+    }
+  }, [fetchError]);
+
+  // Clear error after a delay
+  React.useEffect(() => {
+    if (promptError) {
+      const timer = setTimeout(() => setPromptError(null), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [promptError]);
+
+  const contextValue = React.useMemo(
+    () => ({
+      promptList,
+      isLoading,
+      selectedPromptName,
+      promptError,
+      onSelectPrompt: setSelectedPromptName,
+    }),
+    [promptList, isLoading, selectedPromptName, promptError],
+  );
+
+  // Only show if prompts are available (hide during loading and when no prompts)
+  if (!promptList || promptList.length === 0) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <McpPromptButtonContext.Provider value={contextValue}>
+      <Comp ref={ref} data-slot="mcp-prompt-button" {...props}>
+        {children}
+      </Comp>
+    </McpPromptButtonContext.Provider>
+  );
+});
+McpPromptButtonRoot.displayName = "McpPromptButton.Root";

--- a/packages/react-ui-base/src/mcp-components/prompt-button/trigger/mcp-prompt-button-trigger.tsx
+++ b/packages/react-ui-base/src/mcp-components/prompt-button/trigger/mcp-prompt-button-trigger.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../../types/component-render-or-children";
+import { useRender } from "../../../use-render/use-render";
+import { useMcpPromptButtonContext } from "../root/mcp-prompt-button-context";
+
+export interface McpPromptButtonTriggerRenderProps {
+  /** Whether there is currently an error */
+  hasError: boolean;
+  /** The error message, if any */
+  errorMessage: string | null;
+}
+
+export type McpPromptButtonTriggerProps = BasePropsWithChildrenOrRenderFunction<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  McpPromptButtonTriggerRenderProps
+>;
+
+/**
+ * Trigger button primitive for the MCP prompt button.
+ * Renders a button element (or a Slot when asChild is true) that can be
+ * used to open the dropdown menu.
+ * @returns The trigger button element
+ */
+export const McpPromptButtonTrigger = React.forwardRef<
+  HTMLButtonElement,
+  McpPromptButtonTriggerProps
+>((props, ref) => {
+  const { promptError } = useMcpPromptButtonContext();
+
+  const renderProps: McpPromptButtonTriggerRenderProps = {
+    hasError: !!promptError,
+    errorMessage: promptError,
+  };
+
+  const { content, componentProps } = useRender(props, renderProps);
+  const { asChild, ...rest } = componentProps;
+
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      type="button"
+      data-slot="mcp-prompt-button-trigger"
+      data-error={promptError ? "true" : undefined}
+      aria-label="Insert MCP Prompt"
+      {...rest}
+    >
+      {content}
+    </Comp>
+  );
+});
+McpPromptButtonTrigger.displayName = "McpPromptButton.Trigger";

--- a/packages/react-ui-base/src/mcp-components/prompt-button/utils.ts
+++ b/packages/react-ui-base/src/mcp-components/prompt-button/utils.ts
@@ -1,0 +1,43 @@
+import type { PromptMessage } from "./root/mcp-prompt-button-context";
+
+/**
+ * Validates that prompt data has a valid messages array structure.
+ * @param promptData - The prompt data to validate
+ * @returns true if the prompt data has valid messages, false otherwise
+ */
+export function isValidPromptData(
+  promptData: unknown,
+): promptData is { messages: PromptMessage[] } {
+  if (!promptData || typeof promptData !== "object") {
+    return false;
+  }
+
+  const data = promptData as { messages?: unknown };
+  if (!Array.isArray(data.messages)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Safely extracts text content from prompt messages.
+ * Handles malformed or missing content gracefully.
+ * @param messages - Array of prompt messages
+ * @returns Extracted text content joined by newlines
+ */
+export function extractPromptText(messages: PromptMessage[]): string {
+  return messages
+    .map((msg) => {
+      // Safely access nested properties
+      if (
+        msg?.content?.type === "text" &&
+        typeof msg.content.text === "string"
+      ) {
+        return msg.content.text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}

--- a/packages/react-ui-base/src/mcp-components/resource-button/index.tsx
+++ b/packages/react-ui-base/src/mcp-components/resource-button/index.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { McpResourceButtonItem } from "./item/mcp-resource-button-item";
+import { McpResourceButtonList } from "./list/mcp-resource-button-list";
+import { McpResourceButtonMenu } from "./menu/mcp-resource-button-menu";
+import { McpResourceButtonRoot } from "./root/mcp-resource-button-root";
+import { McpResourceButtonSearchInput } from "./search-input/mcp-resource-button-search-input";
+import { McpResourceButtonTrigger } from "./trigger/mcp-resource-button-trigger";
+
+/**
+ * McpResourceButton namespace containing all MCP resource button base components.
+ */
+const McpResourceButton = {
+  Root: McpResourceButtonRoot,
+  Trigger: McpResourceButtonTrigger,
+  Menu: McpResourceButtonMenu,
+  SearchInput: McpResourceButtonSearchInput,
+  List: McpResourceButtonList,
+  Item: McpResourceButtonItem,
+};
+
+export type {
+  McpResourceButtonItemProps,
+  McpResourceButtonItemRenderProps,
+} from "./item/mcp-resource-button-item";
+export type {
+  McpResourceButtonListProps,
+  McpResourceButtonListRenderProps,
+} from "./list/mcp-resource-button-list";
+export type { McpResourceButtonMenuProps } from "./menu/mcp-resource-button-menu";
+export type {
+  McpResourceButtonContextValue,
+  McpResourceEntry,
+} from "./root/mcp-resource-button-context";
+export {
+  useMcpResourceButtonContext,
+  useOptionalMcpResourceButtonContext,
+} from "./root/mcp-resource-button-context";
+export type { McpResourceButtonRootProps } from "./root/mcp-resource-button-root";
+export type {
+  McpResourceButtonSearchInputProps,
+  McpResourceButtonSearchInputRenderProps,
+} from "./search-input/mcp-resource-button-search-input";
+export type { McpResourceButtonTriggerProps } from "./trigger/mcp-resource-button-trigger";
+
+export { McpResourceButton };

--- a/packages/react-ui-base/src/mcp-components/resource-button/item/mcp-resource-button-item.tsx
+++ b/packages/react-ui-base/src/mcp-components/resource-button/item/mcp-resource-button-item.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import {
+  useMcpResourceButtonContext,
+  type McpResourceEntry,
+} from "../root/mcp-resource-button-context";
+
+export interface McpResourceButtonItemRenderProps {
+  /** The resource entry data */
+  resource: McpResourceEntry;
+  /** The resource URI */
+  uri: string;
+  /** The resource name, if any */
+  name: string | undefined;
+  /** The resource description, if any */
+  description: string | undefined;
+}
+
+export interface McpResourceButtonItemProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "onClick" | "children" | "resource"
+> {
+  /** When true, renders as a Slot, merging props into the child element. */
+  asChild?: boolean;
+  /** The resource entry to render */
+  resource: McpResourceEntry;
+  /** Optional click handler override (defaults to selecting the resource) */
+  onSelect?: () => void;
+  /** Children as ReactNode or render function */
+  children?:
+    | React.ReactNode
+    | ((props: McpResourceButtonItemRenderProps) => React.ReactNode);
+}
+
+/**
+ * Item primitive for displaying a single resource option.
+ * Renders a clickable item that selects the resource when clicked.
+ * @returns The resource item element
+ */
+export const McpResourceButtonItem = React.forwardRef<
+  HTMLDivElement,
+  McpResourceButtonItemProps
+>(({ resource, onSelect, asChild, children, ...props }, ref) => {
+  const { onSelectResource } = useMcpResourceButtonContext();
+
+  const renderProps: McpResourceButtonItemRenderProps = {
+    resource,
+    uri: resource.resource.uri,
+    name: resource.resource.name,
+    description: resource.resource.description,
+  };
+
+  const handleClick = () => {
+    if (onSelect) {
+      onSelect();
+    } else {
+      onSelectResource(
+        resource.resource.uri,
+        resource.resource.name ?? resource.resource.uri,
+      );
+    }
+  };
+
+  const Comp = asChild ? Slot : "div";
+  const content =
+    typeof children === "function" ? children(renderProps) : children;
+
+  return (
+    <Comp
+      ref={ref}
+      role="menuitem"
+      tabIndex={0}
+      data-slot="mcp-resource-button-item"
+      onClick={handleClick}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+      {...props}
+    >
+      {content}
+    </Comp>
+  );
+});
+McpResourceButtonItem.displayName = "McpResourceButton.Item";

--- a/packages/react-ui-base/src/mcp-components/resource-button/list/mcp-resource-button-list.tsx
+++ b/packages/react-ui-base/src/mcp-components/resource-button/list/mcp-resource-button-list.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../../types/component-render-or-children";
+import { useRender } from "../../../use-render/use-render";
+import {
+  useMcpResourceButtonContext,
+  type McpResourceEntry,
+} from "../root/mcp-resource-button-context";
+
+export interface McpResourceButtonListRenderProps {
+  /** Filtered list of resources based on search query */
+  filteredResources: McpResourceEntry[];
+  /** Whether the list is loading */
+  isLoading: boolean;
+  /** Whether there are no resources matching the search */
+  isEmpty: boolean;
+  /** Current search query */
+  searchQuery: string;
+}
+
+export type McpResourceButtonListProps = BasePropsWithChildrenOrRenderFunction<
+  React.HTMLAttributes<HTMLDivElement>,
+  McpResourceButtonListRenderProps
+>;
+
+/**
+ * List container primitive for resource items.
+ * Provides render props with filtered resource list data for custom rendering.
+ * @returns The list container element
+ */
+export const McpResourceButtonList = React.forwardRef<
+  HTMLDivElement,
+  McpResourceButtonListProps
+>((props, ref) => {
+  const { filteredResources, isLoading, searchQuery } =
+    useMcpResourceButtonContext();
+
+  const renderProps: McpResourceButtonListRenderProps = {
+    filteredResources,
+    isLoading,
+    isEmpty: filteredResources.length === 0,
+    searchQuery,
+  };
+
+  const { content, componentProps } = useRender(props, renderProps);
+  const { asChild, ...rest } = componentProps;
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp ref={ref} role="menu" data-slot="mcp-resource-button-list" {...rest}>
+      {content}
+    </Comp>
+  );
+});
+McpResourceButtonList.displayName = "McpResourceButton.List";

--- a/packages/react-ui-base/src/mcp-components/resource-button/menu/mcp-resource-button-menu.tsx
+++ b/packages/react-ui-base/src/mcp-components/resource-button/menu/mcp-resource-button-menu.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../../types/component-render-or-children";
+
+export type McpResourceButtonMenuProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement>
+>;
+
+/**
+ * Menu container primitive for the MCP resource button.
+ * Renders a container for the dropdown content with search and resource list.
+ * Typically used with a dropdown library like Radix DropdownMenu.
+ * @returns The menu container element
+ */
+export const McpResourceButtonMenu = React.forwardRef<
+  HTMLDivElement,
+  McpResourceButtonMenuProps
+>(({ asChild, children, ...props }, ref) => {
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <Comp ref={ref} data-slot="mcp-resource-button-menu" {...props}>
+      {children}
+    </Comp>
+  );
+});
+McpResourceButtonMenu.displayName = "McpResourceButton.Menu";

--- a/packages/react-ui-base/src/mcp-components/resource-button/root/mcp-resource-button-context.tsx
+++ b/packages/react-ui-base/src/mcp-components/resource-button/root/mcp-resource-button-context.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Represents a resource entry from MCP servers.
+ */
+export interface McpResourceEntry {
+  server: { url: string } | null;
+  resource: {
+    uri: string;
+    name?: string;
+    description?: string;
+  };
+}
+
+/**
+ * Context value for the MCP resource button compound component.
+ */
+export interface McpResourceButtonContextValue {
+  /** List of available resources from MCP servers */
+  resourceList: McpResourceEntry[] | undefined;
+  /** Filtered resources based on search query */
+  filteredResources: McpResourceEntry[];
+  /** Whether the resource list is loading */
+  isLoading: boolean;
+  /** Whether the dropdown is open */
+  isOpen: boolean;
+  /** Set the open state of the dropdown */
+  setIsOpen: (open: boolean) => void;
+  /** Current search query */
+  searchQuery: string;
+  /** Set the search query */
+  setSearchQuery: (query: string) => void;
+  /** Handler to select a resource */
+  onSelectResource: (id: string, label: string) => void;
+}
+
+const McpResourceButtonContext =
+  React.createContext<McpResourceButtonContextValue | null>(null);
+
+/**
+ * Hook to access the MCP resource button context.
+ * @throws Error if used outside of McpResourceButton.Root
+ * @returns The MCP resource button context value
+ */
+export function useMcpResourceButtonContext(): McpResourceButtonContextValue {
+  const context = React.useContext(McpResourceButtonContext);
+  if (!context) {
+    throw new Error(
+      "useMcpResourceButtonContext must be used within McpResourceButton.Root",
+    );
+  }
+  return context;
+}
+
+/**
+ * Hook to optionally access the MCP resource button context.
+ * Returns null if used outside of McpResourceButton.Root.
+ * @returns The MCP resource button context value or null
+ */
+export function useOptionalMcpResourceButtonContext(): McpResourceButtonContextValue | null {
+  return React.useContext(McpResourceButtonContext);
+}
+
+export { McpResourceButtonContext };

--- a/packages/react-ui-base/src/mcp-components/resource-button/root/mcp-resource-button-root.tsx
+++ b/packages/react-ui-base/src/mcp-components/resource-button/root/mcp-resource-button-root.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import { useTamboMcpResourceList } from "@tambo-ai/react/mcp";
+import * as React from "react";
+import { BaseProps } from "../../../types/component-render-or-children";
+import { McpResourceButtonContext } from "./mcp-resource-button-context";
+
+export type McpResourceButtonRootProps = BaseProps<
+  React.HTMLAttributes<HTMLDivElement> & {
+    /** Callback to insert a resource reference */
+    onInsertResource: (id: string, label: string) => void;
+    /** Current input value (unused but kept for API consistency) */
+    value?: string;
+  }
+>;
+
+/**
+ * Root primitive for the MCP resource button compound component.
+ * Provides context for child components including resource list data,
+ * search state, and selection handlers.
+ * Renders nothing if no resources are available.
+ * @returns The root container element with MCP resource button context, or null if no resources
+ */
+export const McpResourceButtonRoot = React.forwardRef<
+  HTMLDivElement,
+  McpResourceButtonRootProps
+>(function McpResourceButtonRoot(
+  { children, asChild, onInsertResource, value: _value, ...props },
+  ref,
+) {
+  const { data: resourceList, isLoading } = useTamboMcpResourceList();
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [searchQuery, setSearchQuery] = React.useState("");
+
+  // Filter resources based on search query
+  const filteredResources = React.useMemo(() => {
+    if (!resourceList) return [];
+    if (!searchQuery) return resourceList;
+
+    const query = searchQuery.toLowerCase();
+    return resourceList.filter((entry) => {
+      const uri = entry.resource.uri.toLowerCase();
+      const name = entry.resource.name?.toLowerCase() ?? "";
+      const description = entry.resource.description?.toLowerCase() ?? "";
+      // Check if any field contains the query
+      return [
+        uri.includes(query),
+        name.includes(query),
+        description.includes(query),
+      ].some(Boolean);
+    });
+  }, [resourceList, searchQuery]);
+
+  const handleSelectResource = React.useCallback(
+    (id: string, label: string) => {
+      onInsertResource(id, label);
+      setIsOpen(false);
+      setSearchQuery("");
+    },
+    [onInsertResource],
+  );
+
+  const contextValue = React.useMemo(
+    () => ({
+      resourceList,
+      filteredResources,
+      isLoading,
+      isOpen,
+      setIsOpen,
+      searchQuery,
+      setSearchQuery,
+      onSelectResource: handleSelectResource,
+    }),
+    [
+      resourceList,
+      filteredResources,
+      isLoading,
+      isOpen,
+      searchQuery,
+      handleSelectResource,
+    ],
+  );
+
+  // Only show if resources are available
+  if (!resourceList || resourceList.length === 0) {
+    return null;
+  }
+
+  const Comp = asChild ? Slot : "div";
+
+  return (
+    <McpResourceButtonContext.Provider value={contextValue}>
+      <Comp ref={ref} data-slot="mcp-resource-button" {...props}>
+        {children}
+      </Comp>
+    </McpResourceButtonContext.Provider>
+  );
+});
+McpResourceButtonRoot.displayName = "McpResourceButton.Root";

--- a/packages/react-ui-base/src/mcp-components/resource-button/search-input/mcp-resource-button-search-input.tsx
+++ b/packages/react-ui-base/src/mcp-components/resource-button/search-input/mcp-resource-button-search-input.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BasePropsWithChildrenOrRenderFunction } from "../../../types/component-render-or-children";
+import { useRender } from "../../../use-render/use-render";
+import { useMcpResourceButtonContext } from "../root/mcp-resource-button-context";
+
+export interface McpResourceButtonSearchInputRenderProps {
+  /** Current search query value */
+  value: string;
+  /** Handler to update the search query */
+  onChange: (value: string) => void;
+  /** Handler to close the dropdown */
+  onClose: () => void;
+}
+
+export type McpResourceButtonSearchInputProps =
+  BasePropsWithChildrenOrRenderFunction<
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange">,
+    McpResourceButtonSearchInputRenderProps
+  >;
+
+/**
+ * Search input primitive for filtering resources.
+ * Provides search functionality within the resource dropdown.
+ * @returns The search input element
+ */
+export const McpResourceButtonSearchInput = React.forwardRef<
+  HTMLInputElement,
+  McpResourceButtonSearchInputProps
+>((props, ref) => {
+  const { searchQuery, setSearchQuery, setIsOpen } =
+    useMcpResourceButtonContext();
+
+  const renderProps: McpResourceButtonSearchInputRenderProps = {
+    value: searchQuery,
+    onChange: setSearchQuery,
+    onClose: () => setIsOpen(false),
+  };
+
+  const { content, componentProps } = useRender(props, renderProps);
+  const { asChild, ...rest } = componentProps;
+
+  // If using render prop pattern, just render the content
+  if ("render" in props && typeof props.render === "function") {
+    return <>{content}</>;
+  }
+
+  const Comp = asChild ? Slot : "input";
+
+  return (
+    <Comp
+      ref={ref}
+      type="text"
+      data-slot="mcp-resource-button-search-input"
+      value={searchQuery}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+        setSearchQuery(e.target.value)
+      }
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        e.stopPropagation();
+        if (e.key === "Escape") {
+          setIsOpen(false);
+        }
+      }}
+      {...rest}
+    >
+      {content}
+    </Comp>
+  );
+});
+McpResourceButtonSearchInput.displayName = "McpResourceButton.SearchInput";

--- a/packages/react-ui-base/src/mcp-components/resource-button/trigger/mcp-resource-button-trigger.tsx
+++ b/packages/react-ui-base/src/mcp-components/resource-button/trigger/mcp-resource-button-trigger.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Slot } from "@radix-ui/react-slot";
+import * as React from "react";
+import { BaseProps } from "../../../types/component-render-or-children";
+
+export type McpResourceButtonTriggerProps = BaseProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>;
+
+/**
+ * Trigger button primitive for the MCP resource button.
+ * Renders a button element (or a Slot when asChild is true) that can be
+ * used to open the dropdown menu.
+ * @returns The trigger button element
+ */
+export const McpResourceButtonTrigger = React.forwardRef<
+  HTMLButtonElement,
+  McpResourceButtonTriggerProps
+>(({ asChild, children, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      ref={ref}
+      type="button"
+      data-slot="mcp-resource-button-trigger"
+      aria-label="Insert MCP Resource"
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+});
+McpResourceButtonTrigger.displayName = "McpResourceButton.Trigger";

--- a/packages/ui-registry/src/components/mcp-components/config.json
+++ b/packages/ui-registry/src/components/mcp-components/config.json
@@ -4,6 +4,7 @@
   "componentName": "MCPComponents",
   "dependencies": [
     "@tambo-ai/react@rc",
+    "@tambo-ai/react-ui-base",
     "lucide-react",
     "@radix-ui/react-dropdown-menu"
   ],

--- a/packages/ui-registry/src/components/mcp-components/mcp-components.tsx
+++ b/packages/ui-registry/src/components/mcp-components/mcp-components.tsx
@@ -1,75 +1,19 @@
 "use client";
 
 import {
+  McpPromptButton as McpPromptButtonBase,
+  McpResourceButton as McpResourceButtonBase,
+  useMcpPromptButtonContext,
+  useMcpResourceButtonContext,
+} from "@tambo-ai/react-ui-base/mcp-components";
+import {
   Tooltip,
   TooltipProvider,
 } from "@tambo-ai/ui-registry/components/message-suggestions";
 import { cn } from "@tambo-ai/ui-registry/utils";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import {
-  useTamboMcpPrompt,
-  useTamboMcpPromptList,
-  useTamboMcpResourceList,
-} from "@tambo-ai/react/mcp";
 import { AlertCircle, AtSign, FileText, Search } from "lucide-react";
 import * as React from "react";
-
-/**
- * Represents a single message content item from an MCP prompt.
- */
-interface PromptMessageContent {
-  type?: string;
-  text?: string;
-}
-
-/**
- * Represents a single message from an MCP prompt.
- */
-interface PromptMessage {
-  content?: PromptMessageContent;
-}
-
-/**
- * Validates that prompt data has a valid messages array structure.
- * @param promptData - The prompt data to validate
- * @returns true if the prompt data has valid messages, false otherwise
- */
-function isValidPromptData(
-  promptData: unknown,
-): promptData is { messages: PromptMessage[] } {
-  if (!promptData || typeof promptData !== "object") {
-    return false;
-  }
-
-  const data = promptData as { messages?: unknown };
-  if (!Array.isArray(data.messages)) {
-    return false;
-  }
-
-  return true;
-}
-
-/**
- * Safely extracts text content from prompt messages.
- * Handles malformed or missing content gracefully.
- * @param messages - Array of prompt messages
- * @returns Extracted text content joined by newlines
- */
-function extractPromptText(messages: PromptMessage[]): string {
-  return messages
-    .map((msg) => {
-      // Safely access nested properties
-      if (
-        msg?.content?.type === "text" &&
-        typeof msg.content.text === "string"
-      ) {
-        return msg.content.text;
-      }
-      return "";
-    })
-    .filter(Boolean)
-    .join("\n");
-}
 
 /**
  * Props for the McpPromptButton component.
@@ -98,66 +42,25 @@ export const McpPromptButton = React.forwardRef<
   HTMLButtonElement,
   McpPromptButtonProps
 >(({ className, onInsertText, value, ...props }, ref) => {
-  const { data: promptList, isLoading } = useTamboMcpPromptList();
-  const [selectedPromptName, setSelectedPromptName] = React.useState<
-    string | null
-  >(null);
-  const [promptError, setPromptError] = React.useState<string | null>(null);
-  const { data: promptData, error: fetchError } = useTamboMcpPrompt(
-    selectedPromptName ?? "",
+  return (
+    <McpPromptButtonBase.Root onInsertText={onInsertText} value={value} asChild>
+      <div>
+        <McpPromptButtonContent ref={ref} className={className} {...props} />
+      </div>
+    </McpPromptButtonBase.Root>
   );
+});
+McpPromptButton.displayName = "McpPromptButton";
 
-  // When prompt data is fetched, validate and insert it into the input
-  React.useEffect(() => {
-    if (selectedPromptName && promptData) {
-      // Validate prompt data structure
-      if (!isValidPromptData(promptData)) {
-        setPromptError("Invalid prompt format received");
-        setSelectedPromptName(null);
-        return;
-      }
-
-      // Extract text with safe access
-      const promptText = extractPromptText(promptData.messages);
-
-      if (!promptText) {
-        setPromptError("Prompt contains no text content");
-        setSelectedPromptName(null);
-        return;
-      }
-
-      // Clear any previous errors
-      setPromptError(null);
-
-      // Insert the prompt text, appending to existing value if any
-      const newValue = value ? `${value}\n\n${promptText}` : promptText;
-      onInsertText(newValue);
-
-      // Reset the selected prompt
-      setSelectedPromptName(null);
-    }
-  }, [promptData, selectedPromptName, onInsertText, value]);
-
-  // Handle fetch errors
-  React.useEffect(() => {
-    if (fetchError) {
-      setPromptError("Failed to load prompt");
-      setSelectedPromptName(null);
-    }
-  }, [fetchError]);
-
-  // Clear error after a delay
-  React.useEffect(() => {
-    if (promptError) {
-      const timer = setTimeout(() => setPromptError(null), 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [promptError]);
-
-  // Only show button if prompts are available (hide during loading and when no prompts)
-  if (!promptList || promptList.length === 0) {
-    return null;
-  }
+/**
+ * Internal component that renders the prompt button content within the context.
+ */
+const McpPromptButtonContent = React.forwardRef<
+  HTMLButtonElement,
+  Omit<McpPromptButtonProps, "onInsertText" | "value">
+>(({ className, ...props }, ref) => {
+  const { promptList, isLoading, promptError, onSelectPrompt } =
+    useMcpPromptButtonContext();
 
   const buttonClasses = cn(
     "w-10 h-10 rounded-lg border border-border bg-background text-foreground transition-colors hover:bg-muted disabled:opacity-50 disabled:pointer-events-none flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
@@ -176,15 +79,12 @@ export const McpPromptButton = React.forwardRef<
       >
         <DropdownMenu.Root>
           <DropdownMenu.Trigger asChild>
-            <button
+            <McpPromptButtonBase.Trigger
               ref={ref}
-              type="button"
               className={cn(
                 buttonClasses,
                 promptError && "border-destructive text-destructive",
               )}
-              aria-label="Insert MCP Prompt"
-              data-slot="mcp-prompt-button"
               {...props}
             >
               {promptError ? (
@@ -192,7 +92,7 @@ export const McpPromptButton = React.forwardRef<
               ) : (
                 <FileText className="w-4 h-4" />
               )}
-            </button>
+            </McpPromptButtonBase.Trigger>
           </DropdownMenu.Trigger>
           <DropdownMenu.Portal>
             <DropdownMenu.Content
@@ -204,7 +104,7 @@ export const McpPromptButton = React.forwardRef<
               <PromptListContent
                 isLoading={isLoading}
                 promptList={promptList}
-                onSelectPrompt={setSelectedPromptName}
+                onSelectPrompt={onSelectPrompt}
               />
             </DropdownMenu.Content>
           </DropdownMenu.Portal>
@@ -213,10 +113,10 @@ export const McpPromptButton = React.forwardRef<
     </TooltipProvider>
   );
 });
-McpPromptButton.displayName = "McpPromptButton";
+McpPromptButtonContent.displayName = "McpPromptButtonContent";
 
 /**
- * Internal component to render prompt list content
+ * Internal component to render prompt list content.
  */
 function PromptListContent({
   isLoading,
@@ -277,13 +177,112 @@ function PromptListContent({
 }
 
 /**
- * Props for the ResourceCombobox internal component
+ * Props for the McpResourceButton component.
+ */
+export interface McpResourceButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Callback to insert text into the input */
+  onInsertResource: (id: string, label: string) => void;
+  /** Current input value */
+  value: string;
+  /** Optional custom className */
+  className?: string;
+}
+
+/**
+ * MCP Resource picker button component for inserting resource references from MCP servers.
+ * Uses a combobox with search for easy filtering of potentially many resources.
+ * @component McpResourceButton
+ * @example
+ * ```tsx
+ * <McpResourceButton
+ *   value={inputValue}
+ *   onInsertResource={(id, label) => setInputValue(label)}
+ * />
+ * ```
+ */
+export const McpResourceButton = React.forwardRef<
+  HTMLButtonElement,
+  McpResourceButtonProps
+>(({ className, onInsertResource, value, ...props }, ref) => {
+  return (
+    <McpResourceButtonBase.Root
+      onInsertResource={onInsertResource}
+      value={value}
+      asChild
+    >
+      <div>
+        <McpResourceButtonContent ref={ref} className={className} {...props} />
+      </div>
+    </McpResourceButtonBase.Root>
+  );
+});
+McpResourceButton.displayName = "McpResourceButton";
+
+/**
+ * Internal component that renders the resource button content within the context.
+ */
+const McpResourceButtonContent = React.forwardRef<
+  HTMLButtonElement,
+  Omit<McpResourceButtonProps, "onInsertResource" | "value">
+>(({ className, ...props }, ref) => {
+  const {
+    filteredResources,
+    isLoading,
+    isOpen,
+    setIsOpen,
+    searchQuery,
+    setSearchQuery,
+    onSelectResource,
+  } = useMcpResourceButtonContext();
+
+  const buttonClasses = cn(
+    "w-10 h-10 rounded-lg border border-border bg-background text-foreground transition-colors hover:bg-muted disabled:opacity-50 disabled:pointer-events-none flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    className,
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip
+        content="Insert MCP Resource"
+        side="top"
+        className="bg-muted text-foreground"
+      >
+        <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
+          <DropdownMenu.Trigger asChild>
+            <McpResourceButtonBase.Trigger
+              ref={ref}
+              className={buttonClasses}
+              {...props}
+            >
+              <AtSign className="w-4 h-4" />
+            </McpResourceButtonBase.Trigger>
+          </DropdownMenu.Trigger>
+          <ResourceCombobox
+            setIsOpen={setIsOpen}
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            filteredResources={filteredResources}
+            isLoading={isLoading}
+            onSelectResource={onSelectResource}
+          />
+        </DropdownMenu.Root>
+      </Tooltip>
+    </TooltipProvider>
+  );
+});
+McpResourceButtonContent.displayName = "McpResourceButtonContent";
+
+/**
+ * Props for the ResourceCombobox internal component.
  */
 interface ResourceComboboxProps {
   setIsOpen: (open: boolean) => void;
   searchQuery: string;
   setSearchQuery: (query: string) => void;
-  filteredResources: ReturnType<typeof useTamboMcpResourceList>["data"];
+  filteredResources: {
+    server: { url: string } | null;
+    resource: { uri: string; name?: string; description?: string };
+  }[];
   isLoading: boolean;
   onSelectResource: (id: string, label: string) => void;
 }
@@ -349,7 +348,7 @@ const ResourceCombobox: React.FC<ResourceComboboxProps> = ({
 };
 
 /**
- * Internal component to render resource list content
+ * Internal component to render resource list content.
  */
 function ResourceListContent({
   isLoading,
@@ -358,7 +357,10 @@ function ResourceListContent({
   onSelectResource,
 }: {
   isLoading: boolean;
-  filteredResources: ReturnType<typeof useTamboMcpResourceList>["data"];
+  filteredResources: {
+    server: { url: string } | null;
+    resource: { uri: string; name?: string; description?: string };
+  }[];
   searchQuery: string;
   onSelectResource: (id: string, label: string) => void;
 }) {
@@ -369,7 +371,7 @@ function ResourceListContent({
       </div>
     );
   }
-  if (!filteredResources || filteredResources.length === 0) {
+  if (filteredResources.length === 0) {
     return (
       <div className="px-2 py-8 text-center text-sm text-muted-foreground">
         {searchQuery
@@ -387,7 +389,7 @@ function ResourceListContent({
           onSelect={() => {
             onSelectResource(
               resourceEntry.resource.uri,
-              resourceEntry.resource.name || resourceEntry.resource.uri,
+              resourceEntry.resource.name ?? resourceEntry.resource.uri,
             );
           }}
         >
@@ -411,107 +413,3 @@ function ResourceListContent({
     </>
   );
 }
-
-/**
- * Props for the McpResourceButton component.
- */
-export interface McpResourceButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Callback to insert text into the input */
-  onInsertResource: (id: string, label: string) => void;
-  /** Current input value */
-  value: string;
-  /** Optional custom className */
-  className?: string;
-}
-
-/**
- * MCP Resource picker button component for inserting resource references from MCP servers.
- * Uses a combobox with search for easy filtering of potentially many resources.
- * @component McpResourceButton
- * @example
- * ```tsx
- * <McpResourceButton
- *   value={inputValue}
- *   onInsertText={(text) => setInputValue(text)}
- * />
- * ```
- */
-export const McpResourceButton = React.forwardRef<
-  HTMLButtonElement,
-  McpResourceButtonProps
->(({ className, onInsertResource, value: _value, ...props }, ref) => {
-  const { data: resourceList, isLoading } = useTamboMcpResourceList();
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [searchQuery, setSearchQuery] = React.useState("");
-
-  // Filter resources based on search query
-  const filteredResources = React.useMemo(() => {
-    if (!resourceList) return [];
-    if (!searchQuery) return resourceList;
-
-    const query = searchQuery.toLowerCase();
-    return resourceList.filter((entry) => {
-      const uri = entry.resource.uri.toLowerCase();
-      const name = entry.resource.name?.toLowerCase() ?? "";
-      const description = entry.resource.description?.toLowerCase() ?? "";
-      // Combine predicates without `||` to satisfy lint rule preferring `??` for fallbacks
-      // Ensure correct boolean semantics by using Array.prototype.some
-      return [
-        uri.includes(query),
-        name.includes(query),
-        description.includes(query),
-      ].some(Boolean);
-    });
-  }, [resourceList, searchQuery]);
-
-  const handleSelectResource = (id: string, label: string) => {
-    // Pass raw resource string to caller; caller decides how to insert
-    onInsertResource(id, label);
-    setIsOpen(false);
-    setSearchQuery("");
-  };
-
-  // Only show button if resources are available
-  if (!resourceList || resourceList.length === 0) {
-    return null;
-  }
-
-  const buttonClasses = cn(
-    "w-10 h-10 rounded-lg border border-border bg-background text-foreground transition-colors hover:bg-muted disabled:opacity-50 disabled:pointer-events-none flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-    className,
-  );
-
-  return (
-    <TooltipProvider>
-      <Tooltip
-        content="Insert MCP Resource"
-        side="top"
-        className="bg-muted text-foreground"
-      >
-        <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
-          <DropdownMenu.Trigger asChild>
-            <button
-              ref={ref}
-              type="button"
-              className={buttonClasses}
-              aria-label="Insert MCP Resource"
-              data-slot="mcp-resource-button"
-              {...props}
-            >
-              <AtSign className="w-4 h-4" />
-            </button>
-          </DropdownMenu.Trigger>
-          <ResourceCombobox
-            setIsOpen={setIsOpen}
-            searchQuery={searchQuery}
-            setSearchQuery={setSearchQuery}
-            filteredResources={filteredResources}
-            isLoading={isLoading}
-            onSelectResource={handleSelectResource}
-          />
-        </DropdownMenu.Root>
-      </Tooltip>
-    </TooltipProvider>
-  );
-});
-McpResourceButton.displayName = "McpResourceButton";


### PR DESCRIPTION
## Summary
- Add unstyled compound component base primitives for MCP prompt and resource buttons
- Implement Context + Root + sub-components pattern for flexible composition
- Update ui-registry mcp-components wrapper to use new base primitives

## Changes
### New Base Components
- `McpPromptButton.Root`, `.Trigger`, `.Menu`, `.List`, `.Item`
- `McpResourceButton.Root`, `.Trigger`, `.Menu`, `.List`, `.Item`, `.SearchInput`

### Features
- Full context system with `useMcpPromptButtonContext`/`useMcpResourceButtonContext`
- Render function support for flexible customization  
- `asChild` prop support via `@radix-ui/react-slot`
- `data-slot` attributes for CSS styling hooks
- Subpath export: `@tambo-ai/react-ui-base/mcp-components`

## Test plan
- [ ] Verify type checks pass
- [ ] Verify existing mcp-components functionality in showcase
- [ ] Test compound component composition patterns

Fixes TAM-1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)