### PR TITLE
fix(web): clean up remaining pre-v1 patterns in apps/web

### DIFF
--- a/apps/web/app/blog/posts/ai-powered-spreadsheet/page.mdx
+++ b/apps/web/app/blog/posts/ai-powered-spreadsheet/page.mdx
@@ -158,10 +158,10 @@ export const updateCellTool = {
   name: "updateSpreadsheetCell",
   description: "Update a single cell in the active spreadsheet tab. For text cells use: { type: 'text', text: 'your text' }. For number cells use: { type: 'number', value: 42, formatOptions: { style: 'currency', currency: 'USD' } }",
   tool: updateCell,
-  toolSchema: z.function().args(
-    z.union([z.string(), z.number()]).describe("Row identifier"),
-    z.string().describe("Column identifier (e.g., 'A', 'B')"),
-    z.object({
+  inputSchema: z.object({
+    row: z.union([z.string(), z.number()]).describe("Row identifier"),
+    column: z.string().describe("Column identifier (e.g., 'A', 'B')"),
+    cell: z.object({
       type: z.literal("text"),
       text: z.string()
     }).or(z.object({
@@ -169,7 +169,8 @@ export const updateCellTool = {
       value: z.number(),
       formatOptions: z.object({...}).optional()
     }))
-  )
+  }),
+  outputSchema: z.any(),
 };
 ```
 

--- a/apps/web/app/blog/posts/llm-web-apps/page.mdx
+++ b/apps/web/app/blog/posts/llm-web-apps/page.mdx
@@ -78,7 +78,7 @@ const components: TamboComponent[] = [
 Similarly, give the LLM tools:
 
 ```typescript
-const getWeather = (city: string) => {
+const getWeather = async ({ city }: { city: string }) => {
   const forecast = await weather.getCityForecast(city);
   return forecast; // return the data, Tambo will format it for the user
 };
@@ -88,10 +88,10 @@ export const tools: TamboTool[] = [
     name: "getWeather",
     description: "A tool to get the current weather conditions of a city",
     tool: getWeather,
-    toolSchema: z
-      .function()
-      .args(z.string().describe("The city name to get weather information for"))
-      .returns(z.string()),
+    inputSchema: z.object({
+      city: z.string().describe("The city name to get weather information for"),
+    }),
+    outputSchema: z.string(),
   },
 ];
 

--- a/apps/web/app/blog/posts/tambo-with-tambo/page.mdx
+++ b/apps/web/app/blog/posts/tambo-with-tambo/page.mdx
@@ -100,26 +100,23 @@ export const tamboRegisteredComponents = [
 This is where your backend actually hooks in. In our case, we wired in the [`generateApiKey` endpoint](https://github.com/tambo-ai/tambo/blob/main/apps/web/components/ui/tambo/chatwithtambo/tools.ts#L162). You'd do the same with your own API.
 
 ```typescript
-export const generateProjectApiKeySchema = z
-  .function()
-  .args(
-    z.string().describe("The project ID"),
-    z.string().describe("The name of the API key"),
-  )
-  .returns(
-    z.object({
-      apiKey: z.string(),
-      id: z.string(),
-      name: z.string(),
-      partiallyHiddenKey: z.string().nullable(),
-      lastUsedAt: z.date().nullable(),
-      projectId: z.string(),
-      hashedKey: z.string(),
-      createdAt: z.date(),
-      updatedAt: z.date(),
-      createdByUserId: z.string(),
-    }),
-  );
+export const generateProjectApiKeyInputSchema = z.object({
+  projectId: z.string().describe("The project ID"),
+  name: z.string().describe("The name of the API key"),
+});
+
+export const generateProjectApiKeyOutputSchema = z.object({
+  apiKey: z.string(),
+  id: z.string(),
+  name: z.string(),
+  partiallyHiddenKey: z.string().nullable(),
+  lastUsedAt: z.date().nullable(),
+  projectId: z.string(),
+  hashedKey: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+  createdByUserId: z.string(),
+});
 
 export function useTamboManagementTools() {
   const { registerTool } = useTambo();
@@ -129,10 +126,17 @@ export function useTamboManagementTools() {
     registerTool({
       name: "generateProjectApiKey",
       description: "Generate a new API key for the current project",
-      tool: async (projectId: string, name: string) => {
+      tool: async ({
+        projectId,
+        name,
+      }: {
+        projectId: string;
+        name: string;
+      }) => {
         return await apiClient.generateApiKey.mutate({ projectId, name });
       },
-      toolSchema: generateProjectApiKeySchema,
+      inputSchema: generateProjectApiKeyInputSchema,
+      outputSchema: generateProjectApiKeyOutputSchema,
     });
   }, [registerTool, apiClient]);
 }

--- a/apps/web/app/subscribe/tambo-subscribe-integration.tsx
+++ b/apps/web/app/subscribe/tambo-subscribe-integration.tsx
@@ -22,7 +22,6 @@ import {
 import { ComponentsThemeProvider } from "@/providers/components-theme-provider";
 import { useTambo, useTamboThreadInput } from "@tambo-ai/react";
 import { useEffect, useRef, useState } from "react";
-import { zodToJsonSchema } from "zod-to-json-schema";
 import { SubscribeForm, SubscribeFormProps } from "./subscribe-form";
 
 export function TamboSubscribeIntegration() {
@@ -43,7 +42,7 @@ export function TamboSubscribeIntegration() {
       description:
         "A form component for subscription information with firstName, lastName, title, and email fields.",
       component: SubscribeForm,
-      propsDefinition: zodToJsonSchema(SubscribeFormProps),
+      propsSchema: SubscribeFormProps,
     });
 
     isRegistered.current = true;

--- a/apps/web/providers/tambo-provider.tsx
+++ b/apps/web/providers/tambo-provider.tsx
@@ -20,24 +20,24 @@ function getOrCreateAnonymousId(): string {
   return newId;
 }
 
-function useContextKey(userId?: string): string | undefined {
+function useUserKey(userId?: string): string | undefined {
   // Initialize with userId if available (server-rendered value)
-  const [contextKey, setContextKey] = useState<string | undefined>(
+  const [userKey, setUserKey] = useState<string | undefined>(
     userId ? `${USER_PREFIX}${userId}` : undefined,
   );
 
   useEffect(() => {
     if (userId) {
-      setContextKey(`${USER_PREFIX}${userId}`);
+      setUserKey(`${USER_PREFIX}${userId}`);
       return;
     }
 
     // For unauthenticated users, use a random UUID stored in localStorage
     const anonymousId = getOrCreateAnonymousId();
-    setContextKey(`${ANON_PREFIX}${anonymousId}`);
+    setUserKey(`${ANON_PREFIX}${anonymousId}`);
   }, [userId]);
 
-  return contextKey;
+  return userKey;
 }
 
 type TamboProviderWrapperProps = Readonly<{
@@ -49,14 +49,14 @@ export function TamboProviderWrapper({
   children,
   userId,
 }: TamboProviderWrapperProps) {
-  const contextKey = useContextKey(userId);
+  const userKey = useUserKey(userId);
 
   return (
     <TamboProvider
       apiKey={env.NEXT_PUBLIC_TAMBO_DASH_KEY!}
       tamboUrl={env.NEXT_PUBLIC_TAMBO_API_URL}
       components={tamboRegisteredComponents}
-      userKey={contextKey}
+      userKey={userKey}
       contextHelpers={{
         userPage: currentPageContextHelper,
       }}


### PR DESCRIPTION
## Summary
- Replace `propsDefinition: zodToJsonSchema(...)` with `propsSchema` in subscribe integration, remove unused `zod-to-json-schema` import
- Rename `useContextKey` → `useUserKey` in `tambo-provider.tsx` to align with v1 naming
- Update blog post code examples from deprecated `toolSchema` (`z.function().args(...)`) to `inputSchema`/`outputSchema` with single-object parameter style

Fixes TAM-1208

## Why the dashboard tools weren't touched
The tool files in `apps/web/lib/tambo/tools/` already use `inputSchema`/`outputSchema` — they were migrated in #1850 back in January. The subscribe integration's `propsDefinition` got missed in that pass and the v1 promotion PR, so this cleans up the leftovers along with the blog post examples.

## Test plan
- [x] `npm run check-types` — passes (19/19 tasks)
- [x] `npm run lint` — passes (0 errors)
- [x] `npm test` — passes (342/342 tests)
- [ ] `npm run dev:cloud` — manually verify subscribe page renders and works
- [ ] Verify blog posts render correctly