### PR TITLE
fix(api): flush Sentry spans during long-running SSE streams

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { LoggerModule } from "./common/logger.module";
 import { DATABASE, DatabaseProvider } from "./common/database-provider";
 import { RequestLoggerMiddleware } from "./common/middleware/request-logger.middleware";
 import { SdkVersionMiddleware } from "./common/middleware/sdk-version.middleware";
+import { SentryFlushMiddleware } from "./common/middleware/sentry-flush.middleware";
 import { AuthService } from "./common/services/auth.service";
 import { EmailService } from "./common/services/email.service";
 import { StorageConfigService } from "./common/services/storage-config.service";
@@ -63,7 +64,11 @@ export class AppModule implements OnModuleInit {
 
   configure(consumer: MiddlewareConsumer) {
     consumer
-      .apply(RequestLoggerMiddleware, SdkVersionMiddleware)
+      .apply(
+        RequestLoggerMiddleware,
+        SdkVersionMiddleware,
+        SentryFlushMiddleware,
+      )
       .forRoutes("*");
   }
 }

--- a/apps/api/src/common/middleware/sentry-flush.middleware.ts
+++ b/apps/api/src/common/middleware/sentry-flush.middleware.ts
@@ -1,0 +1,61 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import * as Sentry from "@sentry/nestjs";
+import { NextFunction, Request, Response } from "express";
+
+/**
+ * Flush Sentry spans/events periodically during long-running responses (e.g. SSE streams).
+ *
+ * Without this, an infrastructure timeout (e.g. a 15-minute load balancer limit) can kill
+ * the connection before Sentry's internal buffer is drained, causing in-flight spans to be
+ * silently lost. This middleware starts a periodic flush once it detects that an SSE stream
+ * has been open for longer than FLUSH_DELAY_MS, and also flushes on abnormal connection close.
+ */
+
+/** Wait this long before starting periodic flushes (skip short-lived requests). */
+const FLUSH_DELAY_MS = 10_000;
+
+/** Flush every this many milliseconds once streaming has started. */
+const FLUSH_INTERVAL_MS = 30_000;
+
+/** Max time to wait for a flush to complete (non-blocking, fire-and-forget). */
+const FLUSH_TIMEOUT_MS = 2_000;
+
+@Injectable()
+export class SentryFlushMiddleware implements NestMiddleware {
+  use(_request: Request, response: Response, next: NextFunction): void {
+    let flushTimer: ReturnType<typeof setInterval> | undefined;
+    let delayTimer: ReturnType<typeof setTimeout> | undefined;
+
+    // Start periodic flushing after the initial delay so we don't add overhead
+    // to quick request/response cycles.
+    delayTimer = setTimeout(() => {
+      flushTimer = setInterval(
+        () => void Sentry.flush(FLUSH_TIMEOUT_MS),
+        FLUSH_INTERVAL_MS,
+      );
+    }, FLUSH_DELAY_MS);
+
+    const cleanup = () => {
+      if (delayTimer) {
+        clearTimeout(delayTimer);
+        delayTimer = undefined;
+      }
+      if (flushTimer) {
+        clearInterval(flushTimer);
+        flushTimer = undefined;
+      }
+    };
+
+    // "finish" fires when the response is done writing (normal completion).
+    response.on("finish", cleanup);
+
+    // "close" fires when the underlying connection is terminated — possibly by
+    // an infrastructure timeout before finish. Flush remaining spans.
+    response.on("close", () => {
+      cleanup();
+      void Sentry.flush(FLUSH_TIMEOUT_MS);
+    });
+
+    next();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds global `SentryFlushMiddleware` that periodically flushes Sentry events during long-running responses
- When an infrastructure timeout (e.g. 15-min load balancer limit) kills an SSE connection, in-flight Sentry spans were silently lost — this was observed in production traces for `POST /v1/threads/:threadId/runs` where ~900s traces had zero custom spans
- The middleware starts periodic flushing (every 30s) after a response has been open for 10s, and does a final flush on abnormal connection close
- Zero overhead for short-lived requests — flush timer only activates after the 10s delay
- Applied globally via NestJS middleware so all current and future SSE endpoints are covered

## Context

Investigation of Sentry issue TAMBO-CLOUD-30 (`AI_NoOutputGeneratedError`) revealed that traces hitting ~900s (infrastructure timeout) were missing all custom spans (`v1.executeRun`, `threads.advance`, `stream.generate`, etc.), while traces that completed normally had full span trees. The timeout kills the connection before Sentry's internal buffer drains.

## Test plan

- [x] All 733 API tests pass (45 suites)
- [x] Lint and type checks pass (pre-existing core type error unrelated)
- [ ] Deploy and verify that long-running traces now retain custom spans even when timed out
- [ ] Confirm no measurable performance impact on short-lived API requests


🤖 Generated with [Claude Code](https://claude.com/claude-code)