### PR TITLE
feat(react-ui-base): add GenerationStage headless primitive

### DIFF
--- a/packages/react-ui-base/package.json
+++ b/packages/react-ui-base/package.json
@@ -139,6 +139,17 @@
         "default": "./dist/cjs/mcp-resources/index.cjs"
       }
     },
+    "./generation-stage": {
+      "@tambo-ai/source": "./src/generation-stage/index.tsx",
+      "import": {
+        "types": "./dist/esm/generation-stage/index.d.ts",
+        "default": "./dist/esm/generation-stage/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/generation-stage/index.d.ts",
+        "default": "./dist/cjs/generation-stage/index.cjs"
+      }
+    },
     "./types": {
       "@tambo-ai/source": "./src/types/component-render-or-children.ts",
       "import": {

--- a/packages/react-ui-base/src/generation-stage/generation-stage-content.tsx
+++ b/packages/react-ui-base/src/generation-stage/generation-stage-content.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRender } from "@base-ui/react/use-render";
+import * as React from "react";
+import { useGenerationStageContext } from "./generation-stage-context";
+
+export interface GenerationStageContentState extends Record<string, unknown> {
+  slot: string;
+  isIdle: boolean;
+}
+
+type GenerationStageContentComponentProps = useRender.ComponentProps<
+  "div",
+  GenerationStageContentState
+>;
+
+export interface GenerationStageContentProps extends GenerationStageContentComponentProps {
+  /** Keeps the node mounted and toggles `data-hidden` when idle. */
+  keepMounted?: boolean;
+}
+
+/**
+ * Container that renders its children only when the thread is not idle
+ * (i.e., when waiting or streaming).
+ * Use `keepMounted` to keep the node in the DOM and toggle `data-hidden` instead.
+ */
+export const GenerationStageContent = React.forwardRef<
+  HTMLDivElement,
+  GenerationStageContentProps
+>((props, ref) => {
+  const { isIdle } = useGenerationStageContext();
+  const { render, keepMounted, ...componentProps } = props;
+
+  const state: GenerationStageContentState = {
+    slot: "generation-stage-content",
+    isIdle,
+  };
+
+  if (isIdle && !keepMounted) {
+    return null;
+  }
+
+  return useRender({
+    defaultTagName: "div",
+    ref,
+    render,
+    state,
+    props: {
+      ...componentProps,
+      "data-hidden": isIdle || undefined,
+      "aria-hidden": isIdle || undefined,
+    },
+  });
+});
+GenerationStageContent.displayName = "GenerationStage.Content";

--- a/packages/react-ui-base/src/generation-stage/generation-stage-context.tsx
+++ b/packages/react-ui-base/src/generation-stage/generation-stage-context.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+
+export interface GenerationStageContextValue {
+  isStreaming: boolean;
+  isWaiting: boolean;
+  isIdle: boolean;
+}
+
+export const GenerationStageContext =
+  React.createContext<GenerationStageContextValue | null>(null);
+
+/**
+ * Hook to access the generation stage context.
+ * @internal This hook is for internal use by base components only.
+ * Consumers should use component `render` props instead.
+ * @returns The generation stage context value
+ * @throws Error if used outside of GenerationStage.Root
+ */
+export function useGenerationStageContext(): GenerationStageContextValue {
+  const context = React.useContext(GenerationStageContext);
+  if (!context) {
+    throw new Error(
+      "React UI Base: GenerationStageContext is missing. GenerationStage parts must be used within <GenerationStage.Root>",
+    );
+  }
+  return context;
+}

--- a/packages/react-ui-base/src/generation-stage/generation-stage-root.tsx
+++ b/packages/react-ui-base/src/generation-stage/generation-stage-root.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useRender } from "@base-ui/react/use-render";
+import { useTambo } from "@tambo-ai/react";
+import * as React from "react";
+import { GenerationStageContext } from "./generation-stage-context";
+
+export interface GenerationStageRootState extends Record<string, unknown> {
+  slot: string;
+  isStreaming: boolean;
+  isWaiting: boolean;
+  isIdle: boolean;
+}
+
+type GenerationStageRootComponentProps = useRender.ComponentProps<
+  "div",
+  GenerationStageRootState
+>;
+
+export type GenerationStageRootProps = GenerationStageRootComponentProps;
+
+/**
+ * Root component for generation stage.
+ * Derives streaming state from Tambo hooks and provides it to children via context.
+ */
+export const GenerationStageRoot = React.forwardRef<
+  HTMLDivElement,
+  GenerationStageRootProps
+>((props, ref) => {
+  const { isStreaming, isWaiting, isIdle } = useTambo();
+
+  const contextValue = React.useMemo(
+    () => ({
+      isStreaming,
+      isWaiting,
+      isIdle,
+    }),
+    [isStreaming, isWaiting, isIdle],
+  );
+
+  const { render, ...componentProps } = props;
+  const state: GenerationStageRootState = {
+    slot: "generation-stage",
+    isStreaming,
+    isWaiting,
+    isIdle,
+  };
+
+  const element = useRender({
+    defaultTagName: "div",
+    ref,
+    render,
+    state,
+    props: componentProps,
+  });
+
+  return (
+    <GenerationStageContext.Provider value={contextValue}>
+      {element}
+    </GenerationStageContext.Provider>
+  );
+});
+GenerationStageRoot.displayName = "GenerationStage.Root";

