### PR TITLE
feat(react-sdk): pass maxCalls through in V1 toAvailableTool() conversion

### DIFF
--- a/react-sdk/src/v1/utils/registry-conversion.test.ts
+++ b/react-sdk/src/v1/utils/registry-conversion.test.ts
@@ -166,6 +166,35 @@ describe("registry-conversion", () => {
       );
     });
 
+    it("includes maxCalls when set", () => {
+      const tool: TamboTool = {
+        name: "limited_tool",
+        description: "Tool with call limit",
+        tool: async () => ({}),
+        inputSchema: z.object({ x: z.string() }),
+        outputSchema: z.any(),
+        maxCalls: 3,
+      };
+
+      const result = toAvailableTool(tool);
+
+      expect(result.maxCalls).toBe(3);
+    });
+
+    it("omits maxCalls when not set", () => {
+      const tool: TamboTool = {
+        name: "unlimited_tool",
+        description: "Tool without call limit",
+        tool: async () => ({}),
+        inputSchema: z.object({ x: z.string() }),
+        outputSchema: z.any(),
+      };
+
+      const result = toAvailableTool(tool);
+
+      expect(result).not.toHaveProperty("maxCalls");
+    });
+
     it("throws when schema is missing", () => {
       const tool = {
         name: "bad_tool",

--- a/react-sdk/src/v1/utils/registry-conversion.ts
+++ b/react-sdk/src/v1/utils/registry-conversion.ts
@@ -100,6 +100,7 @@ export function toAvailableTool(
       name: tool.name,
       description: tool.description,
       inputSchema: inputSchema as Record<string, unknown>,
+      ...(tool.maxCalls !== undefined ? { maxCalls: tool.maxCalls } : {}),
     };
   }
 
@@ -110,6 +111,7 @@ export function toAvailableTool(
       name: tool.name,
       description: tool.description,
       inputSchema: inputSchema as Record<string, unknown>,
+      ...(tool.maxCalls !== undefined ? { maxCalls: tool.maxCalls } : {}),
     };
   }
 


### PR DESCRIPTION
## Summary

- `toAvailableTool()` in `registry-conversion.ts` was silently dropping the per-tool `maxCalls` limit when converting `TamboTool` to V1 API format
- The API DTO and backend `convertV1ToolToInternal()` already support `maxCalls` — this closes the SDK-side gap so the field flows end-to-end
- Added tests for both the present and absent `maxCalls` cases

Fixes TAM-1143

## Test plan

- [x] Existing registry-conversion tests pass (12/12)
- [x] New test: `maxCalls` is included in output when set on tool
- [x] New test: `maxCalls` is omitted from output when not set on tool
- [x] Type check passes
- [x] Lint passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)