### PR TITLE
fix(react-sdk): pass userKey in updateThreadName to threads.update()

### DIFF
--- a/react-sdk/src/v1/hooks/use-tambo-v1.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1.test.tsx
@@ -1245,6 +1245,7 @@ describe("useTambo", () => {
 
       expect(mockUpdate).toHaveBeenCalledWith("thread_456", {
         name: "My New Thread",
+        userKey: undefined,
       });
 
       expect(result.current.thread?.thread.name).toBe("My New Thread");
@@ -1282,6 +1283,7 @@ describe("useTambo", () => {
 
       expect(mockUpdate).toHaveBeenCalledWith("thread_789", {
         name: "New Title",
+        userKey: undefined,
       });
       const invalidatedKeys = invalidateQueriesSpy.mock.calls
         .map(([arg]) => (arg as any).queryKey)

--- a/react-sdk/src/v1/hooks/use-tambo-v1.ts
+++ b/react-sdk/src/v1/hooks/use-tambo-v1.ts
@@ -269,7 +269,7 @@ export function useTambo(): UseTamboReturn {
   // Update a thread's name
   const updateThreadName = useCallback(
     async (threadId: string, name: string) => {
-      await client.threads.update(threadId, { name });
+      await client.threads.update(threadId, { name, userKey });
 
       if (threadMapRef.current[threadId]) {
         dispatch({
@@ -295,7 +295,7 @@ export function useTambo(): UseTamboReturn {
         );
       }
     },
-    [client, dispatch, queryClient],
+    [client, userKey, dispatch, queryClient],
   );
 
   // Memoize the return object to prevent unnecessary re-renders


### PR DESCRIPTION
## Summary
- Fix `updateThreadName` in `useTambo()` to pass `userKey` to `client.threads.update()`
- The typescript-sdk's `threads.update()` destructures `userKey` from params into the query string, which overrides `defaultQuery` with `undefined` when not passed explicitly
- This caused a 400 "received neither" error from the V1 API when renaming threads

## Root cause
`cancelRun` (line 256) correctly passes `userKey`: `client.threads.runs.delete(runId, { threadId, userKey })`, but `updateThreadName` (line 272) did not: `client.threads.update(threadId, { name })`.

Fixes TAM-1199

## Test plan
- [x] Existing `updateThreadName` tests updated and passing (3/3)
- [ ] Manual: rename a thread in tambo-template-vite with userKey auth — should succeed without 400