### PR TITLE
fix(web): auto-close CLI auth page after successful login

### DIFF
--- a/apps/web/components/device-auth/device-code-form.tsx
+++ b/apps/web/components/device-auth/device-code-form.tsx
@@ -55,19 +55,24 @@ const AUTO_CLOSE_SECONDS = 30;
 
 function SuccessState() {
   const [secondsLeft, setSecondsLeft] = useState(AUTO_CLOSE_SECONDS);
+  const [closeBlocked, setCloseBlocked] = useState(false);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setSecondsLeft((prev) => {
-        if (prev <= 1) {
-          window.close();
-          return 0;
-        }
-        return prev - 1;
-      });
+    const interval = window.setInterval(() => {
+      setSecondsLeft((prev) => Math.max(0, prev - 1));
     }, 1000);
 
-    return () => clearInterval(interval);
+    const timeout = window.setTimeout(() => {
+      window.close();
+      window.setTimeout(() => {
+        if (!window.closed) setCloseBlocked(true);
+      }, 250);
+    }, AUTO_CLOSE_SECONDS * 1000);
+
+    return () => {
+      window.clearInterval(interval);
+      window.clearTimeout(timeout);
+    };
   }, []);
 
   return (
@@ -91,7 +96,9 @@ function SuccessState() {
         </div>
 
         <p className="text-sm text-muted-foreground">
-          This page will close in {secondsLeft}s
+          {closeBlocked
+            ? "Auto-close was blocked by your browser. Please close this tab and return to your terminal."
+            : `This page will close in ${secondsLeft}s`}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Remove the "Go to Dashboard" link from CLI device auth success state
- Add a 30-second countdown that auto-closes the tab after successful authorization
- Pushes users back to their terminal instead of leaving them on a dead-end page

## Test plan
- [ ] Run `tambo auth login` and complete the device code flow in the browser
- [ ] Verify the success page shows a countdown instead of the dashboard link
- [ ] Verify the tab attempts to close after 30 seconds
- [ ] If the tab was opened via `window.open`, confirm it actually closes; otherwise confirm the countdown message still displays gracefully