### PR TITLE
fix(showcase): key TamboProvider on userContextKey to reset state on navigation

### DIFF
--- a/showcase/src/app/template.tsx
+++ b/showcase/src/app/template.tsx
@@ -56,6 +56,7 @@ export default function Template({
                 </div>
               ) : (
                 <TamboProvider
+                  key={userContextKey}
                   apiKey={process.env.NEXT_PUBLIC_TAMBO_API_KEY ?? ""}
                   tamboUrl={process.env.NEXT_PUBLIC_TAMBO_API_URL ?? ""}
                   mcpServers={[

--- a/showcase/src/lib/useUserContextKey.ts
+++ b/showcase/src/lib/useUserContextKey.ts
@@ -1,18 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
-
-function getOrCreateUserId(storageKey: string): string {
-  if (typeof window === "undefined") {
-    return "";
-  }
-  let userId = localStorage.getItem(storageKey);
-  if (!userId) {
-    userId = `user-${crypto.randomUUID()}`;
-    localStorage.setItem(storageKey, userId);
-  }
-  return userId;
-}
+import { useLayoutEffect, useState } from "react";
 
 /**
  * Custom hook to generate a user-specific context key
@@ -24,7 +12,25 @@ export function useUserContextKey(
   baseKey: string,
   storageKey = "tambo-user-id",
 ): string {
-  const userId = useMemo(() => getOrCreateUserId(storageKey), [storageKey]);
+  const [userId] = useState(() => {
+    if (typeof window === "undefined") {
+      return "";
+    }
+
+    return localStorage.getItem(storageKey) ?? `user-${crypto.randomUUID()}`;
+  });
+
+  useLayoutEffect(() => {
+    if (typeof window === "undefined" || !userId) {
+      return;
+    }
+
+    if (localStorage.getItem(storageKey)) {
+      return;
+    }
+
+    localStorage.setItem(storageKey, userId);
+  }, [storageKey, userId]);
 
   if (!userId) {
     return baseKey;


### PR DESCRIPTION
## Summary
- Thread state and QueryClient were leaking across page navigations in the showcase
- When navigating from one component page to another, the old thread/messages persisted and new messages would 403 because the userKey didn't match the thread owner
- Root cause: `template.tsx` re-renders (not remounts) on client-side navigation, so TamboProvider's internal QueryClient and stream state persisted across pages
- Fix: Add `key={userContextKey}` to TamboProvider so React fully unmounts/remounts the provider tree when the page changes, resetting all internal state
- Also improved `useUserContextKey` to compute userId synchronously via `useState` lazy initializer instead of deferring to `useEffect`

## Test plan
- [ ] Navigate to Form page, send a message
- [ ] Navigate to Input Fields page via sidebar link
- [ ] Verify the thread resets (shows "Loading threads...", not the form thread)
- [ ] Verify sending a new message works without 403
- [ ] Verify thread isolation: each page has its own independent threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)