### PR TITLE
fix(api): skip previousRunId check for threads with only initialMessages

### DIFF
--- a/apps/api/src/v1/v1.service.ts
+++ b/apps/api/src/v1/v1.service.ts
@@ -411,7 +411,7 @@ export class V1Service {
       };
     }
 
-    if (hasMessages && !dto.previousRunId) {
+    if (hasMessages && !dto.previousRunId && thread.lastCompletedRunId) {
       return {
         success: false,
         error: new HttpException(


### PR DESCRIPTION
## Summary
- When `POST /v1/threads/runs` includes `thread.initialMessages`, the seeded messages caused `startRun` to reject with a `previousRunId` validation error — even though no prior run existed.
- Fix: add `thread.lastCompletedRunId` to the guard condition so threads that have never completed a run aren't required to provide `previousRunId`.

Fixes TAM-1150

## Test plan
- [x] Updated existing test to properly set `lastCompletedRunId` on the mock thread
- [x] Added new test verifying `previousRunId` can be omitted when messages come from `initialMessages` (no prior run)
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)