### PR TITLE
chore(react-ui-base): add package description

### DIFF
--- a/packages/react-ui-base/package.json
+++ b/packages/react-ui-base/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tambo-ai/react-ui-base",
   "version": "0.1.0-alpha.2",
+  "description": "Headless base components for Tambo AI",
   "author": {
     "name": "Tambo",
     "url": "https://tambo.co"


### PR DESCRIPTION
## Summary

- Adds missing `description` field to react-ui-base package.json
- Includes `Release-As: 0.1.0-alpha.3` to fix release-please version (the global `Release-As: 1.0.0-rc.1` from #2297 incorrectly applied to all packages)

## Context

PR #2297 had a `Release-As: 1.0.0-rc.1` trailer that was only intended for react-sdk, but since it touched files across all packages, release-please applied it globally. This commit overrides that with the correct next version for react-ui-base.