### PR TITLE
fix(ci): exclude CHANGELOG.md files from domain check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
             '*.json'
             '*.html'
             ':(exclude)node_modules/**'
+            ':(exclude)**/CHANGELOG.md'
           )
 
           # Examples (match): tambo[.]ai/, tambo[.]ai:443, tambo[.]com/, tambo[.]com:443


### PR DESCRIPTION
## Summary
- Excludes `**/CHANGELOG.md` files from the CI domain check step
- Changelogs are auto-generated and may legitimately contain references to old domains (e.g. `tambo.ai`) from commit messages or PR titles

## Test plan
- [ ] Verify the `Check for incorrect domain` CI step passes with changelog files containing old domain references

🤖 Generated with [Claude Code](https://claude.com/claude-code)