### PR TITLE
chore: add team notes setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ coverage
 # git worktrees
 .worktrees/
 
+# team notes (tracked in separate private repo)
+team-notes/
+
 # misc
 .DS_Store
 *.pem

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,12 +1,16 @@
 # Remind about uncommitted team notes changes
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 TEAM_NOTES_DIR="$REPO_ROOT/team-notes"
 
 if [ -d "$TEAM_NOTES_DIR/.git" ]; then
-  if [ -n "$(git -C "$TEAM_NOTES_DIR" status --porcelain 2>/dev/null)" ]; then
-    echo ""
-    echo "You have uncommitted changes in team-notes/"
-    echo "Remember to commit and push those separately."
-    echo ""
+  if TEAM_NOTES_STATUS=$(git -C "$TEAM_NOTES_DIR" status --porcelain 2>/dev/null); then
+    if [ -n "$TEAM_NOTES_STATUS" ]; then
+      echo ""
+      echo "You have uncommitted changes in team-notes/"
+      echo "Remember to commit and push those separately."
+      echo ""
+    fi
+  else
+    echo "post-commit hook: failed to check team-notes status" >&2
   fi
 fi

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,11 +1,12 @@
 # Remind about uncommitted team notes changes
-if [ -d "team-notes/.git" ]; then
-  cd team-notes
-  if [ -n "$(git status --porcelain)" ]; then
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+TEAM_NOTES_DIR="$REPO_ROOT/team-notes"
+
+if [ -d "$TEAM_NOTES_DIR/.git" ]; then
+  if [ -n "$(git -C "$TEAM_NOTES_DIR" status --porcelain 2>/dev/null)" ]; then
     echo ""
-    echo "📝 You have uncommitted changes in team-notes/"
-    echo "   Remember to commit and push those separately."
+    echo "You have uncommitted changes in team-notes/"
+    echo "Remember to commit and push those separately."
     echo ""
   fi
-  cd ..
 fi

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,11 @@
+# Remind about uncommitted team notes changes
+if [ -d "team-notes/.git" ]; then
+  cd team-notes
+  if [ -n "$(git status --porcelain)" ]; then
+    echo ""
+    echo "📝 You have uncommitted changes in team-notes/"
+    echo "   Remember to commit and push those separately."
+    echo ""
+  fi
+  cd ..
+fi

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,16 +1,31 @@
 # Remind about uncommitted team notes changes
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "post-commit hook: could not determine repo root; skipping team-notes check" >&2
+  exit 0
+}
+
+if [ ! -f "$REPO_ROOT/scripts/setup-team-notes.sh" ]; then
+  echo "post-commit hook: resolved git root ($REPO_ROOT) does not look like the Tambo repo; skipping team-notes check" >&2
+  exit 0
+fi
 TEAM_NOTES_DIR="$REPO_ROOT/team-notes"
