### PR TITLE
fix: remove displayMessage tambo param

### DIFF
--- a/apps/api/src/v1/__tests__/v1.service.test.ts
+++ b/apps/api/src/v1/__tests__/v1.service.test.ts
@@ -1004,7 +1004,6 @@ describe("V1Service", () => {
         location: "San Francisco",
         _tambo_statusMessage: "Getting weather for San Francisco...",
         _tambo_completionStatusMessage: "Got weather for San Francisco",
-        _tambo_displayMessage: "Fetching weather data",
       });
     });
 

--- a/apps/api/src/v1/v1-conversions.ts
+++ b/apps/api/src/v1/v1-conversions.ts
@@ -299,10 +299,6 @@ export function contentToV1Blocks(
       if (typeof decision.completionStatusMessage === "string") {
         input._tambo_completionStatusMessage = decision.completionStatusMessage;
       }
-      // The display message is stored as 'message' in componentDecision
-      if (typeof decision.message === "string" && decision.message.trim()) {
-        input._tambo_displayMessage = decision.message;
-      }
     }
 
     const toolUseBlock: V1ToolUseContentDto = {

--- a/packages/backend/src/services/decision-loop/decision-loop-service.ts
+++ b/packages/backend/src/services/decision-loop/decision-loop-service.ts
@@ -214,7 +214,6 @@ export async function* runDecisionLoop(
           // Ignore parse errors for incomplete JSON
         }
       }
-      const paramDisplayMessage = toolArgs._tambo_displayMessage;
       const statusMessage = toolArgs._tambo_statusMessage;
       const completionStatusMessage = toolArgs._tambo_completionStatusMessage;
 
@@ -243,7 +242,7 @@ export async function* runDecisionLoop(
       }
 
       const displayMessage = extractMessageContent(
-        message.length > 0 ? message.trim() : paramDisplayMessage || " ",
+        message.length > 0 ? message.trim() : " ",
         false,
       );
 

--- a/packages/backend/src/services/tool/tool-service.ts
+++ b/packages/backend/src/services/tool/tool-service.ts
@@ -15,18 +15,12 @@ import { ToolRegistry } from "../../systemTools";
 export interface TamboToolParameters {
   _tambo_statusMessage: string;
   _tambo_completionStatusMessage: string;
-  _tambo_displayMessage: string;
 }
 
 // Standard parameters to be added to all tools
 export const standardToolParameters: FunctionParameters = {
   type: "object",
   properties: {
-    _tambo_displayMessage: {
-      type: "string",
-      description:
-        "A message to be displayed before the tool is called. This should be a natural language response to the previous message to describe what you are about to do. For example, `First, let me <do something>` or 'Great, I can see <something>, let me <do something>'. Get creative, this is what will make the user feel like they are having a conversation with you. You can and should use markdown formatting (code blocks with language specification, bold, lists) when showing examples or code.",
-    },
     _tambo_statusMessage: {
       type: "string",
       description:
@@ -38,11 +32,7 @@ export const standardToolParameters: FunctionParameters = {
         "A message that will be displayed to the user to explain in a few words what the tool has done, to replace the statusMessage when the tool has completed its task. For example, 'looked for <something>' or 'created <something>'",
     },
   },
-  required: [
-    "_tambo_statusMessage",
-    "_tambo_displayMessage",
-    "_tambo_completionStatusMessage",
-  ],
+  required: ["_tambo_statusMessage", "_tambo_completionStatusMessage"],
   additionalProperties: false,
 };
 

--- a/react-sdk/src/v1/hooks/use-tambo-v1.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1.test.tsx
@@ -849,7 +849,6 @@ describe("useTambo", () => {
                         units: "celsius",
                         _tambo_statusMessage: "Fetching...",
                         _tambo_completionStatusMessage: "Done",
-                        _tambo_displayMessage: "Weather lookup",
                       },
                     },
                   ],
@@ -878,7 +877,6 @@ describe("useTambo", () => {
       expect(content.input).toEqual({ location: "NYC", units: "celsius" });
       expect(content.input._tambo_statusMessage).toBeUndefined();
       expect(content.input._tambo_completionStatusMessage).toBeUndefined();
-      expect(content.input._tambo_displayMessage).toBeUndefined();
     });
 
     it("handles tool_use with empty input", () => {

--- a/react-sdk/src/v1/hooks/use-tambo-v1.ts
+++ b/react-sdk/src/v1/hooks/use-tambo-v1.ts
@@ -328,10 +328,6 @@ export function useTambo(): UseTamboReturn {
 
           // Extract Tambo display props from input
           const tamboDisplayProps: TamboToolDisplayProps = {
-            _tambo_displayMessage:
-              typeof input._tambo_displayMessage === "string"
-                ? input._tambo_displayMessage
-                : undefined,
             _tambo_statusMessage:
               typeof input._tambo_statusMessage === "string"
                 ? input._tambo_statusMessage

--- a/react-sdk/src/v1/types/message.ts
+++ b/react-sdk/src/v1/types/message.ts
@@ -75,8 +75,6 @@ export interface TamboComponentContent extends ComponentContent {
  * These are used to customize tool status messages shown in the UI.
  */
 export interface TamboToolDisplayProps {
-  /** Generic display message for the tool */
-  _tambo_displayMessage?: string;
   /** Message shown while the tool is executing */
   _tambo_statusMessage?: string;
   /** Message shown after the tool completes */


### PR DESCRIPTION
Removes param added to all tools `_tambo_displayMessage` which was used to have the LLM generate text messages when it was calling tools. Now, they can generate text events even when they are also going to generate toolcalls. This param seems to "train" the LLM into adding a display message in this param rather than in their normal text events.