### PR TITLE
fix(react-ui-base): hide loading bubbles when tool_use or component blocks exist

### DIFF
--- a/packages/react-ui-base/src/utils/check-has-content.test.ts
+++ b/packages/react-ui-base/src/utils/check-has-content.test.ts
@@ -107,7 +107,7 @@ describe("checkHasContent", () => {
     });
   });
 
-  describe("array content with API content parts (ChatCompletionContentPart)", () => {
+  describe("array content with Content parts", () => {
     it("returns true for text content part with non-empty text", () => {
       expect(checkHasContent([{ type: "text", text: "Hello" }])).toBe(true);
     });
@@ -123,65 +123,7 @@ describe("checkHasContent", () => {
     it("returns false for text content part with undefined text", () => {
       // Test runtime behavior with malformed data
       expect(
-        checkHasContent([
-          { type: "text" } as unknown as { type: "text"; text: string },
-        ]),
-      ).toBe(false);
-    });
-
-    it("returns true for image_url-like content part with url", () => {
-      // Test runtime behavior with non-V1 content types
-      expect(
-        checkHasContent([
-          {
-            type: "image_url",
-            image_url: { url: "https://example.com/img.png" },
-          } as unknown as { type: "text"; text: string },
-        ]),
-      ).toBe(true);
-    });
-
-    it("returns false for image_url-like content part without url", () => {
-      // Test runtime behavior with malformed data
-      expect(
-        checkHasContent([
-          { type: "image_url", image_url: {} } as unknown as {
-            type: "text";
-            text: string;
-          },
-        ]),
-      ).toBe(false);
-    });
-
-    it("returns false for image_url-like content part with undefined image_url", () => {
-      expect(
-        checkHasContent([
-          { type: "image_url" } as unknown as { type: "text"; text: string },
-        ]),
-      ).toBe(false);
-    });
-
-    it("returns true for input_audio-like content part with data", () => {
-      // Test runtime behavior with non-V1 content types
-      expect(
-        checkHasContent([
-          {
-            type: "input_audio",
-            input_audio: { data: "base64data", format: "wav" },
-          } as unknown as { type: "text"; text: string },
-        ]),
-      ).toBe(true);
-    });
-
-    it("returns false for input_audio-like content part without data", () => {
-      // Test runtime behavior with malformed data
-      expect(
-        checkHasContent([
-          { type: "input_audio", input_audio: {} } as unknown as {
-            type: "text";
-            text: string;
-          },
-        ]),
+        checkHasContent([{ type: "text" } as { type: "text"; text: string }]),
       ).toBe(false);
     });
 
@@ -205,24 +147,6 @@ describe("checkHasContent", () => {
       ).toBe(false);
     });
 
-    it("returns true for mixed API content parts (some valid)", () => {
-      expect(
-        checkHasContent([
-          { type: "text", text: "" },
-          { type: "text", text: "Hello" },
-        ]),
-      ).toBe(true);
-    });
-
-    it("returns false for unknown type content part", () => {
-      // Test runtime behavior with unknown type (not a valid V1 Content type)
-      expect(
-        checkHasContent([
-          { type: "unknown" } as unknown as { type: "text"; text: string },
-        ]),
-      ).toBe(false);
-    });
-
     it("returns true for tool_use content part", () => {
       expect(
         checkHasContent([
@@ -231,7 +155,7 @@ describe("checkHasContent", () => {
             id: "tool_1",
             name: "get_weather",
             input: { city: "SF" },
-          } as unknown as { type: "text"; text: string },
+          },
         ]),
       ).toBe(true);
     });
@@ -244,7 +168,7 @@ describe("checkHasContent", () => {
             id: "tool_1",
             name: "get_weather",
             input: {},
-          } as unknown as { type: "text"; text: string },
+          },
         ]),
       ).toBe(true);
     });
@@ -257,7 +181,7 @@ describe("checkHasContent", () => {
             id: "comp_1",
             name: "WeatherCard",
             props: { city: "SF" },
-          } as unknown as { type: "text"; text: string },
+          },
         ]),
       ).toBe(true);
     });
@@ -270,9 +194,27 @@ describe("checkHasContent", () => {
             id: "comp_1",
             name: "WeatherCard",
             props: {},
-          } as unknown as { type: "text"; text: string },
+          },
         ]),
       ).toBe(true);
+    });
+
+    it("returns true for mixed content parts (some valid)", () => {
+      expect(
+        checkHasContent([
+          { type: "text", text: "" },
+          { type: "text", text: "Hello" },
+        ]),
+      ).toBe(true);
+    });
+
+    it("returns false for unknown type content part", () => {
+      // Test runtime behavior with unknown type (not a valid Content type)
+      expect(
+        checkHasContent([
+          { type: "unknown" } as unknown as { type: "text"; text: string },
+        ]),
+      ).toBe(false);
     });
 
     it("returns true for mixed tool_use and empty text content parts", () => {
@@ -284,7 +226,7 @@ describe("checkHasContent", () => {
             id: "tool_1",
             name: "search",
             input: {},
-          } as unknown as { type: "text"; text: string },
+          },
         ]),
       ).toBe(true);
     });
@@ -298,7 +240,7 @@ describe("checkHasContent", () => {
             id: "comp_1",
             name: "Chart",
             props: {},
-          } as unknown as { type: "text"; text: string },
+          },
         ]),
       ).toBe(true);
     });


### PR DESCRIPTION
## Summary

- Fixes loading indicator (bouncing dots) incorrectly appearing above tool call UI when assistant messages have `tool_use` or `component` content blocks but no text content
- Adds `tool_use` and `component` to the content type checks in `checkHasContent()` so these block types are recognized as meaningful content
- Refactors `hasContentInApiPart()` → `hasMeaningfulContent()` using `Partial<Content>` from the SDK instead of a loose object type
- Removes `image_url` and `input_audio` checks (not V1 content types — these are OpenAI-specific types that don't exist in the Tambo SDK)
- Cleans up tests to use real `Content` shapes instead of casting through `as unknown`

## Changes

**`packages/react-ui-base/src/utils/check-has-content.ts`**
- Renamed `hasContentInApiPart()` → `hasMeaningfulContent()` with `Partial<Content>` param type
- Refactored to switch statement
- Added `tool_use` and `component` cases that return `true` (presence = content)
- Removed `image_url` and `input_audio` cases (not V1 content types)

**`packages/react-ui-base/src/utils/check-has-content.test.ts`**
- Removed 5 tests for `image_url` and `input_audio` content types
- Updated remaining tests to use real `Content` shapes (removed `as unknown` casts)
- Renamed describe block from "ChatCompletionContentPart" to "Content parts"

## Test plan

- [x] All 37 unit tests pass
- [x] `turbo lint --filter=@tambo-ai/react-ui-base` passes (0 errors)
- [x] `turbo check-types --filter=@tambo-ai/react-ui-base` passes (0 errors)
- [x] Pattern consistency verified against `getToolCallRequest()` and `MessageRenderedComponent` which use the same type-only checks

Fixes TAM-1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)