### PR TITLE
chore(web): add package description

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tambo-ai-cloud/web",
   "version": "0.132.0",
+  "description": "Tambo Cloud web dashboard",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds missing `description` field to web package.json
- Includes `Release-As: 0.132.1` to fix release-please version (the global `Release-As: 1.0.0-rc.1` from #2297 incorrectly applied to all packages)

## Context

PR #2297 had a `Release-As: 1.0.0-rc.1` trailer that was only intended for react-sdk, but since it touched files across all packages, release-please applied it globally. This commit overrides that with the correct next version for web.