### PR TITLE
fix(ci): add node-workspace plugin to fix cross-package releases

### DIFF
--- a/.config/release-please/.release-please-manifest.json
+++ b/.config/release-please/.release-please-manifest.json
@@ -1,1 +1,11 @@
-{"packages/client":"1.0.0","react-sdk":"1.1.0","showcase":"0.37.2","cli":"0.54.0","create-tambo-app":"0.3.0","docs":"1.29.0","apps/web":"0.132.2","apps/api":"0.143.3","packages/react-ui-base":"0.1.0-alpha.8"}
+{
+  "apps/api": "0.143.3",
+  "apps/web": "0.132.2",
+  "cli": "0.54.0",
+  "create-tambo-app": "0.3.0",
+  "docs": "1.29.0",
+  "packages/client": "1.0.0",
+  "packages/react-ui-base": "0.1.0-alpha.8",
+  "react-sdk": "1.1.0",
+  "showcase": "0.37.2"
+}

--- a/.config/release-please/release-please-config.json
+++ b/.config/release-please/release-please-config.json
@@ -33,6 +33,7 @@
     "apps/web": {},
     "apps/api": {}
   },
+  "plugins": [{ "type": "node-workspace" }],
   "changelog-sections": [
     {
       "type": "feat",

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,9 +70,9 @@ jobs:
 
   # NPM Package Publishing - React SDK
   publish-react-sdk:
-    needs: [release-please, publish-client]
+    needs: release-please
     runs-on: ubuntu-latest
-    if: ${{ !failure() && !cancelled() && needs.release-please.outputs.react-sdk--release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.react-sdk--release_created == 'true' }}
     permissions:
       contents: read
       id-token: write # Required for OIDC publishing to NPM

--- a/devdocs/solutions/build-errors/release-please-lockfile-sync.md
+++ b/devdocs/solutions/build-errors/release-please-lockfile-sync.md
@@ -18,6 +18,7 @@ symptoms:
   - Inconsistent lockfile state in repository
   - Version mismatches between package.json and package-lock.json
 date_documented: 2026-01-24
+date_updated: 2026-03-01
 ---
 
 # release-please not updating package-lock.json for interdependencies
@@ -48,25 +49,38 @@ When release-please creates release PRs that bump package versions in a Turborep
 The `release-please-config.json` was missing the `node-workspace` plugin. This plugin is specifically designed to:
 
 1. Build a dependency graph of workspace packages
-2. Propagate version updates to dependent packages
-3. Update `package-lock.json` workspace entries
+2. Propagate version updates to dependent packages' `package.json` files
+3. Update `package-lock.json` workspace entries via `PackageLockJson` updaters
 
-Without it, release-please updates `package.json` files but leaves the lockfile out of sync.
+Without it, release-please only updates the bumped package's own `package.json` — dependents still reference the old (potentially unpublished) version, and the lockfile is left out of sync.
+
+Note: The plugin performs targeted JSON updates to version strings in the lockfile, but does not run a full `npm install` resolution. This means integrity hashes and resolved URLs may not be fully updated. A backup sync workflow is recommended to ensure full lockfile consistency.
 
 ## Solution
 
 ### Step 1: Add node-workspace Plugin
 
-In `release-please-config.json`, add the `node-workspace` plugin with `updatePeerDependencies: true`. Also ensure `always-link-local: true` and `always-update: true` are set.
+In `release-please-config.json`, add the `node-workspace` plugin. Also ensure `always-link-local: true` is set.
+
+```json
+{
+  "always-link-local": true,
+  "plugins": [{ "type": "node-workspace" }]
+}
+```
+
+This ensures that when a workspace dependency is bumped, all packages that depend on it get their `package.json` dependency references updated and receive a patch version bump.
 
 ### Step 2: Add Backup Sync Workflow
 
-Create `.github/workflows/sync-lockfile.yml` that:
+Create `.github/workflows/release-please-sync-lockfile.yml` that:
 
 - Triggers on `pull_request` events (`labeled`, `synchronize`) targeting `main`
 - Only runs on PRs from release-please bot with "autorelease: pending" label
 - Runs `npm install --package-lock-only` to regenerate the lockfile
 - Commits and pushes changes if the lockfile was modified
+
+This acts as a safety net because the plugin's lockfile update is a targeted JSON edit, not a full `npm install` resolution pass.
 
 ### Step 3: Remove CI Workaround
 
@@ -76,7 +90,7 @@ Remove any `frozen: false` workarounds from CI workflows. The setup-tools action
 
 ### Warning Signs
 
-- CI fails on release PRs with `ERESOLVE` errors
+- CI fails on release PRs with `ERESOLVE` or `ETARGET` errors
 - `frozen: false` workarounds appearing in CI config
 - Sync-lockfile workflow making no changes when it should
 - Manual lockfile regeneration becoming necessary
@@ -91,23 +105,23 @@ git diff package-lock.json  # Should show no changes if in sync
 
 ### Configuration Checklist
 
-- [ ] `node-workspace` plugin enabled with `updatePeerDependencies: true`
+- [ ] `node-workspace` plugin enabled in release-please config
 - [ ] `always-link-local: true` set
-- [ ] `always-update: true` set
 - [ ] Backup sync workflow in place
 - [ ] CI uses `npm ci` (no `frozen: false` workarounds)
 
 ## Related Files
 
-- `release-please-config.json` - Main configuration
-- `.release-please-manifest.json` - Version tracking
+- `.config/release-please/release-please-config.json` - Main configuration
+- `.config/release-please/.release-please-manifest.json` - Version tracking
 - `.github/workflows/release-please.yml` - Release workflow
-- `.github/workflows/sync-lockfile.yml` - Backup sync workflow
+- `.github/workflows/release-please-sync-lockfile.yml` - Lockfile sync workflow
 - `.github/actions/setup-tools/action.yml` - CI setup action
 - `RELEASING.md` - Release documentation
 
 ## References
 
-- [release-please issue #1993: Root package-lock.json not updated](https://github.com/googleapis/release-please/issues/1993)
+- [release-please issue #1993: Root package-lock.json not updated](https://github.com/googleapis/release-please/issues/1993) — fixed via PRs #2088 and #2107
+- [release-please issue #1939: v3 lockfile "" package not updated](https://github.com/googleapis/release-please/issues/1939) — fixed via PRs #1940 and #1969
 - [release-please manifest docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md)
 - [node-workspace plugin source](https://github.com/googleapis/release-please/blob/main/src/plugins/node-workspace.ts)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "@tambo-ai/source": "./src/index.ts",
       "import": {
         "types": "./esm/index.d.ts",
         "default": "./esm/index.js"


### PR DESCRIPTION
## Summary

- Add `node-workspace` plugin to release-please config — propagates version bumps to dependent packages (e.g. when `@tambo-ai/client` bumps, `react-sdk`'s dependency reference gets updated automatically)
- Format `.release-please-manifest.json` as multi-line JSON so release-please preserves formatting on future updates (reduces merge conflicts)
- Simplify `publish-react-sdk` workflow job — remove unnecessary `publish-client` dependency since `separate-pull-requests` means they never run in the same workflow
- Update lockfile sync solution doc with verified information and correct file paths
- Fix client package.json export condition naming for dev builds

Fixes #2518 (CI failures on client release PR due to unpublished dependency version)

## Test plan

- [ ] Merge and verify release-please recreates the client release PR with `react-sdk` dependency updated
- [ ] Verify lockfile sync workflow still runs on release PRs
- [ ] Verify react-sdk publish job still triggers correctly on its own release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)