### PR TITLE
feat(react-ui-base): export GenerationStage from package barrel

### DIFF
--- a/packages/react-ui-base/src/index.ts
+++ b/packages/react-ui-base/src/index.ts
@@ -6,6 +6,20 @@
  * allowing consumers to apply their own design system.
  */
 
+// GenerationStage components
+export { GenerationStage } from "./generation-stage";
+export type {
+  GenerationStageContentProps,
+  GenerationStageContentState,
+  GenerationStageContextValue,
+  GenerationStageRootProps,
+  GenerationStageRootState,
+  GenerationStageStreamingProps,
+  GenerationStageStreamingState,
+  GenerationStageWaitingProps,
+  GenerationStageWaitingState,
+} from "./generation-stage";
+
 // Elicitation components
 export { Elicitation } from "./elicitation";
 export type {


### PR DESCRIPTION
## Summary

- Exports `GenerationStage` component and all associated types from `@tambo-ai/react-ui-base` package barrel (`src/index.ts`)
- The component was added in #2585 but not exported from the package entry point

### Exported

- `GenerationStage` (component namespace with Root, Content, Waiting, Streaming)
- All prop and state types: `GenerationStageRootProps`, `GenerationStageContentProps`, `GenerationStageWaitingProps`, `GenerationStageStreamingProps`, `GenerationStageContextValue`, and corresponding state types

## Test plan

- [x] `npm run check-types` passes
- [ ] Verify `import { GenerationStage } from "@tambo-ai/react-ui-base"` works in consuming packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)