### PR TITLE
feat(react-sdk): add authentication state management to V1 SDK

### DIFF
--- a/react-sdk/src/hooks/use-tambo-voice.test.tsx
+++ b/react-sdk/src/hooks/use-tambo-voice.test.tsx
@@ -49,6 +49,9 @@ describe("useTamboVoice", () => {
           client: mockClient,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <QueryClientProvider client={queryClient}>

--- a/react-sdk/src/mcp/mcp-hooks.test.tsx
+++ b/react-sdk/src/mcp/mcp-hooks.test.tsx
@@ -101,6 +101,9 @@ describe("useTamboMcpPromptList - individual server caching", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -208,6 +211,9 @@ describe("useTamboMcpPromptList - individual server caching", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -249,6 +255,9 @@ describe("useTamboMcpPromptList - individual server caching", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -341,6 +350,9 @@ describe("useTamboMcpPromptList - individual server caching", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -443,6 +455,9 @@ describe("useTamboMcpPromptList - individual server caching", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -532,6 +547,9 @@ describe("useTamboMcpPromptList - individual server caching", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -567,6 +585,9 @@ describe("useTamboMcpPromptList - individual server caching", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -661,6 +682,9 @@ describe("useTamboMcpPromptList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -692,6 +716,9 @@ describe("useTamboMcpPromptList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -762,6 +789,9 @@ describe("useTamboMcpPromptList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -911,6 +941,9 @@ describe("useTamboMcpResourceList - resource management", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1005,6 +1038,9 @@ describe("useTamboMcpResourceList - resource management", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1106,6 +1142,9 @@ describe("useTamboMcpResourceList - resource management", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1145,6 +1184,9 @@ describe("useTamboMcpResourceList - resource management", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1249,6 +1291,9 @@ describe("useTamboMcpResourceList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1280,6 +1325,9 @@ describe("useTamboMcpResourceList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1345,6 +1393,9 @@ describe("useTamboMcpResourceList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1378,6 +1429,9 @@ describe("useTamboMcpResourceList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1438,6 +1492,9 @@ describe("useTamboMcpResourceList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1529,6 +1586,9 @@ describe("useTamboMcpResourceList - search filtering", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1641,6 +1701,9 @@ describe("useTamboMcpResource - read individual resource", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1752,6 +1815,9 @@ describe("useTamboMcpResource - read individual resource", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -1819,6 +1885,9 @@ describe("useTamboMcpResource - read individual resource", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider

--- a/react-sdk/src/mcp/tambo-mcp-provider.test.tsx
+++ b/react-sdk/src/mcp/tambo-mcp-provider.test.tsx
@@ -78,6 +78,9 @@ const TestWrapper: React.FC<{
         client,
         queryClient: {} as any,
         isUpdatingToken: false,
+        tokenExchangeError: null,
+        userToken: undefined,
+        hasValidToken: false,
       }}
     >
       <TamboRegistryProvider mcpServers={mcpServers}>
@@ -269,6 +272,9 @@ describe("TamboMcpProvider server list changes", () => {
           client: useTamboClient(),
           queryClient: {} as any,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider mcpServers={["https://a.example"]}>
@@ -293,6 +299,9 @@ describe("TamboMcpProvider server list changes", () => {
           client: useTamboClient(),
           queryClient: {} as any,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -323,6 +332,9 @@ describe("TamboMcpProvider server list changes", () => {
           client: useTamboClient(),
           queryClient: {} as any,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -348,6 +360,9 @@ describe("TamboMcpProvider server list changes", () => {
           client: useTamboClient(),
           queryClient: {} as any,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider mcpServers={["https://a.example"]}>
@@ -507,6 +522,9 @@ describe("TamboMcpProvider server list changes", () => {
           client: useTamboClient(),
           queryClient: {} as any,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -534,6 +552,9 @@ describe("TamboMcpProvider server list changes", () => {
           client: useTamboClient(),
           queryClient: {} as any,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider mcpServers={["https://a.example"]}>
@@ -569,6 +590,9 @@ describe("TamboMcpProvider server list changes", () => {
           client: useTamboClient(),
           queryClient: {} as any,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider

--- a/react-sdk/src/mcp/use-mcp-servers.test.tsx
+++ b/react-sdk/src/mcp/use-mcp-servers.test.tsx
@@ -49,6 +49,9 @@ describe("useTamboMcpServers + TamboMcpProvider", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient: new QueryClient(),
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider
@@ -90,6 +93,9 @@ describe("useTamboMcpServers + TamboMcpProvider", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient: new QueryClient(),
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider mcpServers={[{ url: "https://ok.example" }]}>
@@ -130,6 +136,9 @@ describe("useTamboMcpServers + TamboMcpProvider", () => {
           client: { baseURL: "https://api.tambo.co" } as any,
           queryClient: new QueryClient(),
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider mcpServers={[{ url: "https://fail.example" }]}>

--- a/react-sdk/src/providers/tambo-client-provider.tsx
+++ b/react-sdk/src/providers/tambo-client-provider.tsx
@@ -44,6 +44,12 @@ export interface TamboClientContextProps {
   isUpdatingToken: boolean;
   /** Additional headers to include in all requests */
   additionalHeaders?: Record<string, string>;
+  /** Error from token exchange, if any */
+  tokenExchangeError: Error | null;
+  /** The raw userToken value passed to the provider */
+  userToken: string | undefined;
+  /** Whether the token exchange succeeded */
+  hasValidToken: boolean;
 }
 
 export const TamboClientContext = createContext<
@@ -90,11 +96,11 @@ export const TamboClientProvider: React.FC<
   const queryClient = useMemo(() => new QueryClient(), []);
 
   // Keep the session token updated and get the updating state
-  const { isFetching: isUpdatingToken } = useTamboSessionToken(
-    client,
-    queryClient,
-    userToken,
-  );
+  const {
+    isFetching: isUpdatingToken,
+    error: tokenExchangeError,
+    data: tokenData,
+  } = useTamboSessionToken(client, queryClient, userToken);
 
   return (
     <TamboClientContext.Provider
@@ -103,6 +109,9 @@ export const TamboClientProvider: React.FC<
         queryClient,
         isUpdatingToken,
         additionalHeaders: tamboConfig.defaultHeaders,
+        tokenExchangeError: tokenExchangeError ?? null,
+        userToken,
+        hasValidToken: !!tokenData?.access_token,
       }}
     >
       {children}

--- a/react-sdk/src/providers/tambo-provider.tsx
+++ b/react-sdk/src/providers/tambo-provider.tsx
@@ -168,7 +168,14 @@ export const TamboCompositeProvider: React.FC<PropsWithChildren> = ({
       "TamboCompositeProvider must be used within a TamboClientProvider",
     );
   }
-  const { client, queryClient, isUpdatingToken } = clientContext;
+  const {
+    client,
+    queryClient,
+    isUpdatingToken,
+    tokenExchangeError,
+    userToken,
+    hasValidToken,
+  } = clientContext;
   const componentRegistry = useTamboComponent();
   const interactableComponents = useTamboInteractable();
   const contextHelpers = useTamboContextHelpers();
@@ -180,6 +187,9 @@ export const TamboCompositeProvider: React.FC<PropsWithChildren> = ({
         client,
         queryClient,
         isUpdatingToken,
+        tokenExchangeError,
+        userToken,
+        hasValidToken,
         ...componentRegistry,
         ...threads,
         ...interactableComponents,

--- a/react-sdk/src/providers/tambo-stubs.tsx
+++ b/react-sdk/src/providers/tambo-stubs.tsx
@@ -90,6 +90,9 @@ const TamboStubClientProvider: React.FC<
         client,
         queryClient,
         isUpdatingToken,
+        tokenExchangeError: null,
+        userToken: undefined,
+        hasValidToken: false,
       }}
     >
       {children}

--- a/react-sdk/src/providers/tambo-thread-provider-initial-messages.test.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider-initial-messages.test.tsx
@@ -64,6 +64,9 @@ const createWrapper = (
           client,
           queryClient,
           isUpdatingToken: false,
+          tokenExchangeError: null,
+          userToken: undefined,
+          hasValidToken: false,
         }}
       >
         <TamboRegistryProvider components={[]} tools={tools}>

--- a/react-sdk/src/providers/tambo-thread-provider.test.tsx
+++ b/react-sdk/src/providers/tambo-thread-provider.test.tsx
@@ -167,6 +167,9 @@ describe("TamboThreadProvider", () => {
             client,
             queryClient,
             isUpdatingToken: false,
+            tokenExchangeError: null,
+            userToken: undefined,
+            hasValidToken: false,
           }}
         >
           <TamboRegistryProvider

--- a/react-sdk/src/v1/hooks/use-tambo-v1-auth-state.test.ts
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-auth-state.test.ts
@@ -1,0 +1,152 @@
+import { renderHook } from "@testing-library/react";
+import React from "react";
+import { QueryClient } from "@tanstack/react-query";
+import TamboAI from "@tambo-ai/typescript-sdk";
+import { TamboClientContext } from "../../providers/tambo-client-provider";
+import type { TamboClientContextProps } from "../../providers/tambo-client-provider";
+import {
+  TamboV1ConfigContext,
+  type TamboV1Config,
+} from "../providers/tambo-v1-provider";
+import { useTamboV1AuthState } from "./use-tambo-v1-auth-state";
+
+function createWrapper(
+  clientOverrides: Partial<TamboClientContextProps>,
+  configOverrides: Partial<TamboV1Config> = {},
+) {
+  const clientContext: TamboClientContextProps = {
+    client: {} as TamboAI,
+    queryClient: new QueryClient(),
+    isUpdatingToken: false,
+    tokenExchangeError: null,
+    userToken: undefined,
+    hasValidToken: false,
+    ...clientOverrides,
+  };
+
+  const config: TamboV1Config = {
+    userKey: undefined,
+    ...configOverrides,
+  };
+
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      TamboClientContext.Provider,
+      { value: clientContext },
+      React.createElement(
+        TamboV1ConfigContext.Provider,
+        { value: config },
+        children,
+      ),
+    );
+  }
+  return Wrapper;
+}
+
+describe("useTamboV1AuthState", () => {
+  it("returns 'identified' with source 'userKey' when only userKey is provided", () => {
+    const { result } = renderHook(() => useTamboV1AuthState(), {
+      wrapper: createWrapper({}, { userKey: "user_123" }),
+    });
+
+    expect(result.current).toEqual({
+      status: "identified",
+      source: "userKey",
+    });
+  });
+
+  it("returns 'identified' with source 'tokenExchange' when token exchange succeeded", () => {
+    const { result } = renderHook(() => useTamboV1AuthState(), {
+      wrapper: createWrapper({
+        userToken: "oauth_token",
+        hasValidToken: true,
+      }),
+    });
+
+    expect(result.current).toEqual({
+      status: "identified",
+      source: "tokenExchange",
+    });
+  });
+
+  it("returns 'exchanging' when userToken provided but exchange not yet complete", () => {
+    const { result } = renderHook(() => useTamboV1AuthState(), {
+      wrapper: createWrapper({
+        userToken: "oauth_token",
+        hasValidToken: false,
+      }),
+    });
+
+    expect(result.current).toEqual({ status: "exchanging" });
+  });
+
+  it("returns 'error' when token exchange failed", () => {
+    const exchangeError = new Error("Token exchange failed");
+    const { result } = renderHook(() => useTamboV1AuthState(), {
+      wrapper: createWrapper({
+        userToken: "oauth_token",
+        tokenExchangeError: exchangeError,
+        hasValidToken: false,
+      }),
+    });
+
+    expect(result.current).toEqual({
+      status: "error",
+      error: exchangeError,
+    });
+  });
+
+  it("returns 'invalid' when both userKey and userToken are provided", () => {
+    const { result } = renderHook(() => useTamboV1AuthState(), {
+      wrapper: createWrapper(
+        { userToken: "oauth_token" },
+        { userKey: "user_123" },
+      ),
+    });
+
+    expect(result.current).toEqual({ status: "invalid" });
+  });
+
+  it("returns 'unauthenticated' when neither userKey nor userToken is provided", () => {
+    const { result } = renderHook(() => useTamboV1AuthState(), {
+      wrapper: createWrapper({}),
+    });
+
+    expect(result.current).toEqual({ status: "unauthenticated" });
+  });
+
+  it("throws when used outside TamboClientContext", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        TamboV1ConfigContext.Provider,
+        { value: { userKey: "x" } },
+        children,
+      );
+
+    expect(() => renderHook(() => useTamboV1AuthState(), { wrapper })).toThrow(
+      "useTamboV1AuthState must be used within TamboV1Provider",
+    );
+  });
+
+  it("throws when used outside TamboV1ConfigContext", () => {
+    const clientContext: TamboClientContextProps = {
+      client: {} as TamboAI,
+      queryClient: new QueryClient(),
+      isUpdatingToken: false,
+      tokenExchangeError: null,
+      userToken: undefined,
+      hasValidToken: false,
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        TamboClientContext.Provider,
+        { value: clientContext },
+        children,
+      );
+
+    expect(() => renderHook(() => useTamboV1AuthState(), { wrapper })).toThrow(
+      "useTamboV1AuthState must be used within TamboV1Provider",
+    );
+  });
+});

--- a/react-sdk/src/v1/hooks/use-tambo-v1-auth-state.ts
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-auth-state.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useContext } from "react";
+import { TamboClientContext } from "../../providers/tambo-client-provider";
+import { TamboV1ConfigContext } from "../providers/tambo-v1-provider";
+import type { TamboV1AuthState } from "../types/auth";
+
+/**
+ * Hook to compute the current authentication state for the v1 SDK.
+ *
+ * Reads from TamboClientContext and TamboV1ConfigContext to determine
+ * whether the SDK is ready to make API calls.
+ * @returns The current auth state as a discriminated union
+ * @throws {Error} If used outside TamboV1Provider
+ */
+export function useTamboV1AuthState(): TamboV1AuthState {
+  const clientContext = useContext(TamboClientContext);
+  if (!clientContext) {
+    throw new Error("useTamboV1AuthState must be used within TamboV1Provider");
+  }
+
+  const config = useContext(TamboV1ConfigContext);
+  if (!config) {
+    throw new Error("useTamboV1AuthState must be used within TamboV1Provider");
+  }
+
+  const { tokenExchangeError, userToken, hasValidToken } = clientContext;
+  const { userKey } = config;
+
+  // Invalid: both userKey AND userToken provided
+  if (userKey && userToken) {
+    return { status: "invalid" };
+  }
+
+  // Identified via userKey
+  if (userKey) {
+    return { status: "identified", source: "userKey" };
+  }
+
+  // Token exchange scenarios
+  if (userToken) {
+    if (tokenExchangeError) {
+      return { status: "error", error: tokenExchangeError };
+    }
+    if (hasValidToken) {
+      return { status: "identified", source: "tokenExchange" };
+    }
+    return { status: "exchanging" };
+  }
+
+  // Neither provided
+  return { status: "unauthenticated" };
+}

--- a/react-sdk/src/v1/hooks/use-tambo-v1-send-message.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-send-message.test.tsx
@@ -26,6 +26,13 @@ jest.mock("../providers/tambo-v1-provider", () => ({
   useTamboV1Config: jest.fn(),
 }));
 
+jest.mock("./use-tambo-v1-auth-state", () => ({
+  useTamboV1AuthState: () => ({
+    status: "identified",
+    source: "userKey",
+  }),
+}));
+
 jest.mock("../../providers/tambo-context-helpers-provider", () => ({
   useTamboContextHelpers: () => ({
     getAdditionalContext: jest.fn().mockResolvedValue([]),

--- a/react-sdk/src/v1/hooks/use-tambo-v1-thread-input.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-thread-input.test.tsx
@@ -20,6 +20,13 @@ jest.mock("../../providers/tambo-client-provider", () => ({
   useTamboClient: jest.fn(),
 }));
 
+jest.mock("./use-tambo-v1-auth-state", () => ({
+  useTamboV1AuthState: () => ({
+    status: "identified",
+    source: "userKey",
+  }),
+}));
+
 const createSuccessfulFileReader = () => {
   const reader = {
     readAsDataURL: jest.fn(),

--- a/react-sdk/src/v1/hooks/use-tambo-v1-thread-list.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-thread-list.test.tsx
@@ -18,6 +18,13 @@ jest.mock("../providers/tambo-v1-provider", () => ({
   useTamboV1Config: jest.fn(),
 }));
 
+jest.mock("./use-tambo-v1-auth-state", () => ({
+  useTamboV1AuthState: () => ({
+    status: "identified",
+    source: "userKey",
+  }),
+}));
+
 describe("useTamboV1ThreadList", () => {
   const mockThreads = {
     threads: [

--- a/react-sdk/src/v1/hooks/use-tambo-v1-thread-list.ts
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-thread-list.ts
@@ -14,6 +14,7 @@ import type {
 import { useTamboClient } from "../../providers/tambo-client-provider";
 import { useTamboQuery } from "../../hooks/react-query-hooks";
 import { useTamboV1Config } from "../providers/tambo-v1-provider";
+import { useTamboV1AuthState } from "./use-tambo-v1-auth-state";
 
 /**
  * Options for fetching thread list.
@@ -66,6 +67,8 @@ export function useTamboV1ThreadList(
 ) {
   const client = useTamboClient();
   const { userKey: contextUserKey } = useTamboV1Config();
+  const authState = useTamboV1AuthState();
+  const isIdentified = authState.status === "identified";
 
   // Merge userKey from context with provided options (explicit option takes precedence)
   const effectiveOptions: ThreadListParams | undefined =
@@ -78,5 +81,6 @@ export function useTamboV1ThreadList(
     queryFn: async () => await client.threads.list(effectiveOptions),
     staleTime: 5000, // Consider stale after 5s
     ...queryOptions,
+    enabled: isIdentified && (queryOptions?.enabled ?? true),
   });
 }

--- a/react-sdk/src/v1/hooks/use-tambo-v1-thread.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-thread.test.tsx
@@ -13,6 +13,13 @@ jest.mock("../../providers/tambo-client-provider", () => ({
   useTamboQueryClient: jest.fn(),
 }));
 
+jest.mock("./use-tambo-v1-auth-state", () => ({
+  useTamboV1AuthState: () => ({
+    status: "identified",
+    source: "userKey",
+  }),
+}));
+
 describe("useTamboV1Thread", () => {
   const mockThread = {
     id: "thread_123",

--- a/react-sdk/src/v1/hooks/use-tambo-v1-thread.ts
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-thread.ts
@@ -10,6 +10,7 @@ import type { UseQueryOptions } from "@tanstack/react-query";
 import type { ThreadRetrieveResponse } from "@tambo-ai/typescript-sdk/resources/threads/threads";
 import { useTamboClient } from "../../providers/tambo-client-provider";
 import { useTamboQuery } from "../../hooks/react-query-hooks";
+import { useTamboV1AuthState } from "./use-tambo-v1-auth-state";
 
 /**
  * Hook to fetch a single thread by ID.
@@ -47,11 +48,14 @@ export function useTamboV1Thread(
   >,
 ) {
   const client = useTamboClient();
+  const authState = useTamboV1AuthState();
+  const isIdentified = authState.status === "identified";
 
   return useTamboQuery({
     queryKey: ["v1-threads", threadId],
     queryFn: async () => await client.threads.retrieve(threadId),
     staleTime: 1000, // Consider stale after 1s (real-time data)
     ...options,
+    enabled: isIdentified && (options?.enabled ?? true),
   });
 }

--- a/react-sdk/src/v1/hooks/use-tambo-v1.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1.test.tsx
@@ -21,6 +21,13 @@ jest.mock("../../providers/tambo-client-provider", () => ({
   useTamboQueryClient: jest.fn(),
 }));
 
+jest.mock("./use-tambo-v1-auth-state", () => ({
+  useTamboV1AuthState: () => ({
+    status: "identified",
+    source: "userKey",
+  }),
+}));
+
 import { useTamboQueryClient } from "../../providers/tambo-client-provider";
 
 describe("useTamboV1", () => {

--- a/react-sdk/src/v1/hooks/use-tambo-v1.ts
+++ b/react-sdk/src/v1/hooks/use-tambo-v1.ts
@@ -17,6 +17,8 @@ import React, {
   type ReactElement,
 } from "react";
 import { useTamboClient } from "../../providers/tambo-client-provider";
+import { useTamboV1AuthState } from "./use-tambo-v1-auth-state";
+import type { TamboV1AuthState } from "../types/auth";
 import {
   TamboRegistryContext,
   type TamboRegistryContext as TamboRegistryContextType,
@@ -135,6 +137,18 @@ export interface UseTamboV1Return {
    * No-op if there's no active run or thread is a placeholder.
    */
   cancelRun: () => Promise<void>;
+
+  /**
+   * Current authentication state.
+   * Use this to show auth-related UI or conditionally render features.
+   */
+  authState: TamboV1AuthState;
+
+  /**
+   * Shorthand for `authState.status === "identified"`.
+   * When true, the SDK is ready to make API calls.
+   */
+  isIdentified: boolean;
 }
 
 /**
@@ -185,6 +199,7 @@ export function useTamboV1(): UseTamboV1Return {
   const dispatch = useStreamDispatch();
   const registry = useContext(TamboRegistryContext);
   const threadManagement = useThreadManagement();
+  const authState = useTamboV1AuthState();
 
   // Cache for rendered component wrappers - maintains stable element references
   // across renders when props haven't changed
@@ -356,6 +371,8 @@ export function useTamboV1(): UseTamboV1Return {
       startNewThread: threadManagement.startNewThread,
       dispatch,
       cancelRun,
+      authState,
+      isIdentified: authState.status === "identified",
     };
   }, [
     cancelRun,
@@ -365,5 +382,6 @@ export function useTamboV1(): UseTamboV1Return {
     streamState.currentThreadId,
     threadManagement,
     dispatch,
+    authState,
   ]);
 }

--- a/react-sdk/src/v1/index.ts
+++ b/react-sdk/src/v1/index.ts
@@ -121,6 +121,8 @@ export {
 
 export { useTamboV1 } from "./hooks/use-tambo-v1";
 
+export type { TamboV1AuthState } from "./types/auth";
+
 export type { ToolChoice } from "./types/tool-choice";
 
 export { useTamboV1ThreadInput } from "./hooks/use-tambo-v1-thread-input";

--- a/react-sdk/src/v1/providers/tambo-v1-provider.test.tsx
+++ b/react-sdk/src/v1/providers/tambo-v1-provider.test.tsx
@@ -26,6 +26,14 @@ jest.mock("../../providers/tambo-client-provider", () => {
   };
 });
 
+// Mock auth state to avoid TamboClientContext dependency
+jest.mock("../hooks/use-tambo-v1-auth-state", () => ({
+  useTamboV1AuthState: () => ({
+    status: "identified",
+    source: "userKey",
+  }),
+}));
+
 // Mock useTamboV1SendMessage to avoid complex dependencies
 jest.mock("../hooks/use-tambo-v1-send-message", () => ({
   useTamboV1SendMessage: jest.fn(() => ({

--- a/react-sdk/src/v1/providers/tambo-v1-stub-provider.tsx
+++ b/react-sdk/src/v1/providers/tambo-v1-stub-provider.tsx
@@ -307,6 +307,7 @@ export function TamboV1StubProvider({
       context: undefined,
       submittedAt: 0,
       isPaused: false,
+      isDisabled: false,
     };
   }, [inputValue, threadId, onSubmit, onSetValue, setInputValueInternal]);
 
@@ -339,6 +340,9 @@ export function TamboV1StubProvider({
       client: stubClient,
       queryClient,
       isUpdatingToken: false,
+      tokenExchangeError: null,
+      userToken: undefined,
+      hasValidToken: false,
     }),
     [stubClient, queryClient],
   );

--- a/react-sdk/src/v1/types/auth.ts
+++ b/react-sdk/src/v1/types/auth.ts
@@ -1,0 +1,16 @@
+/**
+ * Authentication state for the v1 SDK.
+ *
+ * Discriminated union tracking the current auth lifecycle:
+ * - `identified`: ready to make API calls (via userKey or successful token exchange)
+ * - `exchanging`: userToken provided, exchange in-flight
+ * - `error`: token exchange failed
+ * - `invalid`: both userKey AND userToken provided (must choose one)
+ * - `unauthenticated`: neither userKey nor userToken provided
+ */
+export type TamboV1AuthState =
+  | { status: "identified"; source: "userKey" | "tokenExchange" }
+  | { status: "exchanging" }
+  | { status: "error"; error: Error }
+  | { status: "invalid" }
+  | { status: "unauthenticated" };


### PR DESCRIPTION
Fixes TAM-1147

## Summary

- Add `TamboV1AuthState` discriminated union type tracking 5 auth states: `identified`, `exchanging`, `error`, `invalid`, `unauthenticated`
- Gate thread-list and thread queries with `enabled` flag so they don't fire before auth is ready
- Fail-fast in `sendMessage` and thread input `submit` when not authenticated, with descriptive error messages
- Add `isDisabled` to thread input context combining pending + auth state for UI consumers
- Emit console warnings when `TamboV1Provider` is misconfigured (no credentials, both credentials, exchange failure)
- Expose `authState` and `isIdentified` from `useTamboV1()` hook

## Usage

### Auth state via `useTamboV1()`

```tsx
function ChatInterface() {
  const { messages, authState, isIdentified } = useTamboV1();
  const { value, setValue, submit, isDisabled } = useTamboV1ThreadInput();

  if (authState.status === "exchanging") {
    return <div>Authenticating...</div>;
  }

  if (authState.status === "error") {
    return <div>Auth failed: {authState.error.message}</div>;
  }

  return (
    <form onSubmit={(e) => { e.preventDefault(); submit(); }}>
      {messages.map((msg) => <Message key={msg.id} message={msg} />)}
      <input
        value={value}
        onChange={(e) => setValue(e.target.value)}
        disabled={isDisabled}
      />
      <button disabled={isDisabled}>Send</button>
    </form>
  );
}
```

### Auth-gated queries with `useTamboV1ThreadList()`

Queries are automatically disabled until auth is ready — no extra work needed:

```tsx
function ThreadSidebar() {
  const { isIdentified } = useTamboV1();
  // This query won't fire until the user is authenticated
  const { data: threads, isLoading } = useTamboV1ThreadList();

  if (!isIdentified) return <div>Sign in to see threads</div>;
  if (isLoading) return <div>Loading threads...</div>;

  return (
    <ul>
      {threads?.data.map((t) => <li key={t.id}>{t.name}</li>)}
    </ul>
  );
}
```

## Test plan

- [x] All 1081 existing tests pass
- [x] New `use-tambo-v1-auth-state.test.ts` covers all 5 auth states plus context-missing error cases
- [x] `npm run check-types` passes
- [x] `npm run lint` passes
- [ ] Manual: verify auth state transitions in showcase app with `userKey` and `userToken` configurations

🤖 Generated with [Claude Code](https://claude.ai/code)