### PR TITLE
 fix(react-ui-base, react-sdk): fix message input stuck

### DIFF
--- a/packages/react-ui-base/src/message-input/message-input-root.tsx
+++ b/packages/react-ui-base/src/message-input/message-input-root.tsx
@@ -66,7 +66,6 @@ export const MessageInputRoot = React.forwardRef<
     value,
     setValue,
     submit,
-    isPending,
     error,
     images,
     addImages,
@@ -85,6 +84,12 @@ export const MessageInputRoot = React.forwardRef<
 
   // Use elicitation context (optional)
   const { elicitation, resolveElicitation } = useTamboElicitationContext();
+
+  // Reset local submit state when switching threads so the new thread
+  // isn't blocked by an in-flight submit from the previous thread.
+  React.useEffect(() => {
+    setIsSubmitting(false);
+  }, [currentThreadId]);
 
   React.useEffect(() => {
     // On mount, load any stored draft value, but only if current value is empty
@@ -249,7 +254,7 @@ export const MessageInputRoot = React.forwardRef<
       submitMessage,
       submit,
       handleSubmit,
-      isPending: isPending ?? isSubmitting,
+      isPending: isSubmitting,
       error,
       editorRef: inputRef ?? editorRef,
       submitError,
@@ -273,7 +278,6 @@ export const MessageInputRoot = React.forwardRef<
       submitMessage,
       submit,
       handleSubmit,
-      isPending,
       isSubmitting,
       error,
       inputRef,
@@ -301,7 +305,7 @@ export const MessageInputRoot = React.forwardRef<
         onSubmit={handleSubmit}
         data-slot="message-input-root"
         data-state={isDragging ? "dragging" : undefined}
-        data-pending={isPending || isSubmitting || undefined}
+        data-pending={isSubmitting || undefined}
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}
         onDragOver={handleDragOver}


### PR DESCRIPTION
 - Fix isIdle in useTambo() to treat "complete" status as idle (not just "idle")
  - Replace mutation-level isPending with local isSubmitting for the message input pending flag
  - Reset isSubmitting when currentThreadId changes

  Problem

  Two related bugs blocked sending messages:

  1. Can't send follow-up after run completes (no thread switch needed): useTambo().isIdle only checked status === "idle", but successful runs set status to "complete". So !isIdle stayed true, the cancel button never went away, and the user
  couldn't send another message.
  2. Can't send in new thread after switching: The React Query mutation's isPending stays true across thread switches because it tracks the mutation instance, not the current thread. The submit button checks showCancelButton = isPending ||
  !isIdle — stale isPending made the button call handleCancel (a no-op on a placeholder thread) instead of submitting.

  Fix

  - useTambo().isIdle now returns true for both "idle" and "complete" statuses
  - Message input uses local isSubmitting (reset on thread switch) instead of the mutation's isPending
  - Per-thread !isIdle still correctly shows the cancel button when a stream is active
