### PR TITLE
fix(ui): message generation stage, input placeholder, canvas page in showcase

### DIFF
--- a/packages/react-ui-base/src/message-input/message-input-root.tsx
+++ b/packages/react-ui-base/src/message-input/message-input-root.tsx
@@ -80,6 +80,10 @@ export const MessageInputRoot = React.forwardRef<
   const [isDragging, setIsDragging] = React.useState(false);
   const editorRef = React.useRef<TamboEditor | null>(null);
   const dragCounter = React.useRef(0);
+  // Tracks whether a submission is in-flight. Used to prevent the display-value
+  // sync effect from restoring the old input text when `currentThreadId` changes
+  // mid-submission (e.g. placeholder → real thread ID migration).
+  const submittingRef = React.useRef(false);
   const isUpdatingToken = useIsTamboTokenUpdating();
 
   // Use elicitation context (optional)
@@ -99,6 +103,11 @@ export const MessageInputRoot = React.forwardRef<
   }, [setValue, currentThreadId]);
 
   React.useEffect(() => {
+    // While a submission is in-flight, displayValue has been intentionally
+    // cleared. Don't overwrite it when currentThreadId changes (e.g.
+    // placeholder → real thread ID migration triggers this effect).
+    if (submittingRef.current) return;
+
     setDisplayValue(value);
     storeValueInSessionStorage(currentThreadId, value);
     if (value && editorRef.current) {
@@ -114,6 +123,7 @@ export const MessageInputRoot = React.forwardRef<
     setImageError(null);
     setDisplayValue("");
     storeValueInSessionStorage(currentThreadId);
+    submittingRef.current = true;
     setIsSubmitting(true);
 
     const imageIdsAtSubmitTime = images.map((image) => image.id);
@@ -144,6 +154,7 @@ export const MessageInputRoot = React.forwardRef<
       // Cancel the thread to reset loading state
       await cancel();
     } finally {
+      submittingRef.current = false;
       setIsSubmitting(false);
     }
   }, [

--- a/packages/ui-registry/src/components/message-suggestions/message-suggestions.tsx
+++ b/packages/ui-registry/src/components/message-suggestions/message-suggestions.tsx
@@ -5,7 +5,6 @@ import { Tooltip, TooltipProvider } from "./suggestions-tooltip";
 import { cn } from "@tambo-ai/ui-registry/utils";
 import type { Suggestion, TamboThreadMessage } from "@tambo-ai/react";
 import { useTambo, useTamboSuggestions } from "@tambo-ai/react";
-import { Loader2Icon } from "lucide-react";
 import * as React from "react";
 import { useEffect, useRef } from "react";
 
@@ -265,39 +264,12 @@ const MessageSuggestionsStatus = React.forwardRef<
 
       {/* Always render a container for generation stage to prevent layout shifts */}
       <div className="generation-stage-container">
-        <GenerationStageContent
-          isStreaming={isStreaming}
-          isGenerating={isGenerating}
-        />
+        {isStreaming && <MessageGenerationStage />}
       </div>
     </div>
   );
 });
 MessageSuggestionsStatus.displayName = "MessageSuggestions.Status";
-
-/**
- * Internal component to render generation stage content
- */
-function GenerationStageContent({
-  isStreaming,
-  isGenerating,
-}: {
-  isStreaming: boolean;
-  isGenerating: boolean;
-}) {
-  if (isStreaming) {
-    return <MessageGenerationStage />;
-  }
-  if (isGenerating) {
-    return (
-      <div className="flex items-center gap-2 text-muted-foreground">
-        <Loader2Icon className="h-4 w-4 animate-spin" />
-        <p>Generating suggestions...</p>
-      </div>
-    );
-  }
-  return null;
-}
 
 /**
  * Props for the MessageSuggestionsList component.

--- a/packages/ui-registry/src/styles/globals-v3.css
+++ b/packages/ui-registry/src/styles/globals-v3.css
@@ -6,6 +6,16 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+/* TipTap editor placeholder - required for @tiptap/extension-placeholder to display */
+.tiptap p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  color: hsl(var(--muted-foreground));
+  opacity: 0.5;
+  pointer-events: none;
+  height: 0;
+}
+
 @layer base {
   :root {
     /* Default Tailwind CSS Variables customized with tambo colors */

--- a/packages/ui-registry/src/styles/globals-v4.css
+++ b/packages/ui-registry/src/styles/globals-v4.css
@@ -106,6 +106,16 @@
   --sidebar-width: 3rem;
 }
 
+/* TipTap editor placeholder - required for @tiptap/extension-placeholder to display */
+.tiptap p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  color: var(--muted-foreground);
+  opacity: 0.5;
+  pointer-events: none;
+  height: 0;
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/showcase/src/app/components/(canvas)/canvas-space/page.tsx
+++ b/showcase/src/app/components/(canvas)/canvas-space/page.tsx
@@ -32,6 +32,7 @@ export function CanvasDemo() {
             previewClassName="p-0"
             fullBleed
             minHeight={650}
+            enableFullscreen
           />
         </div>
       </section>

--- a/showcase/src/components/generative/CanvasChatInterface.tsx
+++ b/showcase/src/components/generative/CanvasChatInterface.tsx
@@ -60,8 +60,8 @@ export const CanvasChatInterface = () => {
 
   return (
     <div className="rounded-lg border border-border/40 h-full relative flex flex-row overflow-hidden">
-      <CanvasSpace className="bg-background rounded-l-lg flex-1" />
-      <MessageThreadPanel className="right rounded-r-lg" />
+      <CanvasSpace className="bg-background rounded-l-lg flex-1 h-full" />
+      <MessageThreadPanel className="right rounded-r-lg h-full" />
     </div>
   );
 };


### PR DESCRIPTION
- Introduced a `submittingRef` to manage submission state in MessageInputRoot, preventing display value restoration during in-flight submissions.
- Simplified MessageSuggestionsStatus by removing the internal GenerationStageContent component and directly rendering MessageGenerationStage when streaming.
- Added CSS for TipTap editor placeholder support in globals-v3.css and globals-v4.css.
- Enabled fullscreen mode in CanvasDemo component.