--- a/packages/react-ui-base/src/generation-stage/generation-stage-streaming.tsx
+++ b/packages/react-ui-base/src/generation-stage/generation-stage-streaming.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRender } from "@base-ui/react/use-render";
+import * as React from "react";
+import { useGenerationStageContext } from "./generation-stage-context";
+
+export interface GenerationStageStreamingState extends Record<string, unknown> {
+  slot: string;
+  isStreaming: boolean;
+}
+
+type GenerationStageStreamingComponentProps = useRender.ComponentProps<
+  "div",
+  GenerationStageStreamingState
+>;
+
+export interface GenerationStageStreamingProps extends GenerationStageStreamingComponentProps {
+  /** Keeps the node mounted and toggles `data-hidden` when not streaming. */
+  keepMounted?: boolean;
+}
+
+/**
+ * Renders its children only when the thread is actively streaming a response.
+ * Use `keepMounted` to keep the node in the DOM and toggle `data-hidden` instead.
+ */
+export const GenerationStageStreaming = React.forwardRef<
+  HTMLDivElement,
+  GenerationStageStreamingProps
+>((props, ref) => {
+  const { isStreaming } = useGenerationStageContext();
+  const { render, keepMounted, children, ...componentProps } = props;
+
+  const state: GenerationStageStreamingState = {
+    slot: "generation-stage-streaming",
+    isStreaming,
+  };
+
+  if (!isStreaming && !keepMounted) {
+    return null;
+  }
+
+  return useRender({
+    defaultTagName: "div",
+    ref,
+    render,
+    state,
+    props: {
+      ...componentProps,
+      children: children ?? "Generating response",
+      "data-hidden": !isStreaming || undefined,
+      "aria-hidden": !isStreaming || undefined,
+    },
+  });
+});
+GenerationStageStreaming.displayName = "GenerationStage.Streaming";

--- a/packages/react-ui-base/src/generation-stage/generation-stage-waiting.tsx
+++ b/packages/react-ui-base/src/generation-stage/generation-stage-waiting.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useRender } from "@base-ui/react/use-render";
+import * as React from "react";
+import { useGenerationStageContext } from "./generation-stage-context";
+
+export interface GenerationStageWaitingState extends Record<string, unknown> {
+  slot: string;
+  isWaiting: boolean;
+}
+
+type GenerationStageWaitingComponentProps = useRender.ComponentProps<
+  "div",
+  GenerationStageWaitingState
+>;
+
+export interface GenerationStageWaitingProps extends GenerationStageWaitingComponentProps {
+  /** Keeps the node mounted and toggles `data-hidden` when not waiting. */
+  keepMounted?: boolean;
+}
+
+/**
+ * Renders its children only when the thread is in the waiting state
+ * (preparing a response, before streaming begins).
+ * Use `keepMounted` to keep the node in the DOM and toggle `data-hidden` instead.
+ */
+export const GenerationStageWaiting = React.forwardRef<
+  HTMLDivElement,
+  GenerationStageWaitingProps
+>((props, ref) => {
+  const { isWaiting } = useGenerationStageContext();
+  const { render, keepMounted, children, ...componentProps } = props;
+
+  const state: GenerationStageWaitingState = {
+    slot: "generation-stage-waiting",
+    isWaiting,
+  };
+
+  if (!isWaiting && !keepMounted) {
+    return null;
+  }
+
+  return useRender({
+    defaultTagName: "div",
+    ref,
+    render,
+    state,
+    props: {
+      ...componentProps,
+      children: children ?? "Preparing response",
+      "data-hidden": !isWaiting || undefined,
+      "aria-hidden": !isWaiting || undefined,
+    },
+  });
+});
+GenerationStageWaiting.displayName = "GenerationStage.Waiting";

