### PR TITLE
fix(web): make thread title and ID open messages modal

### DIFF
--- a/apps/web/components/observability/thread-table/thread-table-row.tsx
+++ b/apps/web/components/observability/thread-table/thread-table-row.tsx
@@ -99,7 +99,11 @@ export const ThreadRow = memo(
                 {thread.id || "N/A"}
               </code>
             </button>
-            <CopyButton clipboardValue={thread.id || ""} className="h-6 w-6" />
+            <CopyButton
+              clipboardValue={thread.id || ""}
+              className="h-6 w-6"
+              disabled={isDeleting}
+            />
           </div>
         </TableCell>
 


### PR DESCRIPTION
## Summary
- Thread name and thread ID in the observability threads table are now clickable, opening the messages modal on click
- Matches the project table UX where the primary identifier is a clickable link
- Context key column now truncates long values to prevent horizontal table overflow

Fixes TAM-1217

## Test plan
- [ ] Verify clicking thread name opens messages modal on the Observability page
- [ ] Verify clicking thread ID opens messages modal (especially in chat-rendered `ThreadTable` where names may not exist)
- [ ] Verify hover underline appears on both thread name and thread ID
- [ ] Verify keyboard accessibility (Tab to focus, Enter/Space to activate)
- [ ] Verify both are disabled while a row is deleting
- [ ] Verify long context keys truncate with ellipsis instead of causing horizontal scroll