### PR TITLE
fix(react-sdk): allow AI to clear optional fields on interactable components

### DIFF
--- a/react-sdk/src/schema/json-schema.test.ts
+++ b/react-sdk/src/schema/json-schema.test.ts
@@ -357,4 +357,58 @@ describe("makeJsonSchemaPartial", () => {
       nothing: false,
     });
   });
+
+  it("should preserve property that is already type: null", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: {
+        alwaysNull: { type: "null" },
+      },
+    };
+
+    const partial = makeJsonSchemaPartial(schema);
+
+    expect(partial.properties).toEqual({
+      alwaysNull: { type: "null" },
+    });
+  });
+
+  it("should flatten existing anyOf without null instead of nesting", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: {
+        value: {
+          anyOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+    };
+
+    const partial = makeJsonSchemaPartial(schema);
+
+    // Should append {type: "null"} to existing anyOf, not nest
+    expect(partial.properties).toEqual({
+      value: {
+        anyOf: [{ type: "string" }, { type: "number" }, { type: "null" }],
+      },
+    });
+  });
+
+  it("should expand multi-type arrays into individual anyOf entries", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: {
+        flexible: {
+          type: ["string", "number", "null"] as unknown as "string",
+        },
+      },
+    };
+
+    const partial = makeJsonSchemaPartial(schema);
+
+    expect(partial.properties).toEqual({
+      flexible: {
+        anyOf: [{ type: "string" }, { type: "number" }, { type: "null" }],
+      },
+    });
+  });
 });

--- a/react-sdk/src/schema/json-schema.ts
+++ b/react-sdk/src/schema/json-schema.ts
@@ -143,33 +143,42 @@ function makePropertyNullable(
     return propSchema;
   }
 
+  // Already just {type: "null"}
+  if (propSchema.type === "null") {
+    return propSchema;
+  }
+
+  const hasNullVariant = (
+    variants: JSONSchema7["anyOf"] | JSONSchema7["oneOf"],
+  ) =>
+    variants?.some((s) => typeof s !== "boolean" && s.type === "null") ?? false;
+
   // Already nullable via anyOf containing {type: "null"}
-  if (
-    propSchema.anyOf?.some((s) => typeof s !== "boolean" && s.type === "null")
-  ) {
+  if (hasNullVariant(propSchema.anyOf)) {
     return propSchema;
   }
 
   // Already nullable via oneOf containing {type: "null"}
-  if (
-    propSchema.oneOf?.some((s) => typeof s !== "boolean" && s.type === "null")
-  ) {
+  if (hasNullVariant(propSchema.oneOf)) {
     return propSchema;
+  }
+
+  // Existing anyOf without null — flatten by appending {type: "null"} to avoid nesting
+  if (propSchema.anyOf) {
+    return { ...propSchema, anyOf: [...propSchema.anyOf, { type: "null" }] };
   }
 
   // Normalize type: [T, "null"] array form to anyOf (LLMs don't handle the array form)
   if (Array.isArray(propSchema.type) && propSchema.type.includes("null")) {
-    const nonNullTypes = propSchema.type.filter((t) => t !== "null");
     const { type: _type, ...rest } = propSchema;
-    const baseSchema: JSONSchema7 =
-      nonNullTypes.length === 1
-        ? { ...rest, type: nonNullTypes[0] as JSONSchema7["type"] }
-        : { ...rest, type: nonNullTypes as JSONSchema7["type"] };
-    return { anyOf: [baseSchema, { type: "null" }] };
+    const baseSchemas = propSchema.type
+      .filter((t) => t !== "null")
+      .map((t) => ({ ...rest, type: t as JSONSchema7["type"] }));
+    return { anyOf: [...baseSchemas, { type: "null" }] };
   }
 
   // Not yet nullable — wrap in anyOf
-  return { anyOf: [propSchema, { type: "null" }] };
+  return { anyOf: [{ ...propSchema }, { type: "null" }] };
 }
 
 /**


### PR DESCRIPTION
## Summary

- `makeJsonSchemaPartial` now wraps each property in `anyOf: [originalSchema, {type: "null"}]` so the LLM can send `null` to clear optional fields
- Normalizes Zod v3's `type: ["string", "null"]` array form to the `anyOf` pattern, since LLMs don't reliably interpret the array form
- Preserves properties already nullable via `anyOf` or `oneOf`
- Early return for `{type: "null"}` properties (already nullable, no wrapping needed)
- Flattens existing `anyOf` without null by appending `{type: "null"}` instead of nesting
- Expands multi-type arrays (e.g. `type: ["string", "number", "null"]`) into individual `anyOf` entries with metadata preserved

This fixes the issue where the AI tries to clear optional fields on interactable components but schema validation strips the `null` values, causing an empty `{}` and a retry loop.

Handles all Zod v3/v4 nullable patterns from Michael's test matrix.

Fixes TAM-1227

![fix of null values](https://github.com/user-attachments/assets/09363bbc-b318-40a3-8888-d400ef6c99ed)

## Test plan

- [x] All existing `makeJsonSchemaPartial` tests updated for new nullable behavior
- [x] New tests for: already-nullable schemas (anyOf/oneOf), type array normalization, boolean schemas, schemas without properties, type:null early return, anyOf flattening, multi-type expansion
- [x] 891 tests pass, type checking clean
- [ ] Manual test: create interactable component with optional fields, populate them, then ask AI to clear them