### PR TITLE
deps: remove gh CLI from mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,5 @@
 [tools]
 cspell = "9.4.0"
-gh = "2.87.2"
 jq = "1.8.1"
 shellcheck = "0.11.0"
 


### PR DESCRIPTION
## Summary
- Removes `gh` from `mise.toml` to unblock Railway API deployments
- The mise aqua backend fails attestation verification for all recent gh versions, causing build failures
- `gh` is only used for dev workflows (PRs, issues) and is not needed for app builds — developers still have it via system install

Fixes TAM-1222

## Test plan
- [ ] Verify Railway API build succeeds