### PR TITLE
fix (docs): Add commands for globally installing supabase cli since `npm install -g supabase` is not working

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,16 @@ Supabase provides PostgreSQL with additional features. The `.env.example` files 
 
 ```bash
 # Install Supabase CLI if you haven't
-npm install -g supabase
+# https://supabase.com/docs/guides/local-development/cli/getting-started
+# on macOS
+brew install supabase/tap/supabase
+
+# on windows
+scoop bucket add supabase https://github.com/supabase/scoop-bucket.git
+scoop install supabase
+
+# on Linux
+brew install supabase/tap/supabase
 
 # Start Supabase (includes PostgreSQL on port 54322)
 supabase start


### PR DESCRIPTION
fixes: #2494 

Added commands for globally installing supabase cli on macOS, windows and Linux along with instruction link for installing supabase cli.

Found a similar [issue](https://github.com/supabase/cli/issues/4496) on official supabase repository.