### PR TITLE
docs(react-sdk): fix docs bugs and add missing reference pages

### DIFF
--- a/docs/content/docs/guides/build-interfaces/build-chat-interface.mdx
+++ b/docs/content/docs/guides/build-interfaces/build-chat-interface.mdx
@@ -34,29 +34,30 @@ export default function MessageList() {
         <div key={message.id} className={`message message-${message.role}`}>
           <div className="message-sender">{message.role}</div>
 
-          {/* Render text content */}
-          {message.content.map((contentPart, idx) => {
-            if (contentPart.type === "text") {
-              return <p key={idx}>{contentPart.text}</p>;
+          {/* Render content blocks */}
+          {message.content.map((content, idx) => {
+            if (content.type === "text") {
+              return <p key={idx}>{content.text}</p>;
+            }
+            if (content.type === "tool_use") {
+              return (
+                <div
+                  key={idx}
+                  className="text-sm text-gray-500 p-2 w-full text-left animate-fade-in"
+                >
+                  -&gt; {content.name}
+                </div>
+              );
+            }
+            if (content.type === "component" && content.renderedComponent) {
+              return (
+                <div key={idx} className="message-component">
+                  {content.renderedComponent}
+                </div>
+              );
             }
             return null;
           })}
-
-          {/* Show tool calls */}
-          {message.role === "assistant" && message.toolCallRequest && (
-            <div className="tool-calls">
-              {message.component?.toolCallRequest && (
-                <div className="text-sm text-gray-500 p-2 w-full text-left animate-fade-in">
-                  -&gt; {message.component.toolCallRequest.toolName}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Render component if present */}
-          {message.renderedComponent && (
-            <div className="message-component">{message.renderedComponent}</div>
-          )}
         </div>
       ))}
     </div>
@@ -64,7 +65,7 @@ export default function MessageList() {
 }
 ```
 
-Messages contain text content, images, generated components, and tool calls. The `renderedComponent` property contains any component Tambo created in response to the message. Tool calls show which tools the AI invoked, useful for debugging or transparency.
+Messages contain an array of content blocks — text, tool calls, tool results, and components. Content blocks with `type: "component"` include a `renderedComponent` property containing any component Tambo created. Tool call blocks (`type: "tool_use"`) show which tools the AI invoked, useful for debugging or transparency.
 
 **Alternative: Canvas-Style Display**
 
@@ -72,14 +73,20 @@ For interfaces showing only the latest component (dashboards, workspaces), walk 
 
 ```tsx
 import { useTambo } from "@tambo-ai/react";
+import { type ReactNode } from "react";
 
 function CanvasView() {
   const { messages } = useTambo();
 
-  const latestComponent = messages
-    .slice()
-    .reverse()
-    .find((message) => message.renderedComponent)?.renderedComponent;
+  // Find the most recent rendered component by scanning forward (last wins)
+  let latestComponent: ReactNode | null = null;
+  for (const message of messages) {
+    for (const block of message.content) {
+      if (block.type === "component" && block.renderedComponent) {
+        latestComponent = block.renderedComponent;
+      }
+    }
+  }
 
   return (
     <div className="canvas">
@@ -218,7 +225,11 @@ function MessageThread() {
     <div>
       {/* Messages */}
       {messages.map((message) => (
-        <div key={message.id}>{message.content}</div>
+        <div key={message.id}>
+          {message.content.map((content, idx) =>
+            content.type === "text" ? <p key={idx}>{content.text}</p> : null,
+          )}
+        </div>
       ))}
 
       {/* Suggestions */}
@@ -252,43 +263,6 @@ accept({ suggestion });
 
 // Set text and automatically submit
 accept({ suggestion, shouldSubmit: true });
-```
-
-### Custom Suggestions
-
-Override auto-generated suggestions for specific contexts using `useTamboContextAttachment`:
-
-```tsx
-import { useTamboContextAttachment } from "@tambo-ai/react";
-
-function ComponentSelector({ component }) {
-  const { setCustomSuggestions } = useTamboContextAttachment();
-
-  const handleSelectComponent = () => {
-    setCustomSuggestions([
-      {
-        id: "1",
-        title: "Edit this component",
-        detailedSuggestion: `Modify the ${component.name} component`,
-        messageId: "",
-      },
-      {
-        id: "2",
-        title: "Add a feature",
-        detailedSuggestion: `Add a new feature to ${component.name}`,
-        messageId: "",
-      },
-    ]);
-  };
-
-  return <button onClick={handleSelectComponent}>Select</button>;
-}
-```
-
-Clear custom suggestions to return to auto-generated ones:
-
-```tsx
-setCustomSuggestions(null);
 ```
 
 ## Related Concepts

--- a/docs/content/docs/reference/react-sdk/hooks.mdx
+++ b/docs/content/docs/reference/react-sdk/hooks.mdx
@@ -54,7 +54,7 @@ function Chat() {
 | Value             | Type                       | Description                                                      |
 | ----------------- | -------------------------- | ---------------------------------------------------------------- |
 | `thread`          | `ThreadState \| undefined` | Current thread state including messages and metadata             |
-| `messages`        | `TamboMessage[]`           | Array of messages in the current thread with computed properties |
+| `messages`        | `TamboThreadMessage[]`     | Array of messages in the current thread with computed properties |
 | `currentThreadId` | `string`                   | ID of the currently active thread                                |
 
 #### Streaming Status
@@ -74,11 +74,12 @@ function Chat() {
 
 #### Thread Management
 
-| Value            | Type                                                               | Description                                     |
-| ---------------- | ------------------------------------------------------------------ | ----------------------------------------------- |
-| `initThread`     | `(threadId: string, initialThread?: Partial<TamboThread>) => void` | Initialize a thread with optional initial state |
-| `switchThread`   | `(threadId: string) => void`                                       | Switch to a different thread by ID              |
-| `startNewThread` | `() => string`                                                     | Create a new thread and return its ID           |
+| Value              | Type                                                               | Description                                     |
+| ------------------ | ------------------------------------------------------------------ | ----------------------------------------------- |
+| `initThread`       | `(threadId: string, initialThread?: Partial<TamboThread>) => void` | Initialize a thread with optional initial state |
+| `switchThread`     | `(threadId: string) => void`                                       | Switch to a different thread by ID              |
+| `startNewThread`   | `() => string`                                                     | Create a new thread and return its ID           |
+| `updateThreadName` | `(threadId: string, name: string) => Promise<void>`                | Update a thread's display name                  |
 
 #### Registry
 
@@ -140,6 +141,7 @@ function MessageInput() {
     clearImages,
     threadId,
     isPending,
+    isDisabled,
     isError,
     error,
   } = useTamboThreadInput();
@@ -160,6 +162,7 @@ function MessageInput() {
 | `clearImages` | `() => void`                                                              | Clear all staged images                                                                  |
 | `threadId`    | `string \| undefined`                                                     | Current thread ID                                                                        |
 | `isPending`   | `boolean`                                                                 | `true` while submission is in progress                                                   |
+| `isDisabled`  | `boolean`                                                                 | `true` when input should be disabled (pending submission or not authenticated)           |
 | `isError`     | `boolean`                                                                 | `true` if submission failed                                                              |
 | `error`       | `Error \| null`                                                           | Error details if submission failed                                                       |
 
@@ -459,43 +462,199 @@ const result = useTamboSuggestions({
 | `suggestion`   | `Suggestion` | The suggestion to accept           |
 | `shouldSubmit` | `boolean`    | Submit immediately after accepting |
 
-## useTamboSendMessage
+## useTamboInteractable
 
-Low-level hook for sending messages with streaming. Most applications should use `useTamboThreadInput` instead.
+Manages the registry of interactable components — components already placed in your UI that the AI can update. Provides functions to add, remove, update, query, and select interactable components.
 
 ```tsx
-import { useTamboSendMessage } from "@tambo-ai/react";
+import { useTamboInteractable } from "@tambo-ai/react";
 
-function CustomSendButton({ threadId }: { threadId: string }) {
-  const { mutate, isPending } = useTamboSendMessage(threadId);
+function InteractableManager() {
+  const {
+    interactableComponents,
+    addInteractableComponent,
+    removeInteractableComponent,
+    updateInteractableComponentProps,
+    getInteractableComponent,
+    getInteractableComponentsByName,
+    clearAllInteractableComponents,
+    setInteractableState,
+    getInteractableComponentState,
+    setInteractableSelected,
+    clearInteractableSelections,
+  } = useTamboInteractable();
+}
+```
 
-  const handleSend = () => {
-    mutate({
-      message: {
-        role: "user",
-        content: [{ type: "text", text: "Hello!" }],
-      },
-      userMessageText: "Hello!", // For optimistic UI
-    });
-  };
+### Return Values
+
+| Value                              | Type                                                                           | Description                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------- |
+| `interactableComponents`           | `TamboInteractableComponent[]`                                                 | All registered interactable components          |
+| `addInteractableComponent`         | `(component: Omit<TamboInteractableComponent, "id" \| "createdAt">) => string` | Register a component, returns its generated ID  |
+| `removeInteractableComponent`      | `(id: string) => void`                                                         | Remove a component by ID                        |
+| `updateInteractableComponentProps` | `(id: string, newProps: Record<string, unknown>) => string`                    | Partially update a component's props            |
+| `getInteractableComponent`         | `(id: string) => TamboInteractableComponent \| undefined`                      | Get a component by ID                           |
+| `getInteractableComponentsByName`  | `(name: string) => TamboInteractableComponent[]`                               | Get all components matching a name              |
+| `clearAllInteractableComponents`   | `() => void`                                                                   | Remove all interactable components              |
+| `setInteractableState`             | `(componentId: string, key: string, value: unknown) => void`                   | Set a single state key on a component           |
+| `getInteractableComponentState`    | `(componentId: string) => Record<string, unknown> \| undefined`                | Get a component's state                         |
+| `setInteractableSelected`          | `(componentId: string, isSelected: boolean) => void`                           | Mark a component as selected for AI interaction |
+| `clearInteractableSelections`      | `() => void`                                                                   | Clear all component selections                  |
+
+> Most applications use `withTamboInteractable()` instead of calling this hook directly. The HOC handles registration and cleanup automatically.
+
+## useCurrentInteractablesSnapshot
+
+Returns a cloned snapshot of all currently registered interactable components. The snapshot is safe to mutate without affecting internal state.
+
+```tsx
+import { useCurrentInteractablesSnapshot } from "@tambo-ai/react";
+
+function InteractablesList() {
+  const interactables = useCurrentInteractablesSnapshot();
 
   return (
-    <button onClick={handleSend} disabled={isPending}>
-      Send
-    </button>
+    <ul>
+      {interactables.map((item) => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
   );
 }
 ```
 
-### Parameters
+**Returns:** `TamboInteractableComponent[]` (shallow-cloned array with cloned props)
 
-| Parameter  | Type                  | Description                                  |
-| ---------- | --------------------- | -------------------------------------------- |
-| `threadId` | `string \| undefined` | Thread to send to (creates new if undefined) |
+## useTamboContextAttachment
+
+Manages context attachments — pieces of context that are automatically included with the next user message and then cleared.
+
+```tsx
+import { useTamboContextAttachment } from "@tambo-ai/react";
+
+function FileAttacher() {
+  const {
+    attachments,
+    addContextAttachment,
+    removeContextAttachment,
+    clearContextAttachments,
+  } = useTamboContextAttachment();
+
+  const attachFile = (fileContent: string, fileName: string) => {
+    addContextAttachment({
+      context: fileContent,
+      displayName: fileName,
+      type: "file",
+    });
+  };
+}
+```
 
 ### Return Values
 
-Returns a React Query `UseMutationResult`.
+| Value                     | Type                                                               | Description                               |
+| ------------------------- | ------------------------------------------------------------------ | ----------------------------------------- |
+| `attachments`             | `ContextAttachment[]`                                              | Current context attachments               |
+| `addContextAttachment`    | `(attachment: Omit<ContextAttachment, "id">) => ContextAttachment` | Add an attachment, returns it with its ID |
+| `removeContextAttachment` | `(id: string) => void`                                             | Remove an attachment by ID                |
+| `clearContextAttachments` | `() => void`                                                       | Remove all attachments                    |
+
+### ContextAttachment
+
+| Property      | Type     | Description                                     |
+| ------------- | -------- | ----------------------------------------------- |
+| `id`          | `string` | Unique identifier (auto-generated)              |
+| `context`     | `string` | The context value included in additionalContext |
+| `displayName` | `string` | Optional display name for UI rendering          |
+| `type`        | `string` | Optional type for grouping (e.g., `"file"`)     |
+
+## useTamboContextHelpers
+
+Accesses the context helpers system for managing dynamic additional context that is included with every message.
+
+```tsx
+import { useEffect } from "react";
+import { useTamboContextHelpers } from "@tambo-ai/react";
+
+function ContextManager() {
+  const { addContextHelper, removeContextHelper } = useTamboContextHelpers();
+
+  useEffect(() => {
+    addContextHelper("appState", () => ({
+      currentPage: window.location.pathname,
+      theme: "dark",
+    }));
+
+    return () => removeContextHelper("appState");
+  }, [addContextHelper, removeContextHelper]);
+}
+```
+
+### Return Values
+
+| Value                  | Type                                              | Description                                         |
+| ---------------------- | ------------------------------------------------- | --------------------------------------------------- |
+| `getAdditionalContext` | `() => Promise<AdditionalContext[]>`              | Resolve all helpers into additional context entries |
+| `getContextHelpers`    | `() => ContextHelpers`                            | Get the current context helpers map                 |
+| `addContextHelper`     | `(name: string, helper: ContextHelperFn) => void` | Register or update a context helper by name         |
+| `removeContextHelper`  | `(name: string) => void`                          | Remove a context helper by name                     |
+
+## useTamboCurrentMessage
+
+Returns the current message from the `TamboMessageProvider` context. Use this inside components rendered via the message pipeline to access the message that triggered the component.
+
+```tsx
+import { useTamboCurrentMessage } from "@tambo-ai/react";
+
+function ComponentWithMessage() {
+  const message = useTamboCurrentMessage();
+
+  return (
+    <div>
+      <p>Message ID: {message.id}</p>
+      <p>Role: {message.role}</p>
+    </div>
+  );
+}
+```
+
+**Returns:** `TamboThreadMessage` — the current message.
+
+**Throws** if used outside a `TamboMessageProvider` (i.e., outside the message rendering pipeline).
+
+## useTamboCurrentComponent
+
+Returns metadata about the current component from the message context. Works for both AI-generated components and interactable components wrapped with `withTamboInteractable`.
+
+```tsx
+import { useTamboCurrentComponent } from "@tambo-ai/react";
+
+function ComponentInfo() {
+  const component = useTamboCurrentComponent();
+
+  if (!component) return null;
+
+  return (
+    <div>
+      <p>Component: {component.componentName}</p>
+      {component.interactableId && <p>ID: {component.interactableId}</p>}
+    </div>
+  );
+}
+```
+
+### Return Values
+
+Returns `TamboCurrentComponent | null` (null if used outside `TamboMessageProvider`).
+
+| Property         | Type                      | Description                                                      |
+| ---------------- | ------------------------- | ---------------------------------------------------------------- |
+| `componentName`  | `string \| undefined`     | Component name from the message or interactable metadata         |
+| `props`          | `Record<string, unknown>` | Component props from the message content block                   |
+| `interactableId` | `string \| undefined`     | Interactable ID (only for `withTamboInteractable` components)    |
+| `description`    | `string \| undefined`     | Description (only for `withTamboInteractable` components)        |
+| `threadId`       | `string \| undefined`     | Thread ID (not available on messages directly, always undefined) |
 
 ## Re-exported Hooks
 

--- a/docs/content/docs/reference/react-sdk/mcp.mdx
+++ b/docs/content/docs/reference/react-sdk/mcp.mdx
@@ -1,0 +1,435 @@
+---
+title: MCP (Model Context Protocol)
+description: API reference for @tambo-ai/react/mcp — hooks, components, utilities, and types for MCP server integration.
+---
+
+The `@tambo-ai/react/mcp` subpath provides hooks, a provider component, utilities, and types for integrating MCP servers into your Tambo application. All exports are imported from `@tambo-ai/react/mcp`.
+
+```tsx
+import {
+  TamboMcpProvider,
+  useTamboMcpServers,
+  useTamboMcpElicitation,
+  useTamboMcpPromptList,
+  useTamboMcpPrompt,
+  useTamboMcpResourceList,
+  useTamboMcpResource,
+  isMcpResourceEntry,
+  MCPTransport,
+} from "@tambo-ai/react/mcp";
+```
+
+## TamboMcpProvider
+
+Provider that manages MCP server connections and tool registration. Must be placed inside `TamboProvider`. MCP servers are configured via the `mcpServers` prop on `TamboProvider`, not on this provider.
+
+```tsx
+import { TamboProvider } from "@tambo-ai/react";
+import { TamboMcpProvider } from "@tambo-ai/react/mcp";
+
+function App() {
+  return (
+    <TamboProvider
+      apiKey="your-api-key"
+      mcpServers={[
+        { url: "https://mcp.example.com/sse", transport: MCPTransport.SSE },
+      ]}
+    >
+      <TamboMcpProvider>
+        <Chat />
+      </TamboMcpProvider>
+    </TamboProvider>
+  );
+}
+```
+
+### Props
+
+| Prop         | Type                  | Description                                                               |
+| ------------ | --------------------- | ------------------------------------------------------------------------- |
+| `handlers`   | `ProviderMCPHandlers` | Optional handlers applied to all MCP servers unless overridden per-server |
+| `contextKey` | `string`              | Optional context key for fetching MCP tokens outside of a thread          |
+| `children`   | `ReactNode`           | Child components                                                          |
+
+## Hooks
+
+### useTamboMcpServers
+
+Returns the list of MCP servers (connected or failed). You can call methods on the MCP client included in connected server objects.
+
+```tsx
+import { useTamboMcpServers } from "@tambo-ai/react/mcp";
+
+function ServerStatus() {
+  const servers = useTamboMcpServers();
+
+  return (
+    <ul>
+      {servers.map((server) => (
+        <li key={server.key}>
+          {server.serverKey}: {server.client ? "Connected" : "Failed"}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+**Returns:** `McpServer[]`
+
+### useTamboMcpElicitation
+
+Accesses the current MCP elicitation state. When an MCP server requests user input through the elicitation protocol, this hook provides the request and a function to respond.
+
+```tsx
+import { useTamboMcpElicitation } from "@tambo-ai/react/mcp";
+
+function ElicitationUI() {
+  const { elicitation, resolveElicitation } = useTamboMcpElicitation();
+
+  if (!elicitation) return null;
+
+  return (
+    <div>
+      <p>{elicitation.message}</p>
+      <button
+        onClick={() =>
+          resolveElicitation?.({
+            action: "accept",
+            content: { confirmed: true },
+          })
+        }
+      >
+        Accept
+      </button>
+      <button onClick={() => resolveElicitation?.({ action: "decline" })}>
+        Decline
+      </button>
+    </div>
+  );
+}
+```
+
+**Returns:**
+
+| Value                | Type                                                     | Description                                    |
+| -------------------- | -------------------------------------------------------- | ---------------------------------------------- |
+| `elicitation`        | `TamboElicitationRequest \| null`                        | Current elicitation request, or null if none   |
+| `resolveElicitation` | `((response: TamboElicitationResponse) => void) \| null` | Function to respond to the elicitation request |
+
+### useTamboMcpPromptList
+
+Returns prompts from all connected MCP servers. Prompt names are prefixed with the server key (e.g., `linear:create-issue`).
+
+```tsx
+import { useTamboMcpPromptList } from "@tambo-ai/react/mcp";
+
+function PromptPicker() {
+  const { data, isPending } = useTamboMcpPromptList();
+
+  return (
+    <ul>
+      {data.map((entry) => (
+        <li key={entry.prompt.name}>{entry.prompt.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+**Parameters:**
+
+| Parameter | Type     | Description                                                 |
+| --------- | -------- | ----------------------------------------------------------- |
+| `search`  | `string` | Optional search string to filter prompts (case-insensitive) |
+
+**Returns:** `{ data: ListPromptEntry[], isPending, isError, error, refetch, ... }`
+
+### useTamboMcpPrompt
+
+Fetches a single prompt by name from the appropriate MCP server.
+
+```tsx
+import { useTamboMcpPrompt } from "@tambo-ai/react/mcp";
+
+function PromptView({ promptName }: { promptName: string }) {
+  const { data, isPending } = useTamboMcpPrompt(promptName, {
+    projectId: "abc-123",
+  });
+
+  if (isPending) return <p>Loading...</p>;
+  return <pre>{JSON.stringify(data, null, 2)}</pre>;
+}
+```
+
+**Parameters:**
+
+| Parameter    | Type                     | Description                                                             |
+| ------------ | ------------------------ | ----------------------------------------------------------------------- |
+| `promptName` | `string \| undefined`    | Prompt name, optionally prefixed with server key (e.g., `linear:issue`) |
+| `args`       | `Record<string, string>` | Arguments to pass to the prompt. Defaults to `{}`                       |
+
+**Returns:** `{ data: GetPromptResult | null, isPending, isError, error, ... }`
+
+### useTamboMcpResourceList
+
+Returns resources from all connected MCP servers and the local registry. Resource URIs are prefixed with the server key or `registry:` for local resources.
+
+```tsx
+import { useTamboMcpResourceList } from "@tambo-ai/react/mcp";
+
+function ResourceBrowser() {
+  const { data, isPending } = useTamboMcpResourceList("search term");
+
+  return (
+    <ul>
+      {data.map((entry) => (
+        <li key={entry.resource.uri}>
+          {entry.resource.name} — {entry.resource.uri}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+**Parameters:**
+
+| Parameter | Type     | Description                                               |
+| --------- | -------- | --------------------------------------------------------- |
+| `search`  | `string` | Optional search string to filter resources by name or URI |
+
+**Returns:** `{ data: ListResourceEntry[], isPending, isError, error, refetch, ... }`
+
+### useTamboMcpResource
+
+Fetches a single resource by URI. The URI must be prefixed (e.g., `linear:file://foo` for MCP resources, `registry:file://bar` for local registry resources).
+
+```tsx
+import { useTamboMcpResource } from "@tambo-ai/react/mcp";
+
+function ResourceViewer({ uri }: { uri: string }) {
+  const { data, isPending } = useTamboMcpResource(uri);
+
+  if (isPending) return <p>Loading...</p>;
+  return <pre>{JSON.stringify(data, null, 2)}</pre>;
+}
+```
+
+**Parameters:**
+
+| Parameter     | Type                  | Description                  |
+| ------------- | --------------------- | ---------------------------- |
+| `resourceUri` | `string \| undefined` | Prefixed URI of the resource |
+
+**Returns:** `{ data: ReadResourceResult | null, isPending, isError, error, ... }`
+
+### useTamboElicitationContext
+
+**Deprecated.** Use `useTamboMcpElicitation` instead.
+
+## Utilities
+
+### isMcpResourceEntry
+
+Type guard that narrows a `ListResourceEntry` to an MCP-backed resource (as opposed to a local registry resource).
+
+```tsx
+import { isMcpResourceEntry } from "@tambo-ai/react/mcp";
+
+const entry: ListResourceEntry = /* ... */;
+
+if (isMcpResourceEntry(entry)) {
+  // entry.server is ConnectedMcpServer
+  console.log(entry.server.serverKey);
+} else {
+  // entry.server is null (local registry resource)
+}
+```
+
+### MCPTransport
+
+Enum for the transport protocol used to connect to MCP servers.
+
+```tsx
+import { MCPTransport } from "@tambo-ai/react/mcp";
+```
+
+| Value               | Description                         |
+| ------------------- | ----------------------------------- |
+| `MCPTransport.SSE`  | Server-Sent Events transport        |
+| `MCPTransport.HTTP` | Streamable HTTP transport (default) |
+
+## Types
+
+### Server Types
+
+#### McpServer
+
+Union type representing an MCP server that is either connected or failed.
+
+```tsx
+type McpServer = ConnectedMcpServer | FailedMcpServer;
+```
+
+#### ConnectedMcpServer
+
+An MCP server with an active client connection.
+
+| Property    | Type           | Description                                        |
+| ----------- | -------------- | -------------------------------------------------- |
+| `client`    | `MCPClient`    | The active MCP client for making requests          |
+| `url`       | `string`       | Server URL                                         |
+| `transport` | `MCPTransport` | Transport protocol                                 |
+| `serverKey` | `string`       | Short name used for namespacing                    |
+| `key`       | `string`       | Stable identity key derived from connection config |
+| `name`      | `string`       | Optional server name                               |
+
+#### FailedMcpServer
+
+An MCP server that failed to connect.
+
+| Property          | Type    | Description          |
+| ----------------- | ------- | -------------------- |
+| `connectionError` | `Error` | The connection error |
+| `client`          | `never` | Always undefined     |
+
+Plus the same base properties as `ConnectedMcpServer` (`url`, `transport`, `serverKey`, `key`, `name`).
+
+#### McpServerInfo
+
+Configuration object for an MCP server, passed via the `mcpServers` prop on `TamboProvider`.
+
+| Property        | Type                     | Description                                                     |
+| --------------- | ------------------------ | --------------------------------------------------------------- |
+| `url`           | `string`                 | Server URL (required)                                           |
+| `name`          | `string`                 | Optional display name                                           |
+| `description`   | `string`                 | Optional description                                            |
+| `transport`     | `MCPTransport`           | Transport protocol. Defaults to `MCPTransport.HTTP`             |
+| `customHeaders` | `Record<string, string>` | Optional headers to include in requests                         |
+| `serverKey`     | `string`                 | Optional short name for namespacing. Derived from URL if absent |
+| `handlers`      | `Partial<MCPHandlers>`   | Optional per-server elicitation and sampling handlers           |
+
+### Handler Types
+
+#### MCPHandlers
+
+Handlers for MCP protocol requests.
+
+| Property      | Type                    | Description                      |
+| ------------- | ----------------------- | -------------------------------- |
+| `elicitation` | `MCPElicitationHandler` | Handler for elicitation requests |
+| `sampling`    | `MCPSamplingHandler`    | Handler for sampling requests    |
+
+#### MCPElicitationHandler
+
+```tsx
+type MCPElicitationHandler = (
+  request: ElicitRequest,
+  extra: RequestHandlerExtra,
+) => Promise<ElicitResult>;
+```
+
+Handler invoked when an MCP server requests user input. The `extra` parameter includes an `AbortSignal` for cancellation.
+
+#### MCPSamplingHandler
+
+```tsx
+type MCPSamplingHandler = (
+  request: CreateMessageRequest,
+  extra: RequestHandlerExtra,
+) => Promise<CreateMessageResult>;
+```
+
+Handler invoked when an MCP server requests a model response (create_message).
+
+#### ProviderMCPHandlers
+
+Provider-level handlers that receive server info as a third parameter. Applied to all servers unless overridden per-server.
+
+| Property      | Type                                                           | Description         |
+| ------------- | -------------------------------------------------------------- | ------------------- |
+| `elicitation` | `(request, extra, serverInfo) => Promise<ElicitResult>`        | Elicitation handler |
+| `sampling`    | `(request, extra, serverInfo) => Promise<CreateMessageResult>` | Sampling handler    |
+
+### Elicitation Types
+
+#### TamboElicitationRequest
+
+Elicitation request surfaced by `useTamboMcpElicitation`.
+
+| Property          | Type                         | Description                                       |
+| ----------------- | ---------------------------- | ------------------------------------------------- |
+| `message`         | `string`                     | Message from the server explaining what is needed |
+| `requestedSchema` | `ElicitationRequestedSchema` | Schema describing the expected form fields        |
+| `signal`          | `AbortSignal`                | Fires when the server cancels the request         |
+
+#### TamboElicitationResponse
+
+Response to send back via `resolveElicitation`.
+
+| Property  | Type                                | Description                |
+| --------- | ----------------------------------- | -------------------------- |
+| `action`  | `"accept" \| "decline" \| "cancel"` | User's response action     |
+| `content` | `Record<string, unknown>`           | Optional form field values |
+
+#### ElicitationRequestedSchema
+
+Type alias for the schema of fields requested in an elicitation. This is an object mapping field names to `PrimitiveSchemaDefinition` values.
+
+#### PrimitiveSchemaDefinition
+
+Re-exported from `@modelcontextprotocol/sdk`. Describes a single field in an elicitation form (type, description, enum values, etc.).
+
+### List Entry Types
+
+#### ListPromptEntry
+
+A prompt from an MCP server, as returned by `useTamboMcpPromptList`.
+
+| Property | Type                 | Description                              |
+| -------- | -------------------- | ---------------------------------------- |
+| `server` | `ConnectedMcpServer` | The server this prompt came from         |
+| `prompt` | `ListPromptItem`     | Prompt metadata (name, description, etc) |
+
+#### ListResourceEntry
+
+A resource from an MCP server or the local registry, as returned by `useTamboMcpResourceList`.
+
+```tsx
+type ListResourceEntry = McpResourceEntry | RegistryResourceEntry;
+```
+
+When `server` is `null`, the resource is from the local registry. Use `isMcpResourceEntry()` to narrow.
+
+| Property   | Type                         | Description                                          |
+| ---------- | ---------------------------- | ---------------------------------------------------- |
+| `server`   | `ConnectedMcpServer \| null` | The server, or null for registry resources           |
+| `resource` | `ListResourceItem`           | Resource metadata (uri, name, description, mimeType) |
+
+#### ListPromptItem
+
+Re-exported from `@modelcontextprotocol/sdk`. Contains prompt metadata: `name`, `description`, and `arguments`.
+
+#### ListResourceItem
+
+Re-exported from `@modelcontextprotocol/sdk`. Contains resource metadata: `uri`, `name`, `description`, and `mimeType`.
+
+### Metadata Types
+
+#### McpServerInfo
+
+Configuration object accepted by `TamboProvider`'s `mcpServers` prop. Also exported from `@tambo-ai/react/mcp`.
+
+See the [McpServerInfo table](#mcpserverinfo) above for all properties.
+
+#### NormalizedMcpServerInfo
+
+Internal type extending `McpServerInfo` with guaranteed `transport` and `serverKey` fields. Useful if you need to work with resolved server configurations.
+
+| Property    | Type           | Description                                 |
+| ----------- | -------------- | ------------------------------------------- |
+| `transport` | `MCPTransport` | Always present (defaults resolved to HTTP)  |
+| `serverKey` | `string`       | Always present (derived from URL if absent) |
+
+Plus all properties from `McpServerInfo`.

--- a/docs/content/docs/reference/react-sdk/meta.json
+++ b/docs/content/docs/reference/react-sdk/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "React SDK",
-  "pages": ["index", "hooks", "types", "providers", "migration"]
+  "pages": ["index", "hooks", "types", "providers", "mcp", "migration"]
 }

--- a/docs/content/docs/reference/react-sdk/types.mdx
+++ b/docs/content/docs/reference/react-sdk/types.mdx
@@ -50,6 +50,7 @@ interface StreamingState {
   runId?: string;
   messageId?: string;
   startTime?: number;
+  reasoningStartTime?: number;
   error?: {
     message: string;
     code?: string;
@@ -59,17 +60,18 @@ interface StreamingState {
 
 ## Message Types
 
-### TamboMessage
+### TamboThreadMessage
 
 A message in a thread, containing an array of content blocks.
 
 ```typescript
-interface TamboMessage {
+interface TamboThreadMessage {
   id: string;
   role: MessageRole;
   content: Content[];
   createdAt?: string;
   metadata?: Record<string, unknown>;
+  parentMessageId?: string;
   reasoning?: string[];
   reasoningDurationMS?: number;
 }
@@ -77,6 +79,7 @@ interface TamboMessage {
 
 | Property              | Type       | Description                                                                                           |
 | --------------------- | ---------- | ----------------------------------------------------------------------------------------------------- |
+| `parentMessageId`     | `string`   | ID of the parent message, if created during generation of another message (e.g., MCP sampling).       |
 | `reasoning`           | `string[]` | Reasoning chunks from the model. Transient — only present during streaming, not persisted to the API. |
 | `reasoningDurationMS` | `number`   | Duration of the reasoning phase in milliseconds, for display purposes.                                |
 
@@ -95,8 +98,8 @@ Messages contain an array of typed content blocks:
 ```typescript
 type Content =
   | TextContent
-  | ComponentContent
-  | ToolUseContent
+  | TamboComponentContent
+  | TamboToolUseContent
   | ToolResultContent
   | ResourceContent;
 ```
@@ -112,12 +115,12 @@ interface TextContent {
 }
 ```
 
-#### ComponentContent
+#### TamboComponentContent
 
-A rendered component with streaming state.
+A rendered component with streaming state. Extends the base `ComponentContent` from the SDK with computed properties.
 
 ```typescript
-interface ComponentContent {
+interface TamboComponentContent {
   type: "component";
   id: string;
   name: string;
@@ -129,12 +132,12 @@ interface ComponentContent {
 
 The `renderedComponent` property contains the pre-rendered React element for the component, looked up from the registry.
 
-#### ToolUseContent
+#### TamboToolUseContent
 
-A tool invocation with display metadata.
+A tool invocation with display metadata. Extends the base `ToolUseContent` from the SDK with computed properties populated by `useTambo()`.
 
 ```typescript
-interface ToolUseContent {
+interface TamboToolUseContent {
   type: "tool_use";
   id: string;
   name: string;
@@ -156,7 +159,6 @@ Display properties extracted from tool inputs.
 
 ```typescript
 interface TamboToolDisplayProps {
-  _tambo_displayMessage?: string;
   _tambo_statusMessage?: string;
   _tambo_completionStatusMessage?: string;
 }
@@ -199,28 +201,29 @@ interface TamboComponent {
   name: string;
   description: string;
   component: ComponentType<any>;
-  propsSchema: Record<string, unknown>;
-  stateSchema?: Record<string, unknown>;
-  initialState?: () => Record<string, unknown>;
+  propsSchema?: SupportedSchema;
+  loadingComponent?: ComponentType<any>;
+  associatedTools?: TamboTool[];
+  annotations?: ToolAnnotations;
 }
 ```
 
 ### Properties
 
-| Property       | Type            | Required | Description                         |
-| -------------- | --------------- | -------- | ----------------------------------- |
-| `name`         | `string`        | Yes      | Unique identifier for the component |
-| `description`  | `string`        | Yes      | Description for AI understanding    |
-| `component`    | `ComponentType` | Yes      | The React component to render       |
-| `propsSchema`  | `object`        | Yes      | JSON Schema for component props     |
-| `stateSchema`  | `object`        | No       | JSON Schema for component state     |
-| `initialState` | `() => object`  | No       | Factory function for initial state  |
+| Property           | Type              | Required | Description                                                        |
+| ------------------ | ----------------- | -------- | ------------------------------------------------------------------ |
+| `name`             | `string`          | Yes      | Unique identifier for the component                                |
+| `description`      | `string`          | Yes      | Description for AI understanding                                   |
+| `component`        | `ComponentType`   | Yes      | The React component to render                                      |
+| `propsSchema`      | `SupportedSchema` | No       | Schema for component props (Zod, Valibot, ArkType, or JSON Schema) |
+| `loadingComponent` | `ComponentType`   | No       | Component to render while the component is loading                 |
+| `associatedTools`  | `TamboTool[]`     | No       | Tools associated with this component                               |
+| `annotations`      | `ToolAnnotations` | No       | Behavior annotations (see [ToolAnnotations](#toolannotations))     |
 
 ### Example Registration
 
 ```typescript
 import { z } from "zod";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 const WeatherCardSchema = z.object({
   city: z.string().describe("The city name"),
@@ -233,7 +236,7 @@ const components: TamboComponent[] = [
     name: "WeatherCard",
     description: "Displays current weather for a city",
     component: WeatherCard,
-    propsSchema: zodToJsonSchema(WeatherCardSchema),
+    propsSchema: WeatherCardSchema,
   },
 ];
 ```
@@ -248,6 +251,7 @@ The same `TamboTool` interface from the base SDK is used.
 interface TamboTool {
   name: string;
   description: string;
+  title?: string;
   tool: (params: Record<string, unknown>) => unknown;
   inputSchema: SupportedSchema;
   outputSchema: SupportedSchema;
@@ -261,9 +265,10 @@ interface TamboTool {
 | -------------------- | ----------------- | -------- | -------------------------------------------------------------------------------------------------------- |
 | `name`               | `string`          | Yes      | Unique identifier for the tool                                                                           |
 | `description`        | `string`          | Yes      | Description for AI understanding                                                                         |
+| `title`              | `string`          | No       | Optional human-readable name for display purposes                                                        |
 | `tool`               | `function`        | Yes      | The tool implementation function                                                                         |
 | `inputSchema`        | `SupportedSchema` | Yes      | Schema for tool input parameters                                                                         |
-| `outputSchema`       | `SupportedSchema` | Yes      | Schema for tool output                                                                                   |
+| `outputSchema`       | `SupportedSchema` | Yes      | Schema for tool output (informational, not validated at runtime)                                         |
 | `maxCalls`           | `number`          | No       | Maximum times this tool can be called in a single response. Overrides the project-level tool call limit. |
 | `annotations`        | `ToolAnnotations` | No       | Behavior annotations (see [ToolAnnotations](#toolannotations))                                           |
 | `transformToContent` | `function`        | No       | Transform tool result into content parts for richer display                                              |
@@ -272,7 +277,7 @@ interface TamboTool {
 
 ### TamboCustomEvent
 
-Custom events emitted during streaming.
+Custom events emitted during streaming. Each event uses an envelope pattern with a `name` string and a `value` object containing the payload.
 
 ```typescript
 type TamboCustomEvent =
@@ -280,7 +285,8 @@ type TamboCustomEvent =
   | ComponentPropsDeltaEvent
   | ComponentStateDeltaEvent
   | ComponentEndEvent
-  | RunAwaitingInputEvent;
+  | RunAwaitingInputEvent
+  | MessageParentEvent;
 ```
 
 #### ComponentStartEvent
@@ -288,11 +294,14 @@ type TamboCustomEvent =
 Emitted when component rendering begins.
 
 ```typescript
-interface ComponentStartEvent {
+type ComponentStartEvent = {
   name: "tambo.component.start";
-  componentId: string;
-  componentName: string;
-}
+  value: {
+    messageId: string;
+    componentId: string;
+    componentName: string;
+  };
+};
 ```
 
 #### ComponentPropsDeltaEvent
@@ -300,11 +309,13 @@ interface ComponentStartEvent {
 Emitted when component props are updated (JSON Patch format).
 
 ```typescript
-interface ComponentPropsDeltaEvent {
+type ComponentPropsDeltaEvent = {
   name: "tambo.component.props_delta";
-  componentId: string;
-  delta: JsonPatchOperation[];
-}
+  value: {
+    componentId: string;
+    operations: Operation[];
+  };
+};
 ```
 
 #### ComponentStateDeltaEvent
@@ -312,11 +323,13 @@ interface ComponentPropsDeltaEvent {
 Emitted when component state is updated (JSON Patch format).
 
 ```typescript
-interface ComponentStateDeltaEvent {
+type ComponentStateDeltaEvent = {
   name: "tambo.component.state_delta";
-  componentId: string;
-  delta: JsonPatchOperation[];
-}
+  value: {
+    componentId: string;
+    operations: Operation[];
+  };
+};
 ```
 
 #### ComponentEndEvent
@@ -324,21 +337,51 @@ interface ComponentStateDeltaEvent {
 Emitted when component rendering completes.
 
 ```typescript
-interface ComponentEndEvent {
+type ComponentEndEvent = {
   name: "tambo.component.end";
-  componentId: string;
-}
+  value: {
+    componentId: string;
+  };
+};
 ```
 
 #### RunAwaitingInputEvent
 
-Emitted when the run is waiting for tool execution.
+Emitted when the run is waiting for client-side tool execution.
 
 ```typescript
-interface RunAwaitingInputEvent {
+type RunAwaitingInputEvent = {
   name: "tambo.run.awaiting_input";
-  toolCalls: ToolCall[];
+  value: {
+    pendingToolCalls: PendingToolCall[];
+  };
+};
+```
+
+#### PendingToolCall
+
+Information about a tool call awaiting execution.
+
+```typescript
+interface PendingToolCall {
+  toolCallId: string;
+  toolName: string;
+  arguments: string;
 }
+```
+
+#### MessageParentEvent
+
+Emitted when a message was created during the generation of another message (e.g., MCP sampling or elicitation).
+
+```typescript
+type MessageParentEvent = {
+  name: "tambo.message.parent";
+  value: {
+    messageId: string;
+    parentMessageId: string;
+  };
+};
 ```
 
 ### Type Guards
@@ -446,6 +489,77 @@ type ToolAnnotations = MCPToolAnnotations & {
 | `tamboStreamableHint` | `boolean` | When `true`, the tool can be called with partially-streamed arguments as they arrive. Use for read-only tools without side effects. |
 
 `ToolAnnotations` can be set on both `TamboTool` and `TamboComponent` via the `annotations` property.
+
+## Interactable Types
+
+### InteractableConfig
+
+Configuration passed to `withTamboInteractable()` to make a component interactable.
+
+```typescript
+interface InteractableConfig<
+  Props = Record<string, unknown>,
+  State = Record<string, unknown>,
+> {
+  componentName: string;
+  description: string;
+  propsSchema?: SupportedSchema<Props>;
+  stateSchema?: SupportedSchema<State>;
+  annotations?: ToolAnnotations;
+}
+```
+
+| Property        | Type              | Required | Description                                      |
+| --------------- | ----------------- | -------- | ------------------------------------------------ |
+| `componentName` | `string`          | Yes      | Name used for identification in Tambo            |
+| `description`   | `string`          | Yes      | Description of the component for the AI          |
+| `propsSchema`   | `SupportedSchema` | No       | Schema for validating prop updates               |
+| `stateSchema`   | `SupportedSchema` | No       | Schema for validating state updates              |
+| `annotations`   | `ToolAnnotations` | No       | Annotations for the auto-registered update tools |
+
+### WithTamboInteractableProps
+
+Props injected by `withTamboInteractable()` that can be passed to the wrapped component.
+
+```typescript
+interface WithTamboInteractableProps {
+  interactableId?: string;
+  onInteractableReady?: (id: string) => void;
+  onPropsUpdate?: (newProps: Record<string, unknown>) => void;
+}
+```
+
+| Property              | Type                                          | Description                                         |
+| --------------------- | --------------------------------------------- | --------------------------------------------------- |
+| `interactableId`      | `string`                                      | Optional custom ID (auto-generated if not provided) |
+| `onInteractableReady` | `(id: string) => void`                        | Called when the component is registered             |
+| `onPropsUpdate`       | `(newProps: Record<string, unknown>) => void` | Called when Tambo updates the component's props     |
+
+## Image Types
+
+### StagedImage
+
+Represents an image staged for upload in message input.
+
+```typescript
+interface StagedImage {
+  id: string;
+  name: string;
+  dataUrl: string;
+  file: File;
+  size: number;
+  type: string;
+}
+```
+
+| Property  | Type     | Description                     |
+| --------- | -------- | ------------------------------- |
+| `id`      | `string` | Unique identifier               |
+| `name`    | `string` | File name                       |
+| `dataUrl` | `string` | Base64 data URL for preview     |
+| `file`    | `File`   | Original File object            |
+| `size`    | `number` | File size in bytes              |
+| `type`    | `string` | MIME type (e.g., `"image/png"`) |
 
 ## Re-exported Types
 


### PR DESCRIPTION
## Summary

Fixes documentation bugs across the React SDK reference pages. All docs verified against the actual SDK v1 source code.

- **TAM-1238**: Rewrite `build-chat-interface.mdx` to use v1 content blocks instead of legacy `message.toolCallRequest`, `message.renderedComponent`, and rendering `message.content` as a string
- **TAM-1234**: Add new MCP reference page (`mcp.mdx`) documenting all `@tambo-ai/react/mcp` exports — provider, hooks, utilities, and types
- **TAM-1228**: Remove `useTamboSendMessage` from hooks reference (not exported from v1)
- **TAM-1245**: Document missing hooks (`useTamboInteractable`, `useCurrentInteractablesSnapshot`, `useTamboContextAttachment`, `useTamboContextHelpers`, `useTamboCurrentMessage`, `useTamboCurrentComponent`) and types (`InteractableConfig`, `WithTamboInteractableProps`, `StagedImage`)

Additional fixes found during full codebase verification:
- Fix `TamboMessage` → `TamboThreadMessage` type name in hooks reference
- Fix Content union member names to `TamboComponentContent` / `TamboToolUseContent`
- Fix event types to use envelope pattern (`{ name, value }`) matching actual SDK
- Add `PendingToolCall`, `MessageParentEvent` types
- Add `title` to `TamboTool`, `updateThreadName` to `useTambo()` return values
- Add `isDisabled` to `useTamboThreadInput()` return values
- Remove non-existent `setCustomSuggestions` section
- Remove non-existent `_tambo_displayMessage` from `TamboToolDisplayProps`
- Fix `TamboComponent` properties (remove `stateSchema`/`initialState`, add `loadingComponent`/`associatedTools`/`annotations`)

## Test plan

- [ ] `npm run build` passes in docs package
- [ ] New MCP reference page renders correctly
- [ ] Hook/type reference tables properly formatted
- [ ] Code examples use correct v1 content block patterns

Fixes TAM-1238, TAM-1234, TAM-1228, TAM-1245