### PR TITLE
feat(react-sdk,api): support initialMessages in V1 stack and add maxCalls to tool DTO

### DIFF
--- a/apps/api/src/v1/__tests__/v1.service.test.ts
+++ b/apps/api/src/v1/__tests__/v1.service.test.ts
@@ -43,6 +43,7 @@ jest.mock("@tambo-ai-cloud/db", () => ({
     markRunCancelled: jest.fn(),
     markMessageCancelled: jest.fn(),
     markLatestAssistantMessageCancelled: jest.fn(),
+    addMessage: jest.fn(),
     releaseRunLockIfCurrent: jest.fn(),
     updateRunStatus: jest.fn(),
     updateThreadRunStatus: jest.fn(),
@@ -487,15 +488,37 @@ describe("V1Service", () => {
       expect(result.metadata).toEqual({ custom: "data" });
     });
 
-    it("should reject initialMessages for now", async () => {
-      await expect(
-        service.createThread("prj_123", "user_456", {
-          initialMessages: [
-            { role: "user", content: [{ type: "text", text: "Hi" }] },
-          ],
+    it("should save initialMessages when provided", async () => {
+      mockOperations.createThread.mockResolvedValue(mockThread);
+      mockOperations.addMessage.mockResolvedValue(mockMessage);
+
+      const result = await service.createThread("prj_123", "user_456", {
+        initialMessages: [
+          { role: "user", content: [{ type: "text", text: "Hi" }] },
+        ],
+      });
+
+      expect(mockOperations.createThread).toHaveBeenCalled();
+      expect(mockOperations.addMessage).toHaveBeenCalledWith(
+        mockDb,
+        "thr_123",
+        expect.objectContaining({
+          role: "user",
+          content: expect.arrayContaining([
+            expect.objectContaining({ type: "text", text: "Hi" }),
+          ]),
         }),
-      ).rejects.toThrow(BadRequestException);
-      expect(mockOperations.createThread).not.toHaveBeenCalled();
+      );
+      expect(result.id).toBe("thr_123");
+    });
+
+    it("should not call addMessage when no initialMessages provided", async () => {
+      mockOperations.createThread.mockResolvedValue(mockThread);
+
+      await service.createThread("prj_123", "user_456", {});
+
+      expect(mockOperations.createThread).toHaveBeenCalled();
+      expect(mockOperations.addMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/v1/dto/tool.dto.ts
+++ b/apps/api/src/v1/dto/tool.dto.ts
@@ -5,6 +5,8 @@ import {
   IsBoolean,
   IsNotEmpty,
   IsObject,
+  IsInt,
+  Min,
 } from "class-validator";
 
 /**
@@ -58,6 +60,18 @@ export class V1ToolDto {
   @IsOptional()
   @IsBoolean()
   strict?: boolean;
+
+  @ApiProperty({
+    description:
+      "Per-tool call limit. Overrides the project's global maxToolCallLimit for this tool.",
+    required: false,
+    minimum: 1,
+    example: 1,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxCalls?: number;
 }
 
 /**

--- a/apps/api/src/v1/v1-tool-conversions.ts
+++ b/apps/api/src/v1/v1-tool-conversions.ts
@@ -131,7 +131,9 @@ export function convertV1ToolToInternal(
   result.name = tool.name;
   result.description = tool.description;
   result.parameters = jsonSchemaToToolParameters(tool.inputSchema);
-  // V1 doesn't have maxCalls, so we don't set it (undefined = no limit)
+  if (tool.maxCalls !== undefined) {
+    result.maxCalls = tool.maxCalls;
+  }
   return result;
 }
 

--- a/apps/api/src/v1/v1.controller.ts
+++ b/apps/api/src/v1/v1.controller.ts
@@ -333,6 +333,7 @@ export class V1Controller {
       {
         userKey: dto.thread?.userKey,
         metadata: dto.threadMetadata ?? dto.thread?.metadata,
+        initialMessages: dto.thread?.initialMessages,
       },
     );
 

--- a/apps/api/src/v1/v1.service.ts
+++ b/apps/api/src/v1/v1.service.ts
@@ -83,6 +83,7 @@ import {
   isHiddenUiToolResponse,
   ContentConversionOptions,
   convertV1InputMessageToInternal,
+  convertV1InputMessageToUnsaved,
 } from "./v1-conversions";
 import { encodeV1CompoundCursor, parseV1CompoundCursor } from "./v1-pagination";
 import {
@@ -209,19 +210,13 @@ export class V1Service {
   }
 
   /**
-   * Create a new empty thread.
+   * Create a new thread, optionally seeded with initial messages.
    */
   async createThread(
     projectId: string,
     contextKey: string,
     dto: V1CreateThreadDto,
   ): Promise<V1CreateThreadResponseDto> {
-    if (dto.initialMessages?.length) {
-      throw new BadRequestException(
-        "initialMessages is not supported yet. Create the thread first, then add messages via runs/message endpoints.",
-      );
-    }
-
     const thread = await operations.createThread(this.db, {
       projectId,
       contextKey,
@@ -233,6 +228,17 @@ export class V1Service {
         `Failed to create thread for project ${projectId}. ` +
           `Database insert did not return created record.`,
       );
+    }
+
+    // Save initial messages to the thread
+    if (dto.initialMessages?.length) {
+      for (const msg of dto.initialMessages) {
+        await operations.addMessage(
+          this.db,
+          thread.id,
+          convertV1InputMessageToUnsaved(msg),
+        );
+      }
     }
 
     return threadToDto(thread);

--- a/react-sdk/src/v1/providers/tambo-v1-provider.tsx
+++ b/react-sdk/src/v1/providers/tambo-v1-provider.tsx
@@ -37,6 +37,7 @@ import type {
   ListResourceItem,
   ResourceSource,
 } from "../../model/resource-info";
+import type { InputMessage } from "../types/message";
 import { TamboV1StreamProvider } from "./tambo-v1-stream-context";
 import { TamboV1ThreadInputProvider } from "./tambo-v1-thread-input-provider";
 
@@ -51,6 +52,11 @@ export interface TamboV1Config {
   autoGenerateThreadName?: boolean;
   /** The message count threshold at which the thread name will be auto-generated. Defaults to 3. */
   autoGenerateNameThreshold?: number;
+  /**
+   * Initial messages to seed new threads with.
+   * These are displayed in the UI immediately and sent to the API on first message.
+   */
+  initialMessages?: InputMessage[];
 }
 
 /**
@@ -154,6 +160,13 @@ export interface TamboV1ProviderProps extends Pick<
   autoGenerateNameThreshold?: number;
 
   /**
+   * Initial messages to seed new threads with.
+   * These are displayed in the UI immediately (before the first API call)
+   * and sent to the API when the first message is sent to create the thread.
+   */
+  initialMessages?: InputMessage[];
+
+  /**
    * Children components
    */
   children: React.ReactNode;
@@ -220,6 +233,7 @@ export function TamboV1Provider({
   userKey,
   autoGenerateThreadName,
   autoGenerateNameThreshold,
+  initialMessages,
   children,
 }: PropsWithChildren<TamboV1ProviderProps>) {
   // Config is static - created once and never changes
@@ -227,6 +241,7 @@ export function TamboV1Provider({
     userKey,
     autoGenerateThreadName,
     autoGenerateNameThreshold,
+    initialMessages,
   };
 
   return (
@@ -249,7 +264,7 @@ export function TamboV1Provider({
           <TamboContextAttachmentProvider>
             <TamboInteractableProvider>
               <TamboV1ConfigContext.Provider value={config}>
-                <TamboV1StreamProvider>
+                <TamboV1StreamProvider initialMessages={initialMessages}>
                   <TamboV1ThreadInputProvider>
                     {children}
                   </TamboV1ThreadInputProvider>


### PR DESCRIPTION
## Summary

- **TAM-1142**: Implements full `initialMessages` support across the V1 stack — API saves them to the thread on creation, React SDK accepts them as a provider prop, seeds the placeholder thread for optimistic UI, and passes them through on first message send.
- **TAM-1143 (DTO only)**: Adds `maxCalls` field to `V1ToolDto` with validation and wires the conversion to internal format. SDK-side changes will follow in a separate PR after codegen.

## Changes

### API (`apps/api/`)
- `v1.service.ts` — `createThread()` now persists initial messages via `operations.addMessage()` instead of rejecting them
- `v1.controller.ts` — passes `initialMessages` from DTO through to `createThread()`
- `v1-conversions.ts` — new `convertV1InputMessageToUnsaved()` function
- `dto/tool.dto.ts` — added `maxCalls` optional field with `@IsInt()` / `@Min(1)` validators
- `v1-tool-conversions.ts` — `convertV1ToolToInternal()` now passes `maxCalls` through
- Updated tests to verify new saving behavior

### React SDK (`react-sdk/`)
- `tambo-v1-provider.tsx` — added `initialMessages` to config and provider props
- `tambo-v1-stream-context.tsx` — seeds placeholder thread with initial messages, re-seeds on `startNewThread()`
- `event-accumulator.ts` — new `createInitialStateWithMessages()` helper
- `use-tambo-v1-send-message.ts` — passes `initialMessages` to API on new thread creation

## Test plan

- [x] `npm run check-types` — 19/19 pass
- [x] `npm test` — 14/14 suites pass (including updated v1.service tests)
- [x] Pre-commit hooks (lint, prettier) pass

Fixes TAM-1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)