### PR TITLE
chore(skills): mark devdocs skills as internal to hide from public indexing

### DIFF
--- a/devdocs/skills/ai-sdk-model-manager/SKILL.md
+++ b/devdocs/skills/ai-sdk-model-manager/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ai-sdk-model-manager
 description: Manages AI SDK model configurations - updates packages, identifies missing models, adds new models with research, and updates documentation
+metadata:
+  internal: true
 ---
 
 # AI SDK Model Manager

--- a/devdocs/skills/compound-components/SKILL.md
+++ b/devdocs/skills/compound-components/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: building-compound-components
 description: Creates unstyled compound components that separate business logic from styles. Use when building headless UI primitives, creating component libraries, implementing Radix-style namespaced components, or when the user mentions "compound components", "headless", "unstyled", "primitives", or "render props".
+metadata:
+  internal: true
 ---
 
 # Building Compound Components

--- a/devdocs/skills/creating-styled-wrappers/SKILL.md
+++ b/devdocs/skills/creating-styled-wrappers/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: creating-styled-wrappers
 description: Creates styled wrapper components that compose headless/base compound components. Use when refactoring styled components to use base primitives, implementing opinionated design systems on top of headless components, or when the user mentions "use base components", "compose primitives", "styled wrapper", or "refactor to use base".
+metadata:
+  internal: true
 ---
 
 # Styling Compound Wrappers


### PR DESCRIPTION
## Summary
- Add `metadata.internal: true` to 3 internal dev-only skills in `devdocs/skills/` (`ai-sdk-model-manager`, `compound-components`, `creating-styled-wrappers`)

## Why
The skills CLI's recursive scanner picks up these internal SKILL.md files and indexes them publicly on skills.sh, confusing users who try to install them (#2566). Marking them as internal hides them from public discovery per the [skills CLI spec](https://github.com/vercel-labs/skills).

## Test Plan
- Verify the 3 SKILL.md files have `metadata.internal: true` in frontmatter
- After skills.sh re-indexes, confirm these no longer appear in the public listing

Fixes #2566