### PR TITLE
fix(ui-registry): use @tambo-ai/react@rc in component configs

### DIFF
--- a/packages/ui-registry/src/components/canvas-space/config.json
+++ b/packages/ui-registry/src/components/canvas-space/config.json
@@ -2,7 +2,7 @@
   "name": "canvas-space",
   "description": "A canvas space component that displays rendered components from chat messages.",
   "componentName": "CanvasSpace",
-  "dependencies": ["@tambo-ai/react"],
+  "dependencies": ["@tambo-ai/react@rc"],
   "devDependencies": [],
   "requires": [],
   "files": [

--- a/packages/ui-registry/src/components/control-bar/config.json
+++ b/packages/ui-registry/src/components/control-bar/config.json
@@ -2,7 +2,11 @@
   "name": "control-bar",
   "description": "Provides controls and actions in the interface",
   "componentName": "ControlBar",
-  "dependencies": ["@tambo-ai/react", "radix-ui", "class-variance-authority"],
+  "dependencies": [
+    "@tambo-ai/react@rc",
+    "radix-ui",
+    "class-variance-authority"
+  ],
   "devDependencies": [],
   "requires": [
     "thread-content",

--- a/packages/ui-registry/src/components/edit-with-tambo-button/config.json
+++ b/packages/ui-registry/src/components/edit-with-tambo-button/config.json
@@ -3,7 +3,7 @@
   "description": "Inline AI editor button with floating popover for interactable components",
   "componentName": "EditWithTamboButton",
   "dependencies": [
-    "@tambo-ai/react",
+    "@tambo-ai/react@rc",
     "lucide-react",
     "@radix-ui/react-popover",
     "@radix-ui/react-tooltip"

--- a/packages/ui-registry/src/components/elicitation-ui/config.json
+++ b/packages/ui-registry/src/components/elicitation-ui/config.json
@@ -2,7 +2,7 @@
   "name": "elicitation-ui",
   "description": "MCP elicitation UI component for handling user input requests from MCP servers",
   "componentName": "ElicitationUI",
-  "dependencies": ["@tambo-ai/react"],
+  "dependencies": ["@tambo-ai/react@rc"],
   "devDependencies": [],
   "requires": [],
   "files": [

--- a/packages/ui-registry/src/components/form/config.json
+++ b/packages/ui-registry/src/components/form/config.json
@@ -5,7 +5,7 @@
   "dependencies": [
     "class-variance-authority",
     "lucide-react",
-    "@tambo-ai/react"
+    "@tambo-ai/react@rc"
   ],
   "devDependencies": [],
   "requires": [],

--- a/packages/ui-registry/src/components/graph/config.json
+++ b/packages/ui-registry/src/components/graph/config.json
@@ -2,7 +2,11 @@
   "name": "graph",
   "description": "Visualizes and interacts with graph-based data structures",
   "componentName": "Graph",
-  "dependencies": ["class-variance-authority", "recharts", "@tambo-ai/react"],
+  "dependencies": [
+    "class-variance-authority",
+    "recharts",
+    "@tambo-ai/react@rc"
+  ],
   "devDependencies": [],
   "requires": [],
   "files": [

--- a/packages/ui-registry/src/components/map/config.json
+++ b/packages/ui-registry/src/components/map/config.json
@@ -9,7 +9,7 @@
     "leaflet",
     "leaflet.heat",
     "leaflet.markercluster",
-    "@tambo-ai/react"
+    "@tambo-ai/react@rc"
   ],
   "devDependencies": [],
   "requires": [],

--- a/packages/ui-registry/src/components/mcp-components/config.json
+++ b/packages/ui-registry/src/components/mcp-components/config.json
@@ -3,7 +3,7 @@
   "description": "MCP prompt and resource picker buttons for message input",
   "componentName": "MCPComponents",
   "dependencies": [
-    "@tambo-ai/react",
+    "@tambo-ai/react@rc",
     "lucide-react",
     "@radix-ui/react-dropdown-menu"
   ],

--- a/packages/ui-registry/src/components/message-input/config.json
+++ b/packages/ui-registry/src/components/message-input/config.json
@@ -5,7 +5,7 @@
   "dependencies": [
     "class-variance-authority",
     "@radix-ui/react-popover",
-    "@tambo-ai/react",
+    "@tambo-ai/react@rc",
     "@tambo-ai/react-ui-base@next",
     "@tiptap/extension-document",
     "@tiptap/extension-hard-break",

--- a/packages/ui-registry/src/components/message-suggestions/config.json
+++ b/packages/ui-registry/src/components/message-suggestions/config.json
@@ -2,7 +2,7 @@
   "name": "message-suggestions",
   "description": "Displays AI-generated message suggestions to help users compose responses",
   "componentName": "MessageSuggestions",
-  "dependencies": ["lucide-react", "@tambo-ai/react", "radix-ui"],
+  "dependencies": ["lucide-react", "@tambo-ai/react@rc", "radix-ui"],
   "devDependencies": [],
   "requires": [],
   "files": [

--- a/packages/ui-registry/src/components/message-thread-collapsible/config.json
+++ b/packages/ui-registry/src/components/message-thread-collapsible/config.json
@@ -3,7 +3,7 @@
   "description": "Displays message threads that can be expanded or collapsed",
   "componentName": "MessageThreadCollapsible",
   "dependencies": [
-    "@tambo-ai/react",
+    "@tambo-ai/react@rc",
     "radix-ui",
     "lucide-react",
     "class-variance-authority"

--- a/packages/ui-registry/src/components/message-thread-full/config.json
+++ b/packages/ui-registry/src/components/message-thread-full/config.json
@@ -2,7 +2,7 @@
   "name": "message-thread-full",
   "description": "Displays a complete message thread with all its content and interactions",
   "componentName": "MessageThreadFull",
-  "dependencies": ["@tambo-ai/react", "class-variance-authority"],
+  "dependencies": ["@tambo-ai/react@rc", "class-variance-authority"],
   "devDependencies": [],
   "requires": [
     "thread-content",

--- a/packages/ui-registry/src/components/message-thread-panel/config.json
+++ b/packages/ui-registry/src/components/message-thread-panel/config.json
@@ -2,7 +2,7 @@
   "name": "message-thread-panel",
   "description": "Displays a message thread in a side panel or modal context",
   "componentName": "MessageThreadPanel",
-  "dependencies": ["@tambo-ai/react", "class-variance-authority"],
+  "dependencies": ["@tambo-ai/react@rc", "class-variance-authority"],
   "devDependencies": [],
   "requires": [
     "thread-content",

--- a/packages/ui-registry/src/components/message/config.json
+++ b/packages/ui-registry/src/components/message/config.json
@@ -7,7 +7,7 @@
     "streamdown",
     "lucide-react",
     "highlight.js",
-    "@tambo-ai/react",
+    "@tambo-ai/react@rc",
     "@tambo-ai/react-ui-base@next",
     "@tambo-ai/typescript-sdk",
     "dompurify",

--- a/packages/ui-registry/src/components/scrollable-message-container/config.json
+++ b/packages/ui-registry/src/components/scrollable-message-container/config.json
@@ -2,7 +2,7 @@
   "name": "scrollable-message-container",
   "description": "A container that scrolls to the bottom when new messages are added",
   "componentName": "ScrollableMessageContainer",
-  "dependencies": ["@tambo-ai/react"],
+  "dependencies": ["@tambo-ai/react@rc"],
   "devDependencies": [],
   "requires": [],
   "files": [

--- a/packages/ui-registry/src/components/thread-content/config.json
+++ b/packages/ui-registry/src/components/thread-content/config.json
@@ -2,7 +2,7 @@
   "name": "thread-content",
   "description": "Displays the messages within a thread",
   "componentName": "ThreadContent",
-  "dependencies": ["class-variance-authority", "@tambo-ai/react"],
+  "dependencies": ["class-variance-authority", "@tambo-ai/react@rc"],
   "devDependencies": [],
   "requires": ["message"],
   "files": [

--- a/packages/ui-registry/src/components/thread-dropdown/config.json
+++ b/packages/ui-registry/src/components/thread-dropdown/config.json
@@ -4,7 +4,7 @@
   "componentName": "ThreadDropdown",
   "dependencies": [
     "class-variance-authority",
-    "@tambo-ai/react",
+    "@tambo-ai/react@rc",
     "lucide-react",
     "radix-ui"
   ],

--- a/packages/ui-registry/src/components/thread-history/config.json
+++ b/packages/ui-registry/src/components/thread-history/config.json
@@ -2,7 +2,7 @@
   "name": "thread-history",
   "description": "Displays the chronological history of a conversation thread",
   "componentName": "ThreadHistory",
-  "dependencies": ["lucide-react", "@tambo-ai/react", "radix-ui"],
+  "dependencies": ["lucide-react", "@tambo-ai/react@rc", "radix-ui"],
   "devDependencies": [],
   "requires": [],
   "files": [


### PR DESCRIPTION
## Summary
- Update all 18 ui-registry component `config.json` files to reference `@tambo-ai/react@rc` instead of `@tambo-ai/react`
- Ensures `tambo add` installs the rc release of `@tambo-ai/react` rather than the latest stable

## Test plan
- [ ] Verify `tambo add` installs `@tambo-ai/react@rc` for any ui-registry component

🤖 Generated with [Claude Code](https://claude.com/claude-code)