### PR TITLE
chore(docs): add package description

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tambo-ai/docs",
   "version": "1.26.0",
+  "description": "Tambo AI documentation site",
   "license": "MIT",
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
## Summary

- Adds missing `description` field to docs package.json
- Includes `Release-As: 1.26.1` to fix release-please version (the global `Release-As: 1.0.0-rc.1` from #2297 incorrectly applied to all packages)

## Context

PR #2297 had a `Release-As: 1.0.0-rc.1` trailer that was only intended for react-sdk, but since it touched files across all packages, release-please applied it globally. This commit overrides that with the correct next version for docs.