### PR TITLE
docs: fix spacing in README a tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-<a href="https://tambo.link/yXkF0hQ">Start For Free</a> •
+  <a href="https://tambo.link/yXkF0hQ">Start For Free</a> •
   <a href="https://docs.tambo.co">Docs</a> •
   <a href="https://discord.gg/dJNvPEHth6">Discord</a>
 </p>


### PR DESCRIPTION
Fixed space in README
Corrected formatting: removed extra space in README so text aligns properly for "a" tags.
