### PR TITLE
deps: bump gh CLI from 2.83.2 to 2.87.2

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 cspell = "9.4.0"
-gh = "2.83.2"
+gh = "2.87.2"
 jq = "1.8.1"
 shellcheck = "0.11.0"
 


### PR DESCRIPTION
## Summary
- Bumps `gh` in `mise.toml` from 2.83.2 to 2.87.2
- Fixes API deployment failure on Railway caused by missing GitHub attestations for gh 2.83.2

## Test plan
- [ ] Verify Railway build succeeds with the new gh version