### PR TITLE
fix(api): return both description and detailedSuggestion in suggestion responses

### DIFF
--- a/apps/api/src/threads/dto/suggestion.dto.ts
+++ b/apps/api/src/threads/dto/suggestion.dto.ts
@@ -36,6 +36,15 @@ export class SuggestionDto {
   detailedSuggestion!: string;
 
   @ApiProperty({
+    description:
+      "Detailed explanation of the suggestion (alias for detailedSuggestion)",
+    example: "Add try-catch block to handle potential API errors",
+  })
+  @IsString()
+  @IsNotEmpty()
+  description!: string;
+
+  @ApiProperty({
     description: "Additional metadata for the suggestion",
     required: false,
     additionalProperties: { type: "string" },

--- a/apps/api/src/threads/util/suggestions.ts
+++ b/apps/api/src/threads/util/suggestions.ts
@@ -9,5 +9,6 @@ export function mapSuggestionToDto(
     messageId: suggestion.messageId,
     title: suggestion.title,
     detailedSuggestion: suggestion.detailedSuggestion,
+    description: suggestion.detailedSuggestion,
   };
 }

--- a/apps/api/src/v1/__tests__/v1-suggestions.test.ts
+++ b/apps/api/src/v1/__tests__/v1-suggestions.test.ts
@@ -129,7 +129,8 @@ describe("V1Service - Suggestions", () => {
         id: "sug_abc123",
         messageId,
         title: "Test suggestion",
-        description: "This is a test suggestion description", // Note: renamed from detailedSuggestion
+        description: "This is a test suggestion description",
+        detailedSuggestion: "This is a test suggestion description",
         createdAt: "2024-01-15T12:00:00.000Z",
       });
     });

--- a/apps/api/src/v1/dto/suggestion.dto.ts
+++ b/apps/api/src/v1/dto/suggestion.dto.ts
@@ -52,6 +52,17 @@ export class V1SuggestionDto {
   description!: string;
 
   @ApiProperty({
+    description:
+      "Detailed explanation of the suggestion (deprecated, use description)",
+    example:
+      "Add try-catch blocks to handle potential API errors and provide user feedback",
+    deprecated: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  detailedSuggestion!: string;
+
+  @ApiProperty({
     description: "When the suggestion was created (ISO 8601)",
     example: "2024-01-15T12:00:00Z",
   })

--- a/apps/api/src/v1/v1.service.ts
+++ b/apps/api/src/v1/v1.service.ts
@@ -1489,6 +1489,7 @@ export class V1Service {
       messageId: suggestion.messageId,
       title: suggestion.title,
       description: suggestion.detailedSuggestion,
+      detailedSuggestion: suggestion.detailedSuggestion,
       createdAt: suggestion.createdAt.toISOString(),
     };
   }


### PR DESCRIPTION
## Summary
- Both V1 and beta suggestion endpoints now return `description` **and** `detailedSuggestion` with the same value
- Fixes the "Suggestion has no content" bug without breaking pre-v1 SDK consumers

## Context
The V1 API returns `description` but the TypeScript SDK type expects `detailedSuggestion`. The React SDK reads `suggestion.detailedSuggestion` which is `undefined`, causing the error when clicking suggestions. Returning both fields fixes it immediately with no downstream changes needed.

Fixes TAM-1284

## Test plan
- [x] All 81 suggestion-related tests pass
- [x] Type checks pass