### PR TITLE
fix(backend): import DecisionStreamItem as a type

### DIFF
--- a/packages/backend/src/tambo-backend.ts
+++ b/packages/backend/src/tambo-backend.ts
@@ -10,10 +10,8 @@ import OpenAI from "openai";
 import { AvailableComponent } from "./model/component-metadata";
 import { Provider } from "./model/providers";
 import { runAgentLoop } from "./services/decision-loop/agent-loop";
-import {
-  DecisionStreamItem,
-  runDecisionLoop,
-} from "./services/decision-loop/decision-loop-service";
+import { runDecisionLoop } from "./services/decision-loop/decision-loop-service";
+import type { DecisionStreamItem } from "./services/decision-loop/decision-loop-service";
 import { AgentClient } from "./services/llm/agent-client";
 import { AISdkClient } from "./services/llm/ai-sdk-client";
 import { EventHandlerParams } from "./services/llm/async-adapters";


### PR DESCRIPTION
`DecisionStreamItem` is a TypeScript interface (type-only) declared in `decision-loop-service.ts` and was previously imported as a runtime value in `packages/backend/src/tambo-backend.ts`

ran `npm run lint` and `npm run test`