### PR TITLE
docs(skills): update skills for v1 React SDK API

### DIFF
--- a/plugins/tambo/skills/add-to-existing-project/SKILL.md
+++ b/plugins/tambo/skills/add-to-existing-project/SKILL.md
@@ -200,11 +200,11 @@ If manual setup is needed (monorepo, read-only filesystem), add the appropriate 
 After setup, verify by creating a simple test:
 
 ```tsx
-import { useTamboThread } from "@tambo-ai/react";
+import { useTambo } from "@tambo-ai/react";
 
 function TestComponent() {
-  const { thread } = useTamboThread();
-  console.log("Tambo connected:", thread !== undefined);
+  const { thread, isIdle } = useTambo();
+  console.log("Tambo connected:", isIdle);
   return <div>Tambo is set up!</div>;
 }
 ```

--- a/plugins/tambo/skills/components/SKILL.md
+++ b/plugins/tambo/skills/components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: components
-description: Creates and registers Tambo components - generative (AI creates on-demand) and interactable (pre-placed, AI updates). Use when defining components, working with TamboComponent, withInteractable, propsSchema, or registering components for AI to render or update.
+description: Creates and registers Tambo components - generative (AI creates on-demand) and interactable (pre-placed, AI updates). Use when defining components, working with TamboComponent, withTamboInteractable, propsSchema, or registering components for AI to render or update.
 ---
 
 # Tambo Components
@@ -54,6 +54,44 @@ const components: TamboComponent[] = [
 </TamboProvider>;
 ```
 
+### Rendering Generative Components
+
+Use `ComponentRenderer` to render AI-generated components in your message list:
+
+```tsx
+import { ComponentRenderer } from "@tambo-ai/react";
+
+function Message({
+  message,
+  threadId,
+}: {
+  message: TamboMessage;
+  threadId: string;
+}) {
+  return (
+    <div>
+      {message.content.map((block) => {
+        switch (block.type) {
+          case "text":
+            return <p key={block.type}>{block.text}</p>;
+          case "component":
+            return (
+              <ComponentRenderer
+                key={block.id}
+                content={block}
+                threadId={threadId}
+                messageId={message.id}
+              />
+            );
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+}
+```
+
 ### Generative Key Points
 
 - **propsSchema**: Zod object with `.describe()` on each field
@@ -66,7 +104,7 @@ const components: TamboComponent[] = [
 Pre-place in your UI; AI can observe and update props via natural language.
 
 ```tsx
-import { withInteractable } from "@tambo-ai/react";
+import { withTamboInteractable } from "@tambo-ai/react";
 import { z } from "zod";
 
 const NoteSchema = z.object({
@@ -84,7 +122,7 @@ function Note({ title, content, color = "white" }: Props) {
   );
 }
 
-export const InteractableNote = withInteractable(Note, {
+export const InteractableNote = withTamboInteractable(Note, {
   componentName: "Note",
   description: "A note with editable title, content, and color",
   propsSchema: NoteSchema,


### PR DESCRIPTION
## Summary

- Update 4 skill files to reflect v1 React SDK breaking changes
- **threads**: Rewritten to use `useTambo()` + `useTamboThreadInput()` instead of old `useTamboThread()`. Adds `ComponentRenderer` for message rendering, new streaming state booleans (`isIdle`/`isStreaming`/`isWaiting`), `accept({ suggestion })` signature, images via `useTamboThreadInput`, `userKey` auth, and thread list with `data.threads`
- **components**: `withInteractable` -> `withTamboInteractable`, added `ComponentRenderer` rendering section
- **component-rendering**: `useTamboComponentState` returns `[state, setState, { isPending, error, flush }]` instead of old `[value, setValue, setFromProp]`
- **add-to-existing-project**: Verification uses `useTambo()` instead of old `useTamboThread()`
- Other 4 skills (tools-and-context, cli, start-from-scratch, add-components-to-registry) already had correct v1 patterns

## Test plan

- [ ] Verify skill files render correctly in Claude Code
- [ ] Confirm code examples match current v1 SDK exports