### PR TITLE
chore(showcase): add package description

### DIFF
--- a/showcase/package.json
+++ b/showcase/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tambo-ai/showcase",
   "version": "0.36.0",
+  "description": "Tambo AI component showcase",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary

- Adds missing `description` field to showcase package.json
- Includes `Release-As: 0.37.0` to fix release-please version (the global `Release-As: 1.0.0-rc.1` from #2297 incorrectly applied to all packages)

## Context

PR #2297 had a `Release-As: 1.0.0-rc.1` trailer that was only intended for react-sdk, but since it touched files across all packages, release-please applied it globally. This commit overrides that with the correct next version for showcase.