### PR TITLE
chore(cli): update package description

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tambo",
   "version": "0.51.0",
-  "description": "Tambo command-line tool",
+  "description": "Tambo CLI for scaffolding and managing AI applications",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Updates `description` field in cli package.json
- Includes `Release-As: 0.52.0` to fix release-please version (the global `Release-As: 1.0.0-rc.1` from #2297 incorrectly applied to all packages)

## Context

PR #2297 had a `Release-As: 1.0.0-rc.1` trailer that was only intended for react-sdk, but since it touched files across all packages, release-please applied it globally. This commit overrides that with the correct next version for cli.