### PR TITLE
fix(api): rename detailedSuggestion to description in beta threads DTO

### DIFF
--- a/apps/api/src/threads/dto/suggestion.dto.ts
+++ b/apps/api/src/threads/dto/suggestion.dto.ts
@@ -33,7 +33,7 @@ export class SuggestionDto {
   })
   @IsString()
   @IsNotEmpty()
-  detailedSuggestion!: string;
+  description!: string;
 
   @ApiProperty({
     description: "Additional metadata for the suggestion",

--- a/apps/api/src/threads/util/suggestions.ts
+++ b/apps/api/src/threads/util/suggestions.ts
@@ -8,6 +8,6 @@ export function mapSuggestionToDto(
     id: suggestion.id,
     messageId: suggestion.messageId,
     title: suggestion.title,
-    detailedSuggestion: suggestion.detailedSuggestion,
+    description: suggestion.detailedSuggestion,
   };
 }


### PR DESCRIPTION
## Summary
- Renames `detailedSuggestion` to `description` in the old beta threads `SuggestionDto` so both V1 and beta APIs use the same field name
- Updates `mapSuggestionToDto` to map the DB column `detailedSuggestion` → DTO field `description`
- This aligns the OpenAPI spec so Stainless regenerates the TypeScript SDK with `description`

Fixes TAM-1284

## Context
The V1 API already returns `description`, but the old beta threads DTO still used `detailedSuggestion`. The TypeScript SDK was generated from the beta shape, causing the React SDK to read `suggestion.detailedSuggestion` which is `undefined` on V1 responses — resulting in "Suggestion has no content" when clicking suggestions.

## Follow-up (after SDK regeneration)
Once the SDK is regenerated with `description`, a follow-up PR will update all consumers (React SDK, showcase, web app, ui-registry tests). See TAM-1284 for the full file list.

## Test plan
- [x] `npm run check-types` passes
- [x] All 81 suggestion-related tests pass (`v1-suggestions`, `threads.service`)