### PR TITLE
fix(react-ui-base): add tabIndex handling to StopButton when keepMounted

### DIFF
--- a/packages/react-ui-base/src/message-input/message-input-stop-button.tsx
+++ b/packages/react-ui-base/src/message-input/message-input-stop-button.tsx
@@ -53,6 +53,7 @@ export const MessageInputStopButton = React.forwardRef<
       disabled,
       tabIndex: effectiveTabIndex,
       onClick,
+      tabIndex: effectiveTabIndex,
       "aria-hidden": hidden ? "true" : undefined,
     }),
   });


### PR DESCRIPTION
Follow-up to #2582.

`MessageInput.SubmitButton` sets `tabIndex={-1}` when hidden so keyboard navigation skips it while it's not visible. `StopButton` was missing the same handling.

This adds the identical pattern from `SubmitButton`:

```ts
const effectiveTabIndex = hidden ? -1 : propTabIndex;
```

And passes it through to `mergeProps`. When `keepMounted` is true and the button is hidden, it will no longer be reachable via Tab.