### PR TITLE
docs(react-sdk): add authState, isIdentified, TamboAuthState to reference

### DIFF
--- a/docs/content/docs/reference/react-sdk/hooks.mdx
+++ b/docs/content/docs/reference/react-sdk/hooks.mdx
@@ -72,10 +72,10 @@ function Chat() {
 
 #### Authentication
 
-| Value            | Type                                                          | Description                                                        |
-| ---------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
-| `authState`      | [`TamboAuthState`](/reference/react-sdk/types#tamboauthstate) | Current authentication state as a discriminated union              |
-| `isIdentified`   | `boolean`                                                     | Shorthand for `authState.status === "identified"`                  |
+| Value          | Type                                                          | Description                                           |
+| -------------- | ------------------------------------------------------------- | ----------------------------------------------------- |
+| `authState`    | [`TamboAuthState`](/reference/react-sdk/types#tamboauthstate) | Current authentication state as a discriminated union |
+| `isIdentified` | `boolean`                                                     | Shorthand for `authState.status === "identified"`     |
 
 #### Run Control
 

--- a/docs/content/docs/reference/react-sdk/types.mdx
+++ b/docs/content/docs/reference/react-sdk/types.mdx
@@ -73,13 +73,13 @@ type TamboAuthState =
   | { status: "unauthenticated" };
 ```
 
-| Status             | Additional Properties   | Description                                                              |
-| ------------------ | ----------------------- | ------------------------------------------------------------------------ |
-| `identified`       | `source: "userKey" \| "tokenExchange"` | Ready to make API calls. `source` indicates how auth was established. |
-| `exchanging`       | —                       | A `userToken` was provided and token exchange is in progress             |
-| `error`            | `error: Error`          | Token exchange failed                                                    |
-| `invalid`          | —                       | Both `userKey` and `userToken` were provided (must use one, not both)    |
-| `unauthenticated`  | —                       | Neither `userKey` nor `userToken` was provided                           |
+| Status            | Additional Properties                  | Description                                                           |
+| ----------------- | -------------------------------------- | --------------------------------------------------------------------- |
+| `identified`      | `source: "userKey" \| "tokenExchange"` | Ready to make API calls. `source` indicates how auth was established. |
+| `exchanging`      | —                                      | A `userToken` was provided and token exchange is in progress          |
+| `error`           | `error: Error`                         | Token exchange failed                                                 |
+| `invalid`         | —                                      | Both `userKey` and `userToken` were provided (must use one, not both) |
+| `unauthenticated` | —                                      | Neither `userKey` nor `userToken` was provided                        |
 
 #### Example: Auth-Aware UI
 


### PR DESCRIPTION
## Summary

- Add `authState` and `isIdentified` to the `useTambo()` code example and return values table in `hooks.mdx`
- Document the `TamboAuthState` discriminated union type in `types.mdx` with all 5 auth states
- Include an auth-aware UI example showing conditional rendering based on auth status

All values verified against `react-sdk/src/v1/types/auth.ts` and `react-sdk/src/v1/hooks/use-tambo-v1.ts`.

Note: `updateThreadName` was already documented in the Thread Management table.

Fixes TAM-1233

## Test plan

- [ ] Verify docs site builds without errors
- [ ] Check `useTambo()` section in hooks reference renders correctly
- [ ] Check `TamboAuthState` section in types reference renders correctly
- [ ] Verify cross-link from hooks.mdx to types.mdx works