### PR TITLE
fix(react-sdk): read description field from V1 suggestions API

### DIFF
--- a/react-sdk/src/v1/hooks/use-tambo-v1-suggestions.test.tsx
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-suggestions.test.tsx
@@ -46,13 +46,13 @@ describe("useTamboSuggestions", () => {
       id: "suggestion_1",
       messageId: "msg_1",
       title: "What's the weather?",
-      detailedSuggestion: "What's the weather like today?",
+      description: "What's the weather like today?",
     },
     {
       id: "suggestion_2",
       messageId: "msg_1",
       title: "Tell me a joke",
-      detailedSuggestion: "Can you tell me a funny joke?",
+      description: "Can you tell me a funny joke?",
     },
   ];
 
@@ -472,7 +472,7 @@ describe("useTamboSuggestions", () => {
         id: "empty_suggestion",
         messageId: "msg_1",
         title: "Empty",
-        detailedSuggestion: "",
+        description: "",
       };
 
       await expect(
@@ -480,7 +480,7 @@ describe("useTamboSuggestions", () => {
       ).rejects.toThrow("Suggestion has no content");
     });
 
-    it("throws error when detailedSuggestion is only whitespace", async () => {
+    it("throws error when description is only whitespace", async () => {
       const { result } = renderHook(() => useTamboSuggestions(), {
         wrapper: createWrapper(),
       });
@@ -489,7 +489,7 @@ describe("useTamboSuggestions", () => {
         id: "whitespace_suggestion",
         messageId: "msg_1",
         title: "Whitespace",
-        detailedSuggestion: "   ",
+        description: "   ",
       };
 
       await expect(
@@ -497,7 +497,7 @@ describe("useTamboSuggestions", () => {
       ).rejects.toThrow("Suggestion has no content");
     });
 
-    it("throws error when detailedSuggestion is undefined", async () => {
+    it("throws error when description is undefined", async () => {
       const { result } = renderHook(() => useTamboSuggestions(), {
         wrapper: createWrapper(),
       });

--- a/react-sdk/src/v1/hooks/use-tambo-v1-suggestions.ts
+++ b/react-sdk/src/v1/hooks/use-tambo-v1-suggestions.ts
@@ -315,7 +315,7 @@ export function useTamboSuggestions(
       suggestion,
       shouldSubmit = false,
     }: AcceptSuggestionOptions) => {
-      const text = suggestion.detailedSuggestion?.trim();
+      const text = suggestion.description?.trim();
       if (!text) {
         throw new Error("Suggestion has no content");
       }


### PR DESCRIPTION
## Summary

- The V1 API returns suggestions with `description` but the React SDK hook read `detailedSuggestion`, causing "Suggestion has no content" errors on `accept()`
- Updated the hook and tests to use `description`
- Requires the TypeScript SDK to be regenerated before this will type-check (SDK currently still defines `detailedSuggestion`)

## Test plan

- [x] Tests updated to use `description` field
- [x] Lint passes
- [ ] Type-check and tests will pass after TypeScript SDK is regenerated
- [ ] Manual verification: click a suggestion and confirm it populates the input