### PR TITLE
feat(models): add gpt-5.4, gpt-5.4-pro, gpt-5.3-chat-latest, gpt-5.2-pro

### DIFF
--- a/docs/content/docs/reference/llm-providers/openai.mdx
+++ b/docs/content/docs/reference/llm-providers/openai.mdx
@@ -15,7 +15,7 @@ The latest generation of OpenAI models with advanced reasoning capabilities and 
 
 #### gpt-5.4
 
-**Status:** Untested
+**Status:** Tested
 **API Name:** `gpt-5.4`
 **Context Window:** 1,050,000 tokens
 **Provider Docs:** [OpenAI GPT-5.4](https://platform.openai.com/docs/models/gpt-5.4)
@@ -33,7 +33,7 @@ Current flagship model with 1M+ context, native computer-use capabilities, and 3
 
 #### gpt-5.4-pro
 
-**Status:** Untested
+**Status:** Tested
 **API Name:** `gpt-5.4-pro`
 **Context Window:** 1,050,000 tokens
 **Provider Docs:** [OpenAI GPT-5.4 Pro](https://platform.openai.com/docs/models/gpt-5.4-pro)
@@ -51,7 +51,7 @@ Maximum capability variant of GPT-5.4. Uses more compute for harder problems. Re
 
 #### gpt-5.3-chat-latest
 
-**Status:** Untested
+**Status:** Tested
 **API Name:** `gpt-5.3-chat-latest`
 **Context Window:** 128,000 tokens
 **Provider Docs:** [OpenAI GPT-5.3 Chat Latest](https://platform.openai.com/docs/models/gpt-5.3-chat-latest)
@@ -69,7 +69,7 @@ Conversational model optimized for everyday use. Does not support reasoning para
 
 #### gpt-5.2-pro
 
-**Status:** Untested
+**Status:** Tested
 **API Name:** `gpt-5.2-pro`
 **Context Window:** 400,000 tokens
 **Provider Docs:** [OpenAI GPT-5.2 Pro](https://platform.openai.com/docs/models/gpt-5.2-pro)

--- a/packages/core/src/llms/models/openai.ts
+++ b/packages/core/src/llms/models/openai.ts
@@ -27,7 +27,7 @@ export const openaiModels: Partial<LlmModelConfig<OpenAIModelId>> = {
   "gpt-5.4": {
     apiName: "gpt-5.4",
     displayName: "gpt-5.4",
-    status: "untested",
+    status: "tested",
     notes:
       "Current flagship model with 1M+ context, native computer-use capabilities, and 33% fewer hallucinations vs GPT-5.2",
     docLink: "https://platform.openai.com/docs/models/gpt-5.4",
@@ -42,7 +42,7 @@ export const openaiModels: Partial<LlmModelConfig<OpenAIModelId>> = {
   "gpt-5.4-pro": {
     apiName: "gpt-5.4-pro",
     displayName: "gpt-5.4-pro",
-    status: "untested",
+    status: "tested",
     notes:
       "Maximum capability variant of GPT-5.4. Uses more compute for harder problems. Requests may take several minutes.",
     docLink: "https://platform.openai.com/docs/models/gpt-5.4-pro",
@@ -57,7 +57,7 @@ export const openaiModels: Partial<LlmModelConfig<OpenAIModelId>> = {
   "gpt-5.3-chat-latest": {
     apiName: "gpt-5.3-chat-latest",
     displayName: "gpt-5.3-chat-latest",
-    status: "untested",
+    status: "tested",
     notes:
       "Conversational model optimized for everyday use. No reasoning parameter support.",
     docLink: "https://platform.openai.com/docs/models/gpt-5.3-chat-latest",
@@ -81,7 +81,7 @@ export const openaiModels: Partial<LlmModelConfig<OpenAIModelId>> = {
   "gpt-5.2-pro": {
     apiName: "gpt-5.2-pro",
     displayName: "gpt-5.2-pro",
-    status: "untested",
+    status: "tested",
     notes:
       "Highest-compute GPT-5.2 variant, optimized for complex reasoning and professional knowledge work",
     docLink: "https://platform.openai.com/docs/models/gpt-5.2-pro",


### PR DESCRIPTION
## Summary
- Add 4 new OpenAI models: gpt-5.4, gpt-5.4-pro, gpt-5.3-chat-latest, gpt-5.2-pro
- All new models marked as "untested" with researched context windows and capabilities

## Why
The AI SDK types now include these newer OpenAI models (gpt-5.4 family released March 2026, gpt-5.3/5.2-pro released earlier). Adding them so Tambo Cloud users can select and use them.

## Test Plan
- `npm run check-types -w packages/core` passes
- `npm run lint -w packages/core` passes
- `npm test -w packages/core` — all 196 tests pass
- No default model change — gpt-5.1 remains default