+
+case "$(pwd)" in
+  "$TEAM_NOTES_DIR"|"$TEAM_NOTES_DIR"/*)
+    exit 0
+    ;;
+esac
 
 if [ -d "$TEAM_NOTES_DIR/.git" ]; then
   if TEAM_NOTES_STATUS=$(git -C "$TEAM_NOTES_DIR" status --porcelain 2>/dev/null); then
     if [ -n "$TEAM_NOTES_STATUS" ]; then
       echo ""
-      echo "You have uncommitted changes in team-notes/"
-      echo "Remember to commit and push those separately."
+      echo "[team-notes] You have uncommitted changes in team-notes/"
+      echo "[team-notes] Remember to commit and push those separately."
       echo ""
     fi
   else
-    echo "post-commit hook: failed to check team-notes status" >&2
+    echo "post-commit hook: failed to check team-notes status at $TEAM_NOTES_DIR" >&2
+    echo "If this directory is missing or not a git repo, remove it and re-run scripts/setup-team-notes.sh." >&2
   fi
 fi

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -4,28 +4,29 @@ REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   exit 0
 }
 
-if [ ! -f "$REPO_ROOT/scripts/setup-team-notes.sh" ]; then
-  echo "post-commit hook: resolved git root ($REPO_ROOT) does not look like the Tambo repo; skipping team-notes check" >&2
-  exit 0
-fi
+TEAM_NOTES_SETUP_SCRIPT="$REPO_ROOT/scripts/setup-team-notes.sh"
 TEAM_NOTES_DIR="$REPO_ROOT/team-notes"
 
-case "$(pwd)" in
-  "$TEAM_NOTES_DIR"|"$TEAM_NOTES_DIR"/*)
-    exit 0
-    ;;
-esac
+if [ -f "$TEAM_NOTES_SETUP_SCRIPT" ]; then
+  case "$(pwd)" in
+    "$TEAM_NOTES_DIR"|"$TEAM_NOTES_DIR"/*)
+      exit 0
+      ;;
+  esac
 
-if [ -d "$TEAM_NOTES_DIR/.git" ]; then
-  if TEAM_NOTES_STATUS=$(git -C "$TEAM_NOTES_DIR" status --porcelain 2>/dev/null); then
-    if [ -n "$TEAM_NOTES_STATUS" ]; then
-      echo ""
-      echo "[team-notes] You have uncommitted changes in team-notes/"
-      echo "[team-notes] Remember to commit and push those separately."
-      echo ""
+  if [ -d "$TEAM_NOTES_DIR/.git" ]; then
+    if TEAM_NOTES_STATUS=$(git -C "$TEAM_NOTES_DIR" status --porcelain 2>/dev/null); then
+      if [ -n "$TEAM_NOTES_STATUS" ]; then
+        echo ""
+        echo "[team-notes] You have uncommitted changes in team-notes/"
+        echo "[team-notes] Remember to commit and push those separately."
+        echo ""
+      fi
+    else
+      echo "post-commit hook: failed to check team-notes status at $TEAM_NOTES_DIR" >&2
+      echo "If this directory is missing or not a git repo, remove it and re-run scripts/setup-team-notes.sh." >&2
     fi
-  else
-    echo "post-commit hook: failed to check team-notes status at $TEAM_NOTES_DIR" >&2
-    echo "If this directory is missing or not a git repo, remove it and re-run scripts/setup-team-notes.sh." >&2
   fi
+else
+  echo "post-commit hook: resolved git root ($REPO_ROOT) does not look like the Tambo repo; skipping team-notes check" >&2
 fi

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Remind about uncommitted team notes changes
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
   echo "post-commit hook: could not determine repo root; skipping team-notes check" >&2

--- a/packages/backend/src/services/llm/agent-client.ts
+++ b/packages/backend/src/services/llm/agent-client.ts
@@ -84,6 +84,7 @@ export class AgentClient {
         const client = new MastraClient({ baseUrl: agentUrl });
         const agents = await MastraAgent.getRemoteAgents({
           mastraClient: client,
+          resourceId: "",
         });
         if (!(normalizedAgentName in agents)) {
           throw new Error(`Agent ${normalizedAgentName} not found`);

--- a/scripts/setup-team-notes.sh
+++ b/scripts/setup-team-notes.sh
@@ -28,7 +28,7 @@ if git clone "$TEAM_NOTES_REMOTE" "$TEAM_NOTES_DIR"; then
 else
   status=$?
   echo ""
-  echo "Could not clone tambo-ai/team-notes (exit $status)."
+  echo "Could not clone $TEAM_NOTES_REMOTE (exit $status)."
   echo "This is a private repo for Tambo team members only."
   echo "If you're an external contributor, you can safely ignore this."
   echo ""

--- a/scripts/setup-team-notes.sh
+++ b/scripts/setup-team-notes.sh
@@ -15,7 +15,14 @@ if [ ! -f "$REPO_ROOT/scripts/setup-team-notes.sh" ]; then
 fi
 
 TEAM_NOTES_DIR="$REPO_ROOT/team-notes"
-TEAM_NOTES_REMOTE="${TEAM_NOTES_REMOTE:-git@github.com:tambo-ai/team-notes.git}"
+TEAM_NOTES_REMOTE_DEFAULT="git@github.com:tambo-ai/team-notes.git"
+
+if [ -n "${TEAM_NOTES_REMOTE+x}" ] && [ -z "$TEAM_NOTES_REMOTE" ]; then
+  echo "Error: TEAM_NOTES_REMOTE is set but empty; expected a git URL (for example, $TEAM_NOTES_REMOTE_DEFAULT)." >&2
+  exit 1
+fi
+
+TEAM_NOTES_REMOTE="${TEAM_NOTES_REMOTE:-$TEAM_NOTES_REMOTE_DEFAULT}"
 
 case "$TEAM_NOTES_REMOTE" in
   *[[:space:]]*)
@@ -42,8 +49,9 @@ if [ -d "$TEAM_NOTES_DIR" ]; then
   exit 1
 fi
 
-if [ ! -w "$REPO_ROOT" ]; then
-  echo "Error: $REPO_ROOT is not writable; cannot create $TEAM_NOTES_DIR." >&2
+TEAM_NOTES_PARENT_DIR="$(dirname "$TEAM_NOTES_DIR")"
+if [ ! -w "$TEAM_NOTES_PARENT_DIR" ]; then
+  echo "Error: $TEAM_NOTES_PARENT_DIR is not writable; cannot create $TEAM_NOTES_DIR." >&2
   exit 1
 fi
 

--- a/scripts/setup-team-notes.sh
+++ b/scripts/setup-team-notes.sh
@@ -4,12 +4,26 @@
 # This script is for Tambo team members only — external contributors can safely ignore it.
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
-  echo "Error: must be run inside a git repository." >&2
+  echo "Error: must be run inside the Tambo git repository (for example, from the repo root)." >&2
   exit 1
 }
 
+if [ ! -f "$REPO_ROOT/scripts/setup-team-notes.sh" ]; then
+  echo "Error: resolved git repo root ($REPO_ROOT) does not look like the Tambo repo." >&2
+  echo "Make sure you're running this from within the main Tambo repository." >&2
+  exit 1
+fi
+
 TEAM_NOTES_DIR="$REPO_ROOT/team-notes"
 TEAM_NOTES_REMOTE="${TEAM_NOTES_REMOTE:-git@github.com:tambo-ai/team-notes.git}"
+
+case "$TEAM_NOTES_REMOTE" in
+  *[[:space:]]*)
+    echo "Error: TEAM_NOTES_REMOTE contains whitespace; got: '$TEAM_NOTES_REMOTE'" >&2
+    echo "Please set it to a valid git URL (no spaces)." >&2
+    exit 1
+    ;;
+esac
 
 if [ -d "$TEAM_NOTES_DIR/.git" ]; then
   echo "Team notes already set up at $TEAM_NOTES_DIR"
@@ -17,8 +31,19 @@ if [ -d "$TEAM_NOTES_DIR/.git" ]; then
 fi
 
 if [ -d "$TEAM_NOTES_DIR" ]; then
-  echo "Error: $TEAM_NOTES_DIR exists but is not a git repo."
-  echo "Remove it and re-run this script, or clone manually."
+  if [ -n "$(ls -A "$TEAM_NOTES_DIR" 2>/dev/null)" ]; then
+    echo "Error: $TEAM_NOTES_DIR exists, is not a git repo, and is not empty."
+    echo "Move or remove its contents, then re-run this script or clone manually with:"
+  else
+    echo "Error: $TEAM_NOTES_DIR exists but is not a git repo."
+    echo "Remove it and re-run this script, or clone manually with:"
+  fi
+  echo "  git clone \"$TEAM_NOTES_REMOTE\" \"$TEAM_NOTES_DIR\""
+  exit 1
+fi
+
+if [ ! -w "$REPO_ROOT" ]; then
+  echo "Error: $REPO_ROOT is not writable; cannot create $TEAM_NOTES_DIR." >&2
   exit 1
 fi
 
@@ -28,7 +53,9 @@ if git clone "$TEAM_NOTES_REMOTE" "$TEAM_NOTES_DIR"; then
 else
   status=$?
   echo ""
-  echo "Could not clone $TEAM_NOTES_REMOTE (exit $status)."
+  echo "Could not clone $TEAM_NOTES_REMOTE into $TEAM_NOTES_DIR (exit $status)."
+  echo "This is usually due to missing access to tambo-ai/team-notes (SSH keys or repo permissions)."
+  echo "If you customized TEAM_NOTES_REMOTE, double-check that it's a valid Git URL and reachable (git ls-remote \"$TEAM_NOTES_REMOTE\")."
   echo "This is a private repo for Tambo team members only."
   echo "If you're an external contributor, you can safely ignore this."
   echo ""

--- a/scripts/setup-team-notes.sh
+++ b/scripts/setup-team-notes.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Sets up the private docs directory by cloning the private repo.
+# This directory is gitignored from the main Tambo repo.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+PRIVATE_DOCS_DIR="$REPO_ROOT/team-notes"
+
+if [ -d "$PRIVATE_DOCS_DIR/.git" ]; then
+  echo "Private docs already set up at $PRIVATE_DOCS_DIR"
+  exit 0
+fi
+
+if [ -d "$PRIVATE_DOCS_DIR" ]; then
+  echo "Error: $PRIVATE_DOCS_DIR exists but is not a git repo."
+  echo "Remove it and re-run this script, or clone manually."
+  exit 1
+fi
+
+echo "Cloning private docs..."
+git clone git@github.com:tambo-ai/team-notes.git "$PRIVATE_DOCS_DIR"
+echo "Done. Open private-docs/ in Obsidian for the best experience."

--- a/scripts/setup-team-notes.sh
+++ b/scripts/setup-team-notes.sh
@@ -3,9 +3,13 @@
 # This directory is gitignored from the main Tambo repo.
 # This script is for Tambo team members only — external contributors can safely ignore it.
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "Error: must be run inside a git repository." >&2
+  exit 1
+}
+
 TEAM_NOTES_DIR="$REPO_ROOT/team-notes"
+TEAM_NOTES_REMOTE="${TEAM_NOTES_REMOTE:-git@github.com:tambo-ai/team-notes.git}"
 
 if [ -d "$TEAM_NOTES_DIR/.git" ]; then
   echo "Team notes already set up at $TEAM_NOTES_DIR"
@@ -19,12 +23,15 @@ if [ -d "$TEAM_NOTES_DIR" ]; then
 fi
 
 echo "Cloning team notes (requires access to tambo-ai/team-notes)..."
-if git clone git@github.com:tambo-ai/team-notes.git "$TEAM_NOTES_DIR" 2>/dev/null; then
+if git clone "$TEAM_NOTES_REMOTE" "$TEAM_NOTES_DIR"; then
   echo "Done. Open team-notes/ in Obsidian for the best experience."
 else
+  status=$?
   echo ""
-  echo "Could not clone tambo-ai/team-notes."
+  echo "Could not clone tambo-ai/team-notes (exit $status)."
   echo "This is a private repo for Tambo team members only."
   echo "If you're an external contributor, you can safely ignore this."
+  echo ""
+  echo "Tip: set TEAM_NOTES_REMOTE=https://github.com/tambo-ai/team-notes.git if you prefer HTTPS."
   exit 1
 fi

--- a/scripts/setup-team-notes.sh
+++ b/scripts/setup-team-notes.sh
@@ -1,24 +1,30 @@
 #!/bin/sh
-# Sets up the private docs directory by cloning the private repo.
+# Sets up the team-notes directory by cloning the private repo.
 # This directory is gitignored from the main Tambo repo.
-
-set -e
+# This script is for Tambo team members only — external contributors can safely ignore it.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
-PRIVATE_DOCS_DIR="$REPO_ROOT/team-notes"
+TEAM_NOTES_DIR="$REPO_ROOT/team-notes"
 
-if [ -d "$PRIVATE_DOCS_DIR/.git" ]; then
-  echo "Private docs already set up at $PRIVATE_DOCS_DIR"
+if [ -d "$TEAM_NOTES_DIR/.git" ]; then
+  echo "Team notes already set up at $TEAM_NOTES_DIR"
   exit 0
 fi
 
-if [ -d "$PRIVATE_DOCS_DIR" ]; then
-  echo "Error: $PRIVATE_DOCS_DIR exists but is not a git repo."
+if [ -d "$TEAM_NOTES_DIR" ]; then
+  echo "Error: $TEAM_NOTES_DIR exists but is not a git repo."
   echo "Remove it and re-run this script, or clone manually."
   exit 1
 fi
 
-echo "Cloning private docs..."
-git clone git@github.com:tambo-ai/team-notes.git "$PRIVATE_DOCS_DIR"
-echo "Done. Open private-docs/ in Obsidian for the best experience."
+echo "Cloning team notes (requires access to tambo-ai/team-notes)..."
+if git clone git@github.com:tambo-ai/team-notes.git "$TEAM_NOTES_DIR" 2>/dev/null; then
+  echo "Done. Open team-notes/ in Obsidian for the best experience."
+else
+  echo ""
+  echo "Could not clone tambo-ai/team-notes."
+  echo "This is a private repo for Tambo team members only."
+  echo "If you're an external contributor, you can safely ignore this."
+  exit 1
+fi


### PR DESCRIPTION
Adds team notes setup.

reviewChanges skipped: additional edge-case shell hardening notes (git availability/path normalization/avoiding ls) to keep this PR focused on the requested robustness fixes.
reviewChanges skipped: packages/backend/src/services/llm/agent-client.ts - `resourceId: ""` matches current `main` behavior for `MastraAgent.getRemoteAgents` and is only included to fix `npm run check-types` on this branch.