### PR TITLE
fix(api): fix potential SQL injection in transaction middleware

### DIFF
--- a/apps/api/src/common/middleware/db-transaction-middleware.ts
+++ b/apps/api/src/common/middleware/db-transaction-middleware.ts
@@ -80,9 +80,7 @@ export class TransactionMiddleware implements NestMiddleware {
       req.tx = tx; // Attach transaction to request
       await tx.execute(sql`
             -- auth.jwt()
-            select set_config('request.apikey.project_id', '${sql.raw(
-              projectId,
-            )}', TRUE);
+            select set_config('request.apikey.project_id', ${projectId}, TRUE);
             -- set local role
             set local role ${sql.raw(schema.projectApiKeyRole.name)};
             `);


### PR DESCRIPTION
Switching to parameterized queries for the `set_config` call in the transaction middleware. The previous implementation used `sql.raw` to interpolate the `projectId`, which is derived from API keys. 

While these IDs are currently system-generated, I noticed using `sql.raw` here is an anti-pattern that could lead to SQL injection if input constraints change or custom identifiers are introduced. This update uses standard Drizzle parameter binding to ensure the query is executed safely. I also kept the `sql.raw` for the role name since it's a schema constant and typically requires an identifier rather than a parameter in Postgres.