### PR TITLE
fix(react-sdk): support useTamboV1ComponentState in interactable components

### DIFF
--- a/react-sdk/src/hoc/with-tambo-interactable.tsx
+++ b/react-sdk/src/hoc/with-tambo-interactable.tsx
@@ -4,6 +4,7 @@ import { TamboMessageProvider } from "../hooks/use-current-message";
 import { TamboThreadMessage } from "../model/generate-component-response";
 import { useTamboInteractable } from "../providers/tambo-interactable-provider";
 import { SupportedSchema } from "../schema";
+import { V1ComponentContentProvider } from "../v1/utils/component-renderer";
 
 export interface InteractableConfig<
   Props = Record<string, unknown>,
@@ -188,7 +189,7 @@ export function withTamboInteractable<ComponentProps extends object>(
       componentState: {},
     };
 
-    // Wrap with TamboMessageProvider including interactable metadata
+    // Wrap with TamboMessageProvider and V1ComponentContentProvider including interactable metadata
     return (
       <TamboMessageProvider
         message={minimalMessage}
@@ -198,7 +199,14 @@ export function withTamboInteractable<ComponentProps extends object>(
           description: config.description,
         }}
       >
-        <WrappedComponent {...(effectiveProps as ComponentProps)} />
+        <V1ComponentContentProvider
+          componentId={interactableId}
+          threadId=""
+          messageId=""
+          componentName={config.componentName}
+        >
+          <WrappedComponent {...(effectiveProps as ComponentProps)} />
+        </V1ComponentContentProvider>
       </TamboMessageProvider>
     );
   };


### PR DESCRIPTION
## Summary

Fixes TAM-1130

- `useTamboV1ComponentState` crashed inside `withTamboInteractable` components because `V1ComponentContentContext` was only provided by `V1ComponentRenderer`
- Added `V1ComponentContentProvider` to `withTamboInteractable` HOC (with `threadId=""` convention to signal interactable context)
- Branched the v1 hook to use interactable state management (via `setInteractableState`/`getInteractableComponentState`) instead of server sync when in interactable context
- Added 9 tests covering interactable component state behavior

## Test plan

- [x] `npm run check-types` passes
- [x] `npm run lint` passes (0 errors, pre-existing warnings only)
- [x] `npm test` passes (1051/1051 tests, including 9 new interactable tests)
- [ ] Manual verification: a component using `useTamboV1ComponentState` wrapped with `withTamboInteractable` renders without crashing and `setState` updates the interactable provider's state

🤖 Generated with [Claude Code](https://claude.com/claude-code)