### PR TITLE
fix(react-sdk): add TamboContextAttachmentProvider to V1 provider tree

### DIFF
--- a/react-sdk/src/v1/providers/tambo-v1-provider.test.tsx
+++ b/react-sdk/src/v1/providers/tambo-v1-provider.test.tsx
@@ -329,7 +329,10 @@ describe("TamboV1Provider", () => {
     const { result } = renderHook(() => useTamboContextHelpers(), { wrapper });
 
     const helpers = result.current.getContextHelpers();
-    // TamboInteractableProvider registers an "interactables" context helper
-    expect(Object.keys(helpers)).toEqual(["interactables"]);
+    // TamboInteractableProvider registers "interactables" and TamboContextAttachmentProvider registers "contextAttachments"
+    expect(Object.keys(helpers)).toEqual([
+      "interactables",
+      "contextAttachments",
+    ]);
   });
 });

--- a/react-sdk/src/v1/providers/tambo-v1-provider.tsx
+++ b/react-sdk/src/v1/providers/tambo-v1-provider.tsx
@@ -7,6 +7,7 @@
  * - TamboClientProvider: API client and authentication
  * - TamboRegistryProvider: Component and tool registration
  * - TamboContextHelpersProvider: Context helper functions
+ * - TamboContextAttachmentProvider: Single-message context attachments
  * - TamboInteractableProvider: Interactive component tracking
  * - TamboV1StreamProvider: Streaming state management
  *
@@ -27,6 +28,7 @@ import {
   TamboRegistryProvider,
   type TamboRegistryProviderProps,
 } from "../../providers/tambo-registry-provider";
+import { TamboContextAttachmentProvider } from "../../providers/tambo-context-attachment-provider";
 import { TamboContextHelpersProvider } from "../../providers/tambo-context-helpers-provider";
 import { TamboInteractableProvider } from "../../providers/tambo-interactable-provider";
 import type { ContextHelpers } from "../../context-helpers";
@@ -244,15 +246,17 @@ export function TamboV1Provider({
         getResource={getResource}
       >
         <TamboContextHelpersProvider contextHelpers={contextHelpers}>
-          <TamboInteractableProvider>
-            <TamboV1ConfigContext.Provider value={config}>
-              <TamboV1StreamProvider>
-                <TamboV1ThreadInputProvider>
-                  {children}
-                </TamboV1ThreadInputProvider>
-              </TamboV1StreamProvider>
-            </TamboV1ConfigContext.Provider>
-          </TamboInteractableProvider>
+          <TamboContextAttachmentProvider>
+            <TamboInteractableProvider>
+              <TamboV1ConfigContext.Provider value={config}>
+                <TamboV1StreamProvider>
+                  <TamboV1ThreadInputProvider>
+                    {children}
+                  </TamboV1ThreadInputProvider>
+                </TamboV1StreamProvider>
+              </TamboV1ConfigContext.Provider>
+            </TamboInteractableProvider>
+          </TamboContextAttachmentProvider>
         </TamboContextHelpersProvider>
       </TamboRegistryProvider>
     </TamboClientProvider>


### PR DESCRIPTION
## Summary
- Adds `TamboContextAttachmentProvider` to `TamboV1Provider`, slotted after `TamboContextHelpersProvider` (its only dependency)
- `useTamboContextAttachment()` now works in V1 apps without throwing

Fixes TAM-1131

## Test plan
- [x] All 1051 existing tests pass
- [ ] Verify `useTamboContextAttachment()` works in a V1 app