### PR TITLE
fix(react-sdk): remove react-dom peer dependency

### DIFF
--- a/react-sdk/AGENTS.md
+++ b/react-sdk/AGENTS.md
@@ -139,7 +139,7 @@ The SDK supports real-time streaming of AI responses:
 
 ### Dependencies
 
-- **Peer Dependencies** - React 18/19, React DOM, TypeScript types
+- **Peer Dependencies** - React 18/19, TypeScript types (no react-dom requirement, enabling React Native support)
 - **Core Dependencies** - Tambo TypeScript SDK, React Query, `@modelcontextprotocol/sdk`
 - **Optional Peer Dependencies**
   - `zod` (`^3.25` or `^4.0`) and `zod-to-json-schema` (`^3.25.0`) for component schemas and JSON Schema generation when using the `@tambo-ai/react/mcp` subpath

--- a/react-sdk/package.json
+++ b/react-sdk/package.json
@@ -63,9 +63,7 @@
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/react": "^18.0.0 || ^19.0.0",
-    "@types/react-dom": "^18.0.0 || ^19.0.0",
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
     "zod": "^3.25.76 || ^4",
     "zod-to-json-schema": "^3.25.1"
   },


### PR DESCRIPTION
## Summary
- Removes `react-dom` and `@types/react-dom` from `peerDependencies` in `@tambo-ai/react`, enabling use in React Native projects
- No source code imports `react-dom`, and no transitive dependencies (`@tanstack/react-query`, `react-media-recorder`) require it as a peer
- Both packages remain in `devDependencies` for `@testing-library/react` in tests

## Test plan
- [x] `npm run check-types -w react-sdk` passes
- [x] `npm run lint -w react-sdk` passes (pre-existing warnings only)
- [x] `npm test -w react-sdk` — all 1005 tests pass
- [ ] Verify a React Native project can install `@tambo-ai/react` without react-dom warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)