### PR TITLE
docs(react-sdk): document missing types in types.mdx

### DIFF
--- a/docs/content/docs/reference/react-sdk/types.mdx
+++ b/docs/content/docs/reference/react-sdk/types.mdx
@@ -665,9 +665,9 @@ type ToolAnnotations = MCPToolAnnotations & {
 
 ## Interactable Types
 
-### TamboInteractableComponent
+### InteractableComponent
 
-Represents a registered interactable component instance. Extends [`TamboComponent`](#tambocomponent) with instance-specific state. Also exported as `InteractableComponent`.
+Represents a registered interactable component instance. Extends [`TamboComponent`](#tambocomponent) with instance-specific state. The internal type name is `TamboInteractableComponent`.
 
 ```typescript
 interface TamboInteractableComponent<
@@ -682,13 +682,13 @@ interface TamboInteractableComponent<
 }
 ```
 
-| Property      | Type              | Required | Description                                                          |
-| ------------- | ----------------- | -------- | -------------------------------------------------------------------- |
-| `id`          | `string`          | Yes      | Unique identifier for this component instance                        |
-| `props`       | `Props`           | Yes      | Current props for the component                                      |
-| `isSelected`  | `boolean`         | No       | Whether the component is selected for AI interaction on next message |
-| `state`       | `State`           | No       | Current state for the component                                      |
-| `stateSchema` | `SupportedSchema` | No       | Schema for validating state updates                                  |
+| Property      | Type                     | Required | Description                                                          |
+| ------------- | ------------------------ | -------- | -------------------------------------------------------------------- |
+| `id`          | `string`                 | Yes      | Unique identifier for this component instance                        |
+| `props`       | `Props`                  | Yes      | Current props for the component                                      |
+| `isSelected`  | `boolean`                | No       | Whether the component is selected for AI interaction on next message |
+| `state`       | `State`                  | No       | Current state for the component                                      |
+| `stateSchema` | `SupportedSchema<State>` | No       | Schema for validating state updates                                  |
 
 ### InteractableConfig
 
@@ -707,13 +707,13 @@ interface InteractableConfig<
 }
 ```
 
-| Property        | Type              | Required | Description                                      |
-| --------------- | ----------------- | -------- | ------------------------------------------------ |
-| `componentName` | `string`          | Yes      | Name used for identification in Tambo            |
-| `description`   | `string`          | Yes      | Description of the component for the AI          |
-| `propsSchema`   | `SupportedSchema` | No       | Schema for validating prop updates               |
-| `stateSchema`   | `SupportedSchema` | No       | Schema for validating state updates              |
-| `annotations`   | `ToolAnnotations` | No       | Annotations for the auto-registered update tools |
+| Property        | Type                     | Required | Description                                      |
+| --------------- | ------------------------ | -------- | ------------------------------------------------ |
+| `componentName` | `string`                 | Yes      | Name used for identification in Tambo            |
+| `description`   | `string`                 | Yes      | Description of the component for the AI          |
+| `propsSchema`   | `SupportedSchema<Props>` | No       | Schema for validating prop updates               |
+| `stateSchema`   | `SupportedSchema<State>` | No       | Schema for validating state updates              |
+| `annotations`   | `ToolAnnotations`        | No       | Annotations for the auto-registered update tools |
 
 ### WithTamboInteractableProps
 


### PR DESCRIPTION
## Summary

Adds documentation for several exported types that were missing from the React SDK types reference:

- **TamboConfig** — provider configuration with `userKey`, `autoGenerateThreadName`, `autoGenerateNameThreshold`, `initialMessages`
- **InitialInputMessage** — message type for seeding threads with system/assistant messages, with usage example
- **TamboInteractableComponent** — registered interactable component instance (extends `TamboComponent` with `id`, `props`, `isSelected`, `state`, `stateSchema`)
- **ResourceSource** — interface for custom resource sources with `listResources` and `getResource`
- Updated **re-exported types** list with `UseTamboReturn`, `SuggestionListResponse`, `InteractableComponent`, `TamboInteractableContext`, `TamboThreadInputContextProps`

### Already documented (no changes needed)

- `TamboAuthState` — added in #2503
- `TamboComponent` fields (`loadingComponent`, `associatedTools`, `annotations`) — already present
- `TamboTool.title` — already present
- `StreamingState.reasoningStartTime` — already present

### Skipped (documented via hook reference)

- `TamboInteractableContext` — all 12 methods documented in `useTamboInteractable` hook section
- `TamboThreadInputContextProps` — all fields documented in `useTamboThreadInput` hook section

All types verified against SDK source.

Fixes TAM-1236

## Test plan

- [ ] Verify docs site builds without errors
- [ ] Check new TamboConfig section renders correctly
- [ ] Check InitialInputMessage section with example renders correctly
- [ ] Check TamboInteractableComponent section renders correctly
- [ ] Check ResourceSource section renders correctly
- [ ] Verify re-exported types list is complete