--- a/packages/react-ui-base/src/generation-stage/generation-stage.test.tsx
+++ b/packages/react-ui-base/src/generation-stage/generation-stage.test.tsx
@@ -1,0 +1,287 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { useTambo } from "@tambo-ai/react";
+import { render, screen } from "@testing-library/react";
+import { GenerationStage } from "./index";
+
+describe("GenerationStage", () => {
+  const mockUseTambo = jest.mocked(useTambo);
+
+  beforeEach(() => {
+    mockUseTambo.mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      isWaiting: false,
+      isIdle: true,
+      currentThreadId: "thread-1",
+      switchThread: jest.fn(),
+      startNewThread: jest.fn().mockReturnValue("new-thread-id"),
+    } as never);
+  });
+
+  it("renders Root with data-slot attribute", () => {
+    const { container } = render(
+      <GenerationStage.Root>
+        <span>child</span>
+      </GenerationStage.Root>,
+    );
+
+    expect(
+      container.querySelector('[data-slot="generation-stage"]'),
+    ).toBeTruthy();
+  });
+
+  it("throws when parts are used outside Root", () => {
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<GenerationStage.Content />)).toThrow(
+      "GenerationStageContext is missing",
+    );
+    spy.mockRestore();
+  });
+
+  describe("Content", () => {
+    it("renders when not idle (waiting)", () => {
+      mockUseTambo.mockReturnValue({
+        isStreaming: false,
+        isWaiting: true,
+        isIdle: false,
+      } as never);
+
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Content>
+            <span>active</span>
+          </GenerationStage.Content>
+        </GenerationStage.Root>,
+      );
+
+      expect(
+        container.querySelector('[data-slot="generation-stage-content"]'),
+      ).toBeTruthy();
+    });
+
+    it("renders when not idle (streaming)", () => {
+      mockUseTambo.mockReturnValue({
+        isStreaming: true,
+        isWaiting: false,
+        isIdle: false,
+      } as never);
+
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Content>
+            <span>active</span>
+          </GenerationStage.Content>
+        </GenerationStage.Root>,
+      );
+
+      expect(
+        container.querySelector('[data-slot="generation-stage-content"]'),
+      ).toBeTruthy();
+    });
+
+    it("unmounts when idle", () => {
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Content>
+            <span>active</span>
+          </GenerationStage.Content>
+        </GenerationStage.Root>,
+      );
+
+      expect(
+        container.querySelector('[data-slot="generation-stage-content"]'),
+      ).toBeNull();
+    });
+
+    it("keeps mounted with keepMounted and sets data-hidden and aria-hidden when idle", () => {
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Content keepMounted>
+            <span>active</span>
+          </GenerationStage.Content>
+        </GenerationStage.Root>,
+      );
+
+      const el = container.querySelector(
+        '[data-slot="generation-stage-content"]',
+      );
+      expect(el).toBeTruthy();
+      expect(el?.hasAttribute("data-hidden")).toBe(true);
+      expect(el?.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  describe("Waiting", () => {
+    it("renders default text when no children provided", () => {
+      mockUseTambo.mockReturnValue({
+        isStreaming: false,
+        isWaiting: true,
+        isIdle: false,
+      } as never);
+
+      render(
+        <GenerationStage.Root>
+          <GenerationStage.Waiting />
+        </GenerationStage.Root>,
+      );
+
+      expect(screen.getByText("Preparing response")).toBeTruthy();
+    });
+
+    it("renders when waiting", () => {
+      mockUseTambo.mockReturnValue({
+        isStreaming: false,
+        isWaiting: true,
+        isIdle: false,
+      } as never);
+
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Waiting>
+            <span>Preparing response</span>
+          </GenerationStage.Waiting>
+        </GenerationStage.Root>,
+      );
+
+      expect(
+        container.querySelector('[data-slot="generation-stage-waiting"]'),
+      ).toBeTruthy();
+    });
+
+    it("unmounts when not waiting", () => {
+      mockUseTambo.mockReturnValue({
+        isStreaming: true,
+        isWaiting: false,
+        isIdle: false,
+      } as never);
+
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Waiting>
+            <span>Preparing response</span>
+          </GenerationStage.Waiting>
+        </GenerationStage.Root>,
+      );
+
+      expect(
+        container.querySelector('[data-slot="generation-stage-waiting"]'),
+      ).toBeNull();
+    });
+
+    it("keeps mounted with keepMounted and sets data-hidden and aria-hidden", () => {
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Waiting keepMounted>
+            <span>Preparing response</span>
+          </GenerationStage.Waiting>
+        </GenerationStage.Root>,
+      );
+
+      const el = container.querySelector(
+        '[data-slot="generation-stage-waiting"]',
+      );
+      expect(el).toBeTruthy();
+      expect(el?.hasAttribute("data-hidden")).toBe(true);
+      expect(el?.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  describe("Streaming", () => {
+    it("renders default text when no children provided", () => {
+      mockUseTambo.mockReturnValue({
+        isStreaming: true,
+        isWaiting: false,
+        isIdle: false,
+      } as never);
+
+      render(
+        <GenerationStage.Root>
+          <GenerationStage.Streaming />
+        </GenerationStage.Root>,
+      );
+
+      expect(screen.getByText("Generating response")).toBeTruthy();
+    });
+
+    it("renders when streaming", () => {
+      mockUseTambo.mockReturnValue({
+        isStreaming: true,
+        isWaiting: false,
+        isIdle: false,
+      } as never);
+
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Streaming>
+            <span>Generating response</span>
+          </GenerationStage.Streaming>
+        </GenerationStage.Root>,
+      );
+
+      expect(
+        container.querySelector('[data-slot="generation-stage-streaming"]'),
+      ).toBeTruthy();
+    });
+
+    it("unmounts when not streaming", () => {
+      mockUseTambo.mockReturnValue({
+        isStreaming: false,
+        isWaiting: true,
+        isIdle: false,
+      } as never);
+
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Streaming>
+            <span>Generating response</span>
+          </GenerationStage.Streaming>
+        </GenerationStage.Root>,
+      );
+
+      expect(
+        container.querySelector('[data-slot="generation-stage-streaming"]'),
+      ).toBeNull();
+    });
+
+    it("keeps mounted with keepMounted and sets data-hidden and aria-hidden", () => {
+      const { container } = render(
+        <GenerationStage.Root>
+          <GenerationStage.Streaming keepMounted>
+            <span>Generating response</span>
+          </GenerationStage.Streaming>
+        </GenerationStage.Root>,
+      );
+
+      const el = container.querySelector(
+        '[data-slot="generation-stage-streaming"]',
+      );
+      expect(el).toBeTruthy();
+      expect(el?.hasAttribute("data-hidden")).toBe(true);
+      expect(el?.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  it("exposes state via Root render prop", () => {
+    mockUseTambo.mockReturnValue({
+      isStreaming: true,
+      isWaiting: false,
+      isIdle: false,
+    } as never);
+
+    let capturedState:
+      | { isStreaming: boolean; isWaiting: boolean; isIdle: boolean }
+      | undefined;
+    render(
+      <GenerationStage.Root
+        render={(props, state) => {
+          capturedState = state;
+          return <div {...props} />;
+        }}
+      />,
+    );
+
+    expect(capturedState?.isStreaming).toBe(true);
+    expect(capturedState?.isWaiting).toBe(false);
+    expect(capturedState?.isIdle).toBe(false);
+  });
+});

--- a/packages/react-ui-base/src/generation-stage/index.tsx
+++ b/packages/react-ui-base/src/generation-stage/index.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { GenerationStageContent } from "./generation-stage-content";
+import { GenerationStageRoot } from "./generation-stage-root";
+import { GenerationStageStreaming } from "./generation-stage-streaming";
+import { GenerationStageWaiting } from "./generation-stage-waiting";
+
+/**
+ * GenerationStage namespace containing all generation stage base components.
+ */
+const GenerationStage = {
+  Root: GenerationStageRoot,
+  Content: GenerationStageContent,
+  Waiting: GenerationStageWaiting,
+  Streaming: GenerationStageStreaming,
+};
+
+export type { GenerationStageContextValue } from "./generation-stage-context";
+export { useGenerationStageContext } from "./generation-stage-context";
+export type {
+  GenerationStageRootProps,
+  GenerationStageRootState,
+} from "./generation-stage-root";
+export type {
+  GenerationStageContentProps,
+  GenerationStageContentState,
+} from "./generation-stage-content";
+export type {
+  GenerationStageWaitingProps,
+  GenerationStageWaitingState,
+} from "./generation-stage-waiting";
+export type {
+  GenerationStageStreamingProps,
+  GenerationStageStreamingState,
+} from "./generation-stage-streaming";
+
+export type { useRender } from "@base-ui/react/use-render";
+
+export { GenerationStage };


### PR DESCRIPTION
## Summary

- Adds `GenerationStage` compound component to `@tambo-ai/react-ui-base`
- Reads thread generation state from `useTambo()` and provides context-driven visibility for waiting and streaming indicators
- Follows the same `useRender` + render props pattern as other base primitives

### Subcomponents

- **Root** — derives `isStreaming`, `isWaiting`, `isIdle` from `useTambo()` and provides via context
- **Content** — visible when not idle, supports `keepMounted` for CSS transitions
- **Waiting** — visible during waiting state, default children "Preparing response"
- **Streaming** — visible during streaming state, default children "Generating response"

### Features

- `keepMounted` prop on Content/Waiting/Streaming toggles `data-hidden`/`aria-hidden` instead of unmounting
- Render props expose state for custom rendering
- `data-slot` attributes for styling hooks

## Test plan

- [x] Unit tests added (287 lines covering all subcomponents and state transitions)
- [x] Verify integration with `useTambo()` thread state

🤖 Generated with [Claude Code](https://claude.com/claude-code)