### PR TITLE
refactor(web): split settings into Agent and Settings tabs

### DIFF
--- a/.claude/skills/building-settings-ui/SKILL.md
+++ b/.claude/skills/building-settings-ui/SKILL.md
@@ -2,11 +2,11 @@
 name: building-settings-ui
 description: >-
   Use this skill when adding or modifying settings UI in Tambo Cloud. Covers where a new settings
-  section belongs (project vs agent category, route structure, sidebar registration) and the
-  component patterns used across settings (card layout, toasts, confirmation dialogs, destructive
-  styling, save behavior conventions). Triggers on "add a new settings section", "where should X
-  go?", "settings UI", "settings page", or any work touching
-  apps/web/components/dashboard-components/project-details/ or project-settings.tsx.
+  section belongs (Agent tab vs Settings tab), and the component patterns used across both pages
+  (card layout, toasts, confirmation dialogs, destructive styling, save behavior conventions).
+  Triggers on "add a new settings section", "where should X go?", "settings UI", "settings page",
+  "agent page", or any work touching apps/web/components/dashboard-components/project-details/,
+  project-settings.tsx, or agent-settings.tsx.
   Not for full-stack feature building (DB, tRPC, tests); those patterns will get their own skills.
 metadata:
   internal: true
@@ -14,55 +14,78 @@ metadata:
 
 # Building Settings UI
 
-Guide for placing and styling settings sections in the Tambo Cloud dashboard. Covers two concerns: where a feature belongs in the navigation, and how to build the UI component to match existing patterns.
+Guide for placing and styling settings sections in the Tambo Cloud dashboard. Covers two concerns: where a feature belongs (which tab/page), and how to build the UI component to match existing patterns.
+
+## Architecture
+
+Settings are split across two top-level tabs in the project layout:
+
+- **Agent tab** (`/[projectId]/agent`) - How the AI agent behaves
+- **Settings tab** (`/[projectId]/settings`) - Project infrastructure and access
+
+Each tab renders a flat vertical stack of Card components. There is no sidebar navigation; each page is short enough to scroll naturally.
+
+### Tab layout
+
+```
+Overview | Observability | Agent | Settings
+```
+
+- Layout file: `apps/web/app/(authed)/(dashboard)/[projectId]/layout.tsx`
+- Agent page: `apps/web/app/(authed)/(dashboard)/[projectId]/agent/page.tsx`
+- Settings page: `apps/web/app/(authed)/(dashboard)/[projectId]/settings/page.tsx`
 
 ## Gotchas
 
-1. **Settings subsections are scroll targets, NOT routes**. Do not create a new route under `settings/`. All sections render within `settings/page.tsx`.
-2. **Agent and Project sections are grouped**. Do not interleave. Check the current order table before placing a new section.
-3. **Do not add a new top-level tab** without explicit team alignment. Current tabs (Overview, Observability, Settings) have been stable.
-4. **Settings page sidebar nav must be updated in TWO places**: the desktop sidebar and the mobile dropdown menu. Missing one creates a broken nav on that viewport.
-5. **`EditWithTamboButton` goes inside `CardTitle`**, not as a sibling of `CardHeader`. It must have a `description` prop explaining what the section configures.
-6. **Invalidate the query before toasting** in `onSuccess`. Reversing the order can show a success toast while the UI still displays old data.
-7. **Use `DeleteConfirmationDialog`**, never inline `AlertDialog` for destructive confirmations.
-8. **Use `text-destructive` semantic color**, never `text-red-500`. Cancel/discard buttons are NOT destructive.
+1. **Do not add a new top-level tab** without explicit team alignment. Current tabs (Overview, Observability, Agent, Settings) have been stable.
+2. **`EditWithTamboButton` goes inside `CardTitle`**, not as a sibling of `CardHeader`. It must have a `description` prop explaining what the section configures.
+3. **Invalidate the query before toasting** in `onSuccess`. Reversing the order can show a success toast while the UI still displays old data.
+4. **Use `DeleteConfirmationDialog`**, never inline `AlertDialog` for destructive confirmations.
+5. **Use `text-destructive` semantic color**, never `text-red-500`. Cancel/discard buttons are NOT destructive.
 
 ---
 
 ## Feature Placement
 
-### Settings Sections (current order)
+### Agent Tab Sections
 
-| #   | Section             | Category | Component                                        |
-| --- | ------------------- | -------- | ------------------------------------------------ |
-| 1   | API Keys            | Project  | `project-details/api-key-list.tsx`               |
-| 2   | LLM Providers       | Agent    | `project-details/provider-key-section.tsx`       |
-| 3   | Custom Instructions | Agent    | `project-details/custom-instructions-editor.tsx` |
-| 4   | Skills              | Agent    | `project-details/skills-section.tsx`             |
-| 5   | MCP Servers         | Agent    | `project-details/available-mcp-servers.tsx`      |
-| 6   | Tool Call Limit     | Agent    | `project-details/tool-call-limit-editor.tsx`     |
-| 7   | User Authentication | Project  | `project-details/oauth-settings.tsx`             |
+| #   | Section             | What it configures                                 | Component                        |
+| --- | ------------------- | -------------------------------------------------- | -------------------------------- |
+| 1   | Model               | Provider + model selection, API key, custom params | `provider-key-section.tsx`       |
+| 2   | Custom Instructions | System prompt, prompt override toggle              | `custom-instructions-editor.tsx` |
+| 3   | Skills              | Skill definitions and imports                      | `skills-section.tsx`             |
+| 4   | Tool Call Limit     | Max tool calls per response                        | `tool-call-limit-editor.tsx`     |
+| 5   | MCP                 | MCP server URLs + headers                          | `available-mcp-servers.tsx`      |
+
+**Container:** `apps/web/components/dashboard-components/agent-settings.tsx`
+
+### Settings Tab Sections
+
+| #   | Section        | What it configures             | Component                  |
+| --- | -------------- | ------------------------------ | -------------------------- |
+| 1   | Name           | Project display name           | `project-name-section.tsx` |
+| 2   | API Keys       | API key list + create          | `api-key-list.tsx`         |
+| 3   | Authentication | OAuth mode, token requirements | `oauth-settings.tsx`       |
+| 4   | Danger Zone    | Project deletion               | `danger-zone-section.tsx`  |
 
 **Container:** `apps/web/components/dashboard-components/project-settings.tsx`
 
+All section components live in `apps/web/components/dashboard-components/project-details/`.
+
 ### Placement Decision Tree
 
-1. **Configures AI agent behavior?** (model selection, prompts, tools, memory, context) -> **Agent** category, grouped with LLM Providers through Tool Call Limit.
-2. **Configures project infrastructure?** (API keys, auth, team access, billing, webhooks) -> **Project** category, grouped with API Keys and User Authentication.
-3. **Monitoring or debugging view?** -> **Observability** tab.
-4. **High-level summary or status?** -> **Overview** tab.
-5. **None of the above?** -> Ask the user.
+1. **Configures AI agent behavior?** (model selection, prompts, tools, memory, context) -> **Agent tab**
+2. **Configures project infrastructure?** (API keys, naming, deletion, billing, webhooks) -> **Settings tab**
+3. **Configures who can access?** (auth, tokens, team members, permissions) -> **Settings tab**
+4. **Monitoring or debugging view?** -> **Observability tab**
+5. **High-level summary or status?** -> **Overview tab**
+6. **None of the above?** -> Ask the user.
 
-### Registering a New Section
+### Adding a New Section
 
-Four changes in `project-settings.tsx`:
-
-1. **Import** the component
-2. **Add a ref**: `const myFeatureRef = useRef<HTMLDivElement>(null)`
-3. **Add to sidebar nav** in BOTH the desktop sidebar (`hidden sm:block` div) AND the mobile dropdown (`sm:hidden` div)
-4. **Add the section** in the scrollable content area, placed in the correct category group
-
-Also add the ref to the `scrollToSection` refs map.
+1. **Create the component** in `project-details/` following the Card layout pattern below.
+2. **Import and render** in the correct container (`agent-settings.tsx` or `project-settings.tsx`).
+3. **Update the skeleton** in `settings-skeletons.tsx` (either `AgentPageSkeleton` or `SettingsPageSkeleton`).
 
 ---
 
@@ -134,7 +157,6 @@ Title includes the item name (`Delete "${name}"?`). Description warns the action
 ### Destructive Action Styling
 
 ```tsx
-// Inline delete button
 <Button
   variant="ghost"
   size="icon"
@@ -152,4 +174,28 @@ Use `Trash2` from `lucide-react`. Use `hover:bg-destructive/10` for ghost varian
 
 **Form fields: Edit/Save/Cancel.** Track `isEditing`, `savedValue`, and `displayValue` state. Cancel reverts to `savedValue`. Save button disabled during mutation, shows "Saving...". `autoFocus` on first input when entering edit mode.
 
-**Reference implementations:** `custom-instructions-editor.tsx` (edit/save/cancel), `tool-call-limit-editor.tsx` (simpler form).
+**Reference implementations:** `custom-instructions-editor.tsx` (edit/save/cancel), `tool-call-limit-editor.tsx` (simpler form), `project-name-section.tsx` (basic edit/save/cancel).
+
+### Danger Zone Pattern
+
+For irreversible destructive actions, use the Danger Zone card pattern:
+
+```tsx
+<Card className="border-destructive/50">
+  <CardHeader>
+    <CardTitle>Danger Zone</CardTitle>
+    <CardDescription>Warning about permanence.</CardDescription>
+  </CardHeader>
+  <CardContent>
+    <Button
+      variant="ghost"
+      className="text-destructive hover:text-destructive hover:bg-destructive/10"
+      aria-label="Delete this project"
+    >
+      Delete this project
+    </Button>
+  </CardContent>
+</Card>
+```
+
+The `DeleteConfirmationDialog` should be owned by the parent component that handles the mutation and post-delete navigation.

--- a/.claude/skills/building-settings-ui/SKILL.md
+++ b/.claude/skills/building-settings-ui/SKILL.md
@@ -81,6 +81,47 @@ All section components live in `apps/web/components/dashboard-components/project
 5. **High-level summary or status?** -> **Overview tab**
 6. **None of the above?** -> Ask the user.
 
+### Conditional and Dependent Settings
+
+Some settings only apply when another setting is in a specific state. Follow these patterns:
+
+**Show but warn (soft dependency).** The section renders normally but displays an `Alert` when the dependency isn't met. The user can still see and configure the setting. Use this when the feature exists but won't work at runtime.
+
+Example: Skills section shows a provider compatibility notice when the selected provider doesn't support skills:
+
+```tsx
+// skills-section.tsx
+const isProviderSupported = SKILLS_SUPPORTED_PROVIDERS.has(
+  defaultLlmProviderName,
+);
+// Renders full skills UI + warning Alert if !isProviderSupported
+```
+
+**Conditionally pass props (data dependency).** The parent reads one setting and passes it as a prop so the child can adapt its behavior. Use this when the child's content or options change based on the parent's state.
+
+Example: MCP servers section receives `providerType` to toggle agent-mode-specific UI:
+
+```tsx
+// agent-settings.tsx
+<AvailableMcpServers providerType={projectData?.providerType} />;
+// available-mcp-servers.tsx
+const isAgentMode = providerType === AiProviderType.AGENT;
+```
+
+Example: Custom LLM parameters change available suggestions based on provider and model:
+
+```tsx
+// provider-key-section.tsx passes selectedProvider to the parameter editor
+<CustomLlmParametersEditor selectedProvider={selectedProvider} />
+```
+
+**Rules for new dependent settings:**
+
+1. Never hide a section entirely based on another setting's state. Always render the card; use an Alert or disabled state to communicate the dependency.
+2. The warning message must name the dependency and tell the user what to change (e.g., "Switch to a supported provider to enable skills").
+3. Keep dependency checks in the section component, not the container. The container (`agent-settings.tsx`, `project-settings.tsx`) should pass data, not make visibility decisions.
+4. If a setting depends on state from a different tab, pass it through the shared project query (`api.project.getProject`) rather than cross-tab state.
+
 ### Adding a New Section
 
 1. **Create the component** in `project-details/` following the Card layout pattern below.

--- a/apps/web/app/(authed)/(dashboard)/[projectId]/agent/page.tsx
+++ b/apps/web/app/(authed)/(dashboard)/[projectId]/agent/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { AgentSettings } from "@/components/dashboard-components/agent-settings";
+import { useParams } from "next/navigation";
+
+export default function AgentPage() {
+  const params = useParams();
+  const projectId = params.projectId as string;
+
+  return <AgentSettings projectId={projectId} />;
+}

--- a/apps/web/app/(authed)/(dashboard)/[projectId]/layout.tsx
+++ b/apps/web/app/(authed)/(dashboard)/[projectId]/layout.tsx
@@ -33,6 +33,13 @@ const fadeInVariants = {
   },
 };
 
+function getActiveTab(pathname: string) {
+  if (pathname.includes("/observability")) return "observability";
+  if (pathname.includes("/agent")) return "agent";
+  if (pathname.includes("/settings")) return "settings";
+  return "overview";
+}
+
 export default function ProjectLayout({
   children,
   params,
@@ -45,14 +52,7 @@ export default function ProjectLayout({
     select: (projects) => projects.find((p) => p.id === projectId),
   });
 
-  // Determine active tab value
-  const activeTab = pathname.includes("/observability")
-    ? "observability"
-    : pathname.includes("/agent")
-      ? "agent"
-      : pathname.includes("/settings")
-        ? "settings"
-        : "overview";
+  const activeTab = getActiveTab(pathname);
 
   return (
     <div className="flex flex-col bg-background">

--- a/apps/web/app/(authed)/(dashboard)/[projectId]/layout.tsx
+++ b/apps/web/app/(authed)/(dashboard)/[projectId]/layout.tsx
@@ -57,7 +57,7 @@ export default function ProjectLayout({
   return (
     <div className="flex flex-col bg-background">
       {/* Sticky Navigation Section */}
-      <div className="sticky top-[var(--header-height)] z-40 bg-background">
+      <div className="sticky top-[var(--dashboard-header-height)] z-40 bg-background">
         <div className="container mx-auto px-4 md:px-6 pb-0">
           {/* Navigation Row */}
           <motion.div

--- a/apps/web/app/(authed)/(dashboard)/[projectId]/layout.tsx
+++ b/apps/web/app/(authed)/(dashboard)/[projectId]/layout.tsx
@@ -48,9 +48,11 @@ export default function ProjectLayout({
   // Determine active tab value
   const activeTab = pathname.includes("/observability")
     ? "observability"
-    : pathname.includes("/settings")
-      ? "settings"
-      : "overview";
+    : pathname.includes("/agent")
+      ? "agent"
+      : pathname.includes("/settings")
+        ? "settings"
+        : "overview";
 
   return (
     <div className="flex flex-col bg-background">
@@ -111,6 +113,13 @@ export default function ProjectLayout({
                   <Link href={`/${projectId}/observability`}>
                     Observability
                   </Link>
+                </TabsTrigger>
+                <TabsTrigger
+                  value="agent"
+                  className="text-xs sm:text-sm rounded-full data-[state=active]:bg-accent data-[state=active]:text-primary data-[state=inactive]:border-transparent data-[state=inactive]:text-foreground px-3 sm:px-4"
+                  asChild
+                >
+                  <Link href={`/${projectId}/agent`}>Agent</Link>
                 </TabsTrigger>
                 <TabsTrigger
                   value="settings"

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -131,6 +131,10 @@ html {
 
     --header-height: 3.5rem;
     --dashboard-header-height: 3rem;
+    --project-nav-height: 7.5rem;
+    --sticky-offset: calc(
+      var(--dashboard-header-height) + var(--project-nav-height)
+    );
     font-family: Inter, sans-serif;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11", "salt";
   }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -131,10 +131,6 @@ html {
 
     --header-height: 3.5rem;
     --dashboard-header-height: 3rem;
-    --project-nav-height: 7.5rem;
-    --sticky-offset: calc(
-      var(--dashboard-header-height) + var(--project-nav-height)
-    );
     font-family: Inter, sans-serif;
     font-feature-settings: "cv02", "cv03", "cv04", "cv11", "salt";
   }

--- a/apps/web/app/oauth/callback/route.ts
+++ b/apps/web/app/oauth/callback/route.ts
@@ -129,6 +129,6 @@ function getPostAuthRedirect(
       return url.toString();
     }
   }
-  // fall back to the project settings page where MCP servers are configured
-  return new URL(`/${projectId}/settings`, baseUrl).toString();
+  // fall back to the agent page where MCP servers are configured
+  return new URL(`/${projectId}/agent`, baseUrl).toString();
 }

--- a/apps/web/components/dashboard-components/agent-settings.tsx
+++ b/apps/web/components/dashboard-components/agent-settings.tsx
@@ -48,96 +48,47 @@ export function AgentSettings({ projectId }: AgentSettingsProps) {
     );
   }
 
-  const sections = [
-    { id: "custom-instructions", label: "Custom Instructions" },
-    { id: "skills", label: "Skills" },
-    { id: "tool-call-limit", label: "Tool Call Limit" },
-    { id: "mcp-servers", label: "MCP Servers" },
-    { id: "llm-providers", label: "LLM Providers" },
-  ];
-
   return (
     <TooltipProvider>
       <motion.div
-        className="flex gap-8 px-2 sm:px-4 max-w-6xl mx-auto"
+        className="px-2 sm:px-4 max-w-4xl mx-auto"
         initial="hidden"
         animate="visible"
         variants={containerVariants}
       >
-        <nav className="hidden lg:block w-48 shrink-0 sticky top-[var(--sticky-offset)] pt-2 self-start bg-background">
-          <p className="text-sm font-medium text-muted-foreground mb-3">
-            On this page
-          </p>
-          <ul className="space-y-1">
-            {sections.map((section) => (
-              <li key={section.id}>
-                <a
-                  href={`#${section.id}`}
-                  className="block text-sm text-muted-foreground py-1 hover:text-foreground transition-colors"
-                >
-                  {section.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <p className="text-muted-foreground mb-4 pt-2">
+          Configure the behavior of your Tambo agent.
+        </p>
+        <div className="space-y-6">
+          <InteractableCustomInstructionsEditor
+            projectId={project.id}
+            customInstructions={project.customInstructions}
+            allowSystemPromptOverride={project.allowSystemPromptOverride}
+            onEdited={handleRefreshProject}
+          />
 
-        <div className="flex-1 min-w-0 max-w-4xl">
-          <p className="text-muted-foreground mb-4 pt-2">
-            Configure the behavior of your Tambo agent.
-          </p>
-          <div className="space-y-6">
-            <div
-              id="custom-instructions"
-              className="scroll-mt-[var(--sticky-offset)]"
-            >
-              <InteractableCustomInstructionsEditor
-                projectId={project.id}
-                customInstructions={project.customInstructions}
-                allowSystemPromptOverride={project.allowSystemPromptOverride}
-                onEdited={handleRefreshProject}
-              />
-            </div>
+          <InteractableSkillsSection
+            projectId={project.id}
+            defaultLlmProviderName={project.defaultLlmProviderName ?? undefined}
+            defaultLlmModelName={project.defaultLlmModelName ?? undefined}
+          />
 
-            <div id="skills" className="scroll-mt-[var(--sticky-offset)]">
-              <InteractableSkillsSection
-                projectId={project.id}
-                defaultLlmProviderName={
-                  project.defaultLlmProviderName ?? undefined
-                }
-                defaultLlmModelName={project.defaultLlmModelName ?? undefined}
-              />
-            </div>
+          <InteractableToolCallLimitEditor
+            projectId={project.id}
+            maxToolCallLimit={project.maxToolCallLimit}
+            onEdited={handleRefreshProject}
+          />
 
-            <div
-              id="tool-call-limit"
-              className="scroll-mt-[var(--sticky-offset)]"
-            >
-              <InteractableToolCallLimitEditor
-                projectId={project.id}
-                maxToolCallLimit={project.maxToolCallLimit}
-                onEdited={handleRefreshProject}
-              />
-            </div>
+          <InteractableAvailableMcpServers
+            projectId={project.id}
+            providerType={project.providerType}
+            onEdited={handleRefreshProject}
+          />
 
-            <div id="mcp-servers" className="scroll-mt-[var(--sticky-offset)]">
-              <InteractableAvailableMcpServers
-                projectId={project.id}
-                providerType={project.providerType}
-                onEdited={handleRefreshProject}
-              />
-            </div>
-
-            <div
-              id="llm-providers"
-              className="scroll-mt-[var(--sticky-offset)]"
-            >
-              <InteractableProviderKeySection
-                projectId={project.id}
-                onEdited={handleRefreshProject}
-              />
-            </div>
-          </div>
+          <InteractableProviderKeySection
+            projectId={project.id}
+            onEdited={handleRefreshProject}
+          />
         </div>
       </motion.div>
     </TooltipProvider>

--- a/apps/web/components/dashboard-components/agent-settings.tsx
+++ b/apps/web/components/dashboard-components/agent-settings.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { InteractableAvailableMcpServers } from "@/components/dashboard-components/project-details/available-mcp-servers";
+import { InteractableCustomInstructionsEditor } from "@/components/dashboard-components/project-details/custom-instructions-editor";
+import { InteractableProviderKeySection } from "@/components/dashboard-components/project-details/provider-key-section";
+import { InteractableSkillsSection } from "@/components/dashboard-components/project-details/skills-section";
+import { InteractableToolCallLimitEditor } from "@/components/dashboard-components/project-details/tool-call-limit-editor";
+import { AgentPageSkeleton } from "@/components/skeletons/settings-skeletons";
+import { Card } from "@/components/ui/card";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { api } from "@/trpc/react";
+import { motion } from "framer-motion";
+
+interface AgentSettingsProps {
+  projectId: string;
+}
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.3 },
+  },
+};
+
+export function AgentSettings({ projectId }: AgentSettingsProps) {
+  const {
+    data: project,
+    isLoading: isLoadingProject,
+    refetch: handleRefreshProject,
+  } = api.project.getUserProjects.useQuery(undefined, {
+    select: (projects) => projects.find((p) => p.id === projectId),
+  });
+
+  if (isLoadingProject) {
+    return <AgentPageSkeleton />;
+  }
+
+  if (!project) {
+    return (
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+        <Card className="p-6 mt-6">
+          <h2 className="text-lg font-heading font-semibold">
+            Project not found
+          </h2>
+        </Card>
+      </motion.div>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <motion.div
+        className="flex flex-col px-2 sm:px-4 max-w-4xl"
+        initial="hidden"
+        animate="visible"
+        variants={containerVariants}
+      >
+        <div className="space-y-6 py-4">
+          {/* Model */}
+          <InteractableProviderKeySection
+            projectId={project.id}
+            onEdited={handleRefreshProject}
+          />
+
+          {/* Behavior: Instructions */}
+          <InteractableCustomInstructionsEditor
+            projectId={project.id}
+            customInstructions={project.customInstructions}
+            allowSystemPromptOverride={project.allowSystemPromptOverride}
+            onEdited={handleRefreshProject}
+          />
+
+          {/* Behavior: Skills */}
+          <InteractableSkillsSection
+            projectId={project.id}
+            defaultLlmProviderName={project.defaultLlmProviderName ?? undefined}
+            defaultLlmModelName={project.defaultLlmModelName ?? undefined}
+          />
+
+          {/* Behavior: Tool Call Limit */}
+          <InteractableToolCallLimitEditor
+            projectId={project.id}
+            maxToolCallLimit={project.maxToolCallLimit}
+            onEdited={handleRefreshProject}
+          />
+
+          {/* MCP */}
+          <InteractableAvailableMcpServers
+            projectId={project.id}
+            providerType={project.providerType}
+            onEdited={handleRefreshProject}
+          />
+        </div>
+      </motion.div>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/components/dashboard-components/agent-settings.tsx
+++ b/apps/web/components/dashboard-components/agent-settings.tsx
@@ -56,7 +56,8 @@ export function AgentSettings({ projectId }: AgentSettingsProps) {
         animate="visible"
         variants={containerVariants}
       >
-        <div className="space-y-6 py-4">
+        <h1 className="text-2xl sm:text-4xl font-semibold mb-4 pt-2">Agent</h1>
+        <div className="space-y-6">
           {/* Model */}
           <InteractableProviderKeySection
             projectId={project.id}

--- a/apps/web/components/dashboard-components/agent-settings.tsx
+++ b/apps/web/components/dashboard-components/agent-settings.tsx
@@ -48,50 +48,96 @@ export function AgentSettings({ projectId }: AgentSettingsProps) {
     );
   }
 
+  const sections = [
+    { id: "custom-instructions", label: "Custom Instructions" },
+    { id: "skills", label: "Skills" },
+    { id: "tool-call-limit", label: "Tool Call Limit" },
+    { id: "mcp-servers", label: "MCP Servers" },
+    { id: "llm-providers", label: "LLM Providers" },
+  ];
+
   return (
     <TooltipProvider>
       <motion.div
-        className="flex flex-col px-2 sm:px-4 max-w-4xl"
+        className="flex gap-8 px-2 sm:px-4 max-w-6xl mx-auto"
         initial="hidden"
         animate="visible"
         variants={containerVariants}
       >
-        <h1 className="text-2xl sm:text-4xl font-semibold mb-4 pt-2">Agent</h1>
-        <div className="space-y-6">
-          {/* Model */}
-          <InteractableProviderKeySection
-            projectId={project.id}
-            onEdited={handleRefreshProject}
-          />
+        <nav className="hidden lg:block w-48 shrink-0 sticky top-[var(--sticky-offset)] pt-2 self-start bg-background">
+          <p className="text-sm font-medium text-muted-foreground mb-3">
+            On this page
+          </p>
+          <ul className="space-y-1">
+            {sections.map((section) => (
+              <li key={section.id}>
+                <a
+                  href={`#${section.id}`}
+                  className="block text-sm text-muted-foreground py-1 hover:text-foreground transition-colors"
+                >
+                  {section.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
 
-          {/* Behavior: Instructions */}
-          <InteractableCustomInstructionsEditor
-            projectId={project.id}
-            customInstructions={project.customInstructions}
-            allowSystemPromptOverride={project.allowSystemPromptOverride}
-            onEdited={handleRefreshProject}
-          />
+        <div className="flex-1 min-w-0 max-w-4xl">
+          <p className="text-muted-foreground mb-4 pt-2">
+            Configure the behavior of your Tambo agent.
+          </p>
+          <div className="space-y-6">
+            <div
+              id="custom-instructions"
+              className="scroll-mt-[var(--sticky-offset)]"
+            >
+              <InteractableCustomInstructionsEditor
+                projectId={project.id}
+                customInstructions={project.customInstructions}
+                allowSystemPromptOverride={project.allowSystemPromptOverride}
+                onEdited={handleRefreshProject}
+              />
+            </div>
 
-          {/* Behavior: Skills */}
-          <InteractableSkillsSection
-            projectId={project.id}
-            defaultLlmProviderName={project.defaultLlmProviderName ?? undefined}
-            defaultLlmModelName={project.defaultLlmModelName ?? undefined}
-          />
+            <div id="skills" className="scroll-mt-[var(--sticky-offset)]">
+              <InteractableSkillsSection
+                projectId={project.id}
+                defaultLlmProviderName={
+                  project.defaultLlmProviderName ?? undefined
+                }
+                defaultLlmModelName={project.defaultLlmModelName ?? undefined}
+              />
+            </div>
 
-          {/* Behavior: Tool Call Limit */}
-          <InteractableToolCallLimitEditor
-            projectId={project.id}
-            maxToolCallLimit={project.maxToolCallLimit}
-            onEdited={handleRefreshProject}
-          />
+            <div
+              id="tool-call-limit"
+              className="scroll-mt-[var(--sticky-offset)]"
+            >
+              <InteractableToolCallLimitEditor
+                projectId={project.id}
+                maxToolCallLimit={project.maxToolCallLimit}
+                onEdited={handleRefreshProject}
+              />
+            </div>
 
-          {/* MCP */}
-          <InteractableAvailableMcpServers
-            projectId={project.id}
-            providerType={project.providerType}
-            onEdited={handleRefreshProject}
-          />
+            <div id="mcp-servers" className="scroll-mt-[var(--sticky-offset)]">
+              <InteractableAvailableMcpServers
+                projectId={project.id}
+                providerType={project.providerType}
+                onEdited={handleRefreshProject}
+              />
+            </div>
+
+            <div
+              id="llm-providers"
+              className="scroll-mt-[var(--sticky-offset)]"
+            >
+              <InteractableProviderKeySection
+                projectId={project.id}
+                onEdited={handleRefreshProject}
+              />
+            </div>
+          </div>
         </div>
       </motion.div>
     </TooltipProvider>

--- a/apps/web/components/dashboard-components/project-details/danger-zone-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/danger-zone-section.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface DangerZoneSectionProps {
+  onRequestDelete: () => void;
+  isDeleting: boolean;
+}
+
+export function DangerZoneSection({
+  onRequestDelete,
+  isDeleting,
+}: DangerZoneSectionProps) {
+  return (
+    <Card className="border-destructive/50">
+      <CardHeader>
+        <CardTitle className="text-lg font-semibold">Danger Zone</CardTitle>
+        <CardDescription className="text-sm font-sans text-foreground">
+          Permanently delete this project and all of its data. This action
+          cannot be undone.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          variant="ghost"
+          className="text-destructive hover:text-destructive hover:bg-destructive/10"
+          onClick={onRequestDelete}
+          disabled={isDeleting}
+          aria-label="Delete this project"
+        >
+          {isDeleting ? "Deleting..." : "Delete this project"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard-components/project-details/project-name-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/project-name-section.tsx
@@ -44,12 +44,12 @@ export function ProjectNameSection({
         projectId,
         name: editedName.trim(),
       });
+      onEdited();
       toast({
         title: "Success",
         description: "Project name updated successfully",
       });
       setIsEditing(false);
-      onEdited();
     } catch {
       toast({
         title: "Error",

--- a/apps/web/components/dashboard-components/project-details/project-name-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/project-name-section.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+import { api } from "@/trpc/react";
+import { useState } from "react";
+
+interface ProjectNameSectionProps {
+  projectId: string;
+  projectName: string;
+  onEdited: () => void;
+}
+
+export function ProjectNameSection({
+  projectId,
+  projectName,
+  onEdited,
+}: ProjectNameSectionProps) {
+  const { toast } = useToast();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedName, setEditedName] = useState("");
+
+  const { mutateAsync: updateProject, isPending } =
+    api.project.updateProject.useMutation();
+
+  const handleEdit = () => {
+    setEditedName(projectName);
+    setIsEditing(true);
+  };
+
+  const handleSave = async () => {
+    if (!editedName.trim()) return;
+
+    try {
+      await updateProject({
+        projectId,
+        name: editedName.trim(),
+      });
+      toast({
+        title: "Success",
+        description: "Project name updated successfully",
+      });
+      setIsEditing(false);
+      onEdited();
+    } catch {
+      toast({
+        title: "Error",
+        description: "Failed to update project name",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditedName("");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg font-semibold">Project Name</CardTitle>
+        <CardDescription className="text-sm font-sans text-foreground">
+          The display name for this project.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isEditing ? (
+          <div className="flex flex-col gap-3">
+            <Input
+              value={editedName}
+              onChange={(e) => setEditedName(e.target.value)}
+              placeholder="Project name"
+              disabled={isPending}
+              onKeyDown={async (e) => {
+                if (e.key === "Enter") {
+                  await handleSave();
+                } else if (e.key === "Escape") {
+                  handleCancel();
+                }
+              }}
+              autoFocus
+            />
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="outline"
+                onClick={handleCancel}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleSave}
+                disabled={isPending || !editedName.trim()}
+              >
+                {isPending ? "Saving..." : "Save"}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between">
+            <span className="text-sm">{projectName}</span>
+            <Button variant="outline" size="sm" onClick={handleEdit}>
+              Edit
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/dashboard-components/project-settings.tsx
+++ b/apps/web/components/dashboard-components/project-settings.tsx
@@ -89,58 +89,92 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
     );
   }
 
+  const sections = [
+    { id: "project-name", label: "Project Name" },
+    { id: "api-keys", label: "API Keys" },
+    { id: "authentication", label: "Authentication" },
+    { id: "danger-zone", label: "Danger Zone" },
+  ];
+
   return (
     <TooltipProvider>
       <motion.div
-        className="flex flex-col px-2 sm:px-4 max-w-4xl"
+        className="flex gap-8 px-2 sm:px-4 max-w-6xl mx-auto"
         initial="hidden"
         animate="visible"
         variants={containerVariants}
       >
-        <h1 className="text-2xl sm:text-4xl font-semibold mb-4 pt-2">
-          Settings
-        </h1>
-        <div className="space-y-6">
-          {/* Name */}
-          <ProjectNameSection
-            projectId={project.id}
-            projectName={project.name}
-            onEdited={handleRefreshProject}
-          />
+        <nav className="hidden lg:block w-48 shrink-0 sticky top-[var(--sticky-offset)] pt-2 self-start bg-background">
+          <p className="text-sm font-medium text-muted-foreground mb-3">
+            On this page
+          </p>
+          <ul className="space-y-1">
+            {sections.map((section) => (
+              <li key={section.id}>
+                <a
+                  href={`#${section.id}`}
+                  className="block text-sm text-muted-foreground py-1 hover:text-foreground transition-colors"
+                >
+                  {section.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
 
-          {/* API Keys */}
-          <InteractableAPIKeyList
-            projectId={project.id}
-            onEdited={handleRefreshProject}
-          />
+        <div className="flex-1 min-w-0 max-w-4xl">
+          <p className="text-muted-foreground mb-4 pt-2">
+            Manage your project name, API keys, and webhooks.
+          </p>
+          <div className="space-y-6">
+            <div id="project-name" className="scroll-mt-[var(--sticky-offset)]">
+              <ProjectNameSection
+                projectId={project.id}
+                projectName={project.name}
+                onEdited={handleRefreshProject}
+              />
+            </div>
 
-          {/* Authentication */}
-          <InteractableOAuthSettings
-            projectId={project.id}
-            isTokenRequired={project.isTokenRequired ?? false}
-            onEdited={handleRefreshProject}
-          />
+            <div id="api-keys" className="scroll-mt-[var(--sticky-offset)]">
+              <InteractableAPIKeyList
+                projectId={project.id}
+                onEdited={handleRefreshProject}
+              />
+            </div>
 
-          {/* Danger Zone */}
-          <DangerZoneSection
-            onRequestDelete={() =>
-              setAlertState({
-                show: true,
-                title: "Delete Project",
-                description:
-                  "Are you sure you want to delete this project? This action cannot be undone.",
-              })
-            }
-            isDeleting={isDeleting}
+            <div
+              id="authentication"
+              className="scroll-mt-[var(--sticky-offset)]"
+            >
+              <InteractableOAuthSettings
+                projectId={project.id}
+                isTokenRequired={project.isTokenRequired ?? false}
+                onEdited={handleRefreshProject}
+              />
+            </div>
+
+            <div id="danger-zone" className="scroll-mt-[var(--sticky-offset)]">
+              <DangerZoneSection
+                onRequestDelete={() =>
+                  setAlertState({
+                    show: true,
+                    title: "Delete Project",
+                    description:
+                      "Are you sure you want to delete this project? This action cannot be undone.",
+                  })
+                }
+                isDeleting={isDeleting}
+              />
+            </div>
+          </div>
+
+          <DeleteConfirmationDialog
+            mode="single"
+            alertState={alertState}
+            setAlertState={setAlertState}
+            onConfirm={handleDeleteProject}
           />
         </div>
-
-        <DeleteConfirmationDialog
-          mode="single"
-          alertState={alertState}
-          setAlertState={setAlertState}
-          onConfirm={handleDeleteProject}
-        />
       </motion.div>
     </TooltipProvider>
   );

--- a/apps/web/components/dashboard-components/project-settings.tsx
+++ b/apps/web/components/dashboard-components/project-settings.tsx
@@ -89,92 +89,54 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
     );
   }
 
-  const sections = [
-    { id: "project-name", label: "Project Name" },
-    { id: "api-keys", label: "API Keys" },
-    { id: "authentication", label: "Authentication" },
-    { id: "danger-zone", label: "Danger Zone" },
-  ];
-
   return (
     <TooltipProvider>
       <motion.div
-        className="flex gap-8 px-2 sm:px-4 max-w-6xl mx-auto"
+        className="px-2 sm:px-4 max-w-4xl mx-auto"
         initial="hidden"
         animate="visible"
         variants={containerVariants}
       >
-        <nav className="hidden lg:block w-48 shrink-0 sticky top-[var(--sticky-offset)] pt-2 self-start bg-background">
-          <p className="text-sm font-medium text-muted-foreground mb-3">
-            On this page
-          </p>
-          <ul className="space-y-1">
-            {sections.map((section) => (
-              <li key={section.id}>
-                <a
-                  href={`#${section.id}`}
-                  className="block text-sm text-muted-foreground py-1 hover:text-foreground transition-colors"
-                >
-                  {section.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <p className="text-muted-foreground mb-4 pt-2">
+          Manage your project name, API keys, and webhooks.
+        </p>
+        <div className="space-y-6">
+          <ProjectNameSection
+            projectId={project.id}
+            projectName={project.name}
+            onEdited={handleRefreshProject}
+          />
 
-        <div className="flex-1 min-w-0 max-w-4xl">
-          <p className="text-muted-foreground mb-4 pt-2">
-            Manage your project name, API keys, and webhooks.
-          </p>
-          <div className="space-y-6">
-            <div id="project-name" className="scroll-mt-[var(--sticky-offset)]">
-              <ProjectNameSection
-                projectId={project.id}
-                projectName={project.name}
-                onEdited={handleRefreshProject}
-              />
-            </div>
+          <InteractableAPIKeyList
+            projectId={project.id}
+            onEdited={handleRefreshProject}
+          />
 
-            <div id="api-keys" className="scroll-mt-[var(--sticky-offset)]">
-              <InteractableAPIKeyList
-                projectId={project.id}
-                onEdited={handleRefreshProject}
-              />
-            </div>
+          <InteractableOAuthSettings
+            projectId={project.id}
+            isTokenRequired={project.isTokenRequired ?? false}
+            onEdited={handleRefreshProject}
+          />
 
-            <div
-              id="authentication"
-              className="scroll-mt-[var(--sticky-offset)]"
-            >
-              <InteractableOAuthSettings
-                projectId={project.id}
-                isTokenRequired={project.isTokenRequired ?? false}
-                onEdited={handleRefreshProject}
-              />
-            </div>
-
-            <div id="danger-zone" className="scroll-mt-[var(--sticky-offset)]">
-              <DangerZoneSection
-                onRequestDelete={() =>
-                  setAlertState({
-                    show: true,
-                    title: "Delete Project",
-                    description:
-                      "Are you sure you want to delete this project? This action cannot be undone.",
-                  })
-                }
-                isDeleting={isDeleting}
-              />
-            </div>
-          </div>
-
-          <DeleteConfirmationDialog
-            mode="single"
-            alertState={alertState}
-            setAlertState={setAlertState}
-            onConfirm={handleDeleteProject}
+          <DangerZoneSection
+            onRequestDelete={() =>
+              setAlertState({
+                show: true,
+                title: "Delete Project",
+                description:
+                  "Are you sure you want to delete this project? This action cannot be undone.",
+              })
+            }
+            isDeleting={isDeleting}
           />
         </div>
+
+        <DeleteConfirmationDialog
+          mode="single"
+          alertState={alertState}
+          setAlertState={setAlertState}
+          onConfirm={handleDeleteProject}
+        />
       </motion.div>
     </TooltipProvider>
   );

--- a/apps/web/components/dashboard-components/project-settings.tsx
+++ b/apps/web/components/dashboard-components/project-settings.tsx
@@ -97,7 +97,10 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
         animate="visible"
         variants={containerVariants}
       >
-        <div className="space-y-6 py-4">
+        <h1 className="text-2xl sm:text-4xl font-semibold mb-4 pt-2">
+          Settings
+        </h1>
+        <div className="space-y-6">
           {/* Name */}
           <ProjectNameSection
             projectId={project.id}

--- a/apps/web/components/dashboard-components/project-settings.tsx
+++ b/apps/web/components/dashboard-components/project-settings.tsx
@@ -5,66 +5,39 @@ import {
   type AlertState,
 } from "@/components/dashboard-components/delete-confirmation-dialog";
 import { InteractableAPIKeyList } from "@/components/dashboard-components/project-details/api-key-list";
-import { InteractableAvailableMcpServers } from "@/components/dashboard-components/project-details/available-mcp-servers";
-import { InteractableCustomInstructionsEditor } from "@/components/dashboard-components/project-details/custom-instructions-editor";
+import { DangerZoneSection } from "@/components/dashboard-components/project-details/danger-zone-section";
 import { InteractableOAuthSettings } from "@/components/dashboard-components/project-details/oauth-settings";
-import { InteractableProviderKeySection } from "@/components/dashboard-components/project-details/provider-key-section";
-import { InteractableSkillsSection } from "@/components/dashboard-components/project-details/skills-section";
-import { InteractableToolCallLimitEditor } from "@/components/dashboard-components/project-details/tool-call-limit-editor";
+import { ProjectNameSection } from "@/components/dashboard-components/project-details/project-name-section";
 import { SettingsPageSkeleton } from "@/components/skeletons/settings-skeletons";
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { api } from "@/trpc/react";
 import { motion } from "framer-motion";
-import { ChevronDown } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 interface ProjectSettingsProps {
   projectId: string;
 }
 
-// Animation variants
 const containerVariants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
-    transition: {
-      duration: 0.3,
-    },
+    transition: { duration: 0.3 },
   },
 };
 
 export function ProjectSettings({ projectId }: ProjectSettingsProps) {
   const { toast } = useToast();
   const router = useRouter();
-  const [activeSection, setActiveSection] = useState("api-keys");
   const [alertState, setAlertState] = useState<AlertState>({
     show: false,
     title: "",
     description: "",
   });
 
-  // Edit mode state
-  const [isEditingName, setIsEditingName] = useState(false);
-  const [editedName, setEditedName] = useState("");
-
-  // Refs for each section
-  const apiKeysRef = useRef<HTMLDivElement>(null);
-  const llmProvidersRef = useRef<HTMLDivElement>(null);
-  const customInstructionsRef = useRef<HTMLDivElement>(null);
-  const oauthSettingsRef = useRef<HTMLDivElement>(null);
-  const skillsRef = useRef<HTMLDivElement>(null);
-  const mcpServersRef = useRef<HTMLDivElement>(null);
-  const toolCallLimitRef = useRef<HTMLDivElement>(null);
-
-  // Add a ref for the scrollable container
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-  // Fetch project details
   const {
     data: project,
     isLoading: isLoadingProject,
@@ -76,12 +49,6 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
   const { mutateAsync: deleteProject, isPending: isDeleting } =
     api.project.removeProject.useMutation();
 
-  // Update project mutation
-  const { mutateAsync: updateProject, isPending: isUpdatingProject } =
-    api.project.updateProject.useMutation();
-
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-
   const handleDeleteProject = async () => {
     try {
       await deleteProject(projectId);
@@ -90,7 +57,7 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
         description: "Project deleted successfully",
       });
       router.push("/");
-    } catch (_error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to delete project",
@@ -102,76 +69,6 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
         title: "",
         description: "",
         data: undefined,
-      });
-    }
-  };
-
-  const handleEditName = () => {
-    if (project) {
-      setEditedName(project.name);
-      setIsEditingName(true);
-    }
-  };
-
-  const handleSaveName = async () => {
-    if (!project || !editedName.trim()) {
-      return;
-    }
-
-    try {
-      await updateProject({
-        projectId: project.id,
-        name: editedName.trim(),
-      });
-
-      toast({
-        title: "Success",
-        description: "Project name updated successfully",
-      });
-
-      setIsEditingName(false);
-      await handleRefreshProject();
-    } catch (_error) {
-      toast({
-        title: "Error",
-        description: "Failed to update project name",
-        variant: "destructive",
-      });
-    }
-  };
-
-  const handleCancelEdit = () => {
-    setIsEditingName(false);
-    setEditedName("");
-  };
-
-  const scrollToSection = (section: string) => {
-    setActiveSection(section);
-    const refs = {
-      "api-keys": apiKeysRef,
-      "llm-providers": llmProvidersRef,
-      "custom-instructions": customInstructionsRef,
-      skills: skillsRef,
-      "oauth-settings": oauthSettingsRef,
-      "mcp-servers": mcpServersRef,
-      "tool-call-limit": toolCallLimitRef,
-    };
-
-    // Get the target element and the scroll container
-    const targetElement = refs[section as keyof typeof refs].current;
-    const scrollContainer = scrollContainerRef.current;
-
-    if (targetElement && scrollContainer) {
-      // Calculate the scroll position relative to the container
-      const containerRect = scrollContainer.getBoundingClientRect();
-      const targetRect = targetElement.getBoundingClientRect();
-      const relativeTop =
-        targetRect.top - containerRect.top + scrollContainer.scrollTop;
-
-      // Smooth scroll the container
-      scrollContainer.scrollTo({
-        top: relativeTop,
-        behavior: "smooth",
       });
     }
   };
@@ -195,351 +92,44 @@ export function ProjectSettings({ projectId }: ProjectSettingsProps) {
   return (
     <TooltipProvider>
       <motion.div
-        className="flex flex-col px-2 sm:px-4"
+        className="flex flex-col px-2 sm:px-4 max-w-4xl"
         initial="hidden"
         animate="visible"
         variants={containerVariants}
       >
-        {/* Header */}
-        <div className="bg-background w-full">
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between py-2 px-2 gap-4">
-            {isEditingName ? (
-              <Input
-                value={editedName}
-                onChange={(e) => setEditedName(e.target.value)}
-                className="text-2xl sm:text-4xl font-semibold py-2 px-3 border-2 w-full sm:max-w-md placeholder:text-muted placeholder:font-normal min-h-[2.5rem] sm:min-h-[3.5rem]"
-                placeholder="Project name"
-                disabled={isUpdatingProject}
-                onKeyDown={async (e) => {
-                  if (e.key === "Enter") {
-                    await handleSaveName();
-                  } else if (e.key === "Escape") {
-                    handleCancelEdit();
-                  }
-                }}
-                autoFocus
-              />
-            ) : (
-              <h1 className="text-2xl sm:text-4xl font-semibold min-h-[2.5rem] sm:min-h-[3.5rem] flex items-center">
-                {project.name}
-              </h1>
-            )}
+        <div className="space-y-6 py-4">
+          {/* Name */}
+          <ProjectNameSection
+            projectId={project.id}
+            projectName={project.name}
+            onEdited={handleRefreshProject}
+          />
 
-            <div className="flex gap-2 sm:gap-3 self-end sm:self-auto">
-              <Button
-                variant="ghost"
-                className="text-destructive hover:text-destructive hover:bg-destructive/10 text-sm sm:text-base"
-                onClick={() =>
-                  setAlertState({
-                    show: true,
-                    title: "Delete Project",
-                    description:
-                      "Are you sure you want to delete this project? This action cannot be undone.",
-                  })
-                }
-                disabled={isDeleting}
-              >
-                {isDeleting ? (
-                  <>
-                    <span className="loading loading-spinner loading-sm mr-2" />
-                    Deleting...
-                  </>
-                ) : (
-                  "Delete"
-                )}
-              </Button>
-              {isEditingName ? (
-                <>
-                  <Button
-                    variant="outline"
-                    onClick={handleCancelEdit}
-                    disabled={isUpdatingProject}
-                    className="text-sm sm:text-base"
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    onClick={handleSaveName}
-                    disabled={isUpdatingProject || !editedName.trim()}
-                    className="text-sm sm:text-base"
-                  >
-                    Save
-                  </Button>
-                </>
-              ) : (
-                <Button
-                  variant="outline"
-                  onClick={handleEditName}
-                  className="text-sm sm:text-base"
-                >
-                  Edit
-                </Button>
-              )}
-            </div>
-          </div>
-        </div>
+          {/* API Keys */}
+          <InteractableAPIKeyList
+            projectId={project.id}
+            onEdited={handleRefreshProject}
+          />
 
-        {/* Mobile Navigation Menu */}
-        <div className="sm:hidden py-4">
-          <Button
-            variant="outline"
-            className="w-full justify-between"
-            onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-          >
-            <span>
-              Navigate to:{" "}
-              {activeSection.replace("-", " ").split(" ").join(" ")}
-            </span>
-            <ChevronDown
-              className={`h-4 w-4 transition-transform ${isMobileMenuOpen ? "rotate-180" : ""}`}
-            />
-          </Button>
+          {/* Authentication */}
+          <InteractableOAuthSettings
+            projectId={project.id}
+            isTokenRequired={project.isTokenRequired ?? false}
+            onEdited={handleRefreshProject}
+          />
 
-          {isMobileMenuOpen && (
-            <div className="mt-2 space-y-1">
-              <Button
-                variant="ghost"
-                className={`w-full justify-start gap-2 rounded-full ${
-                  activeSection === "api-keys" ? "bg-accent" : "hover:bg-accent"
-                }`}
-                onClick={() => {
-                  scrollToSection("api-keys");
-                  setIsMobileMenuOpen(false);
-                }}
-              >
-                API keys
-              </Button>
-              <Button
-                variant="ghost"
-                className={`w-full justify-start gap-2 rounded-full ${
-                  activeSection === "llm-providers"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => {
-                  scrollToSection("llm-providers");
-                  setIsMobileMenuOpen(false);
-                }}
-              >
-                LLM providers
-              </Button>
-              <Button
-                variant="ghost"
-                className={`w-full justify-start gap-2 rounded-full ${
-                  activeSection === "custom-instructions"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => {
-                  scrollToSection("custom-instructions");
-                  setIsMobileMenuOpen(false);
-                }}
-              >
-                Custom instructions
-              </Button>
-              <Button
-                variant="ghost"
-                className={`w-full justify-start gap-2 rounded-full ${
-                  activeSection === "skills" ? "bg-accent" : "hover:bg-accent"
-                }`}
-                onClick={() => {
-                  scrollToSection("skills");
-                  setIsMobileMenuOpen(false);
-                }}
-              >
-                Skills
-              </Button>
-              <Button
-                variant="ghost"
-                className={`w-full justify-start gap-2 rounded-full ${
-                  activeSection === "mcp-servers"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => {
-                  scrollToSection("mcp-servers");
-                  setIsMobileMenuOpen(false);
-                }}
-              >
-                MCP servers
-              </Button>
-              <Button
-                variant="ghost"
-                className={`w-full justify-start gap-2 rounded-full ${
-                  activeSection === "tool-call-limit"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => {
-                  scrollToSection("tool-call-limit");
-                  setIsMobileMenuOpen(false);
-                }}
-              >
-                Tool Call Limit
-              </Button>
-              <Button
-                variant="ghost"
-                className={`w-full justify-start gap-2 rounded-full ${
-                  activeSection === "oauth-settings"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => {
-                  scrollToSection("oauth-settings");
-                  setIsMobileMenuOpen(false);
-                }}
-              >
-                User Authentication
-              </Button>
-            </div>
-          )}
-        </div>
-
-        {/* Main Layout */}
-        <div className="flex gap-8 sm:gap-12 lg:gap-48 w-full">
-          {/* Sidebar Navigation */}
-          <div className="hidden sm:block py-6 w-48 lg:w-1/5 shrink-0">
-            <div className="flex flex-col gap-1">
-              <Button
-                variant="ghost"
-                className={`justify-start gap-2 rounded-full text-sm ${
-                  activeSection === "api-keys" ? "bg-accent" : "hover:bg-accent"
-                }`}
-                onClick={() => scrollToSection("api-keys")}
-              >
-                API keys
-              </Button>
-              <Button
-                variant="ghost"
-                className={`justify-start gap-2 rounded-full text-sm ${
-                  activeSection === "llm-providers"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => scrollToSection("llm-providers")}
-              >
-                LLM providers
-              </Button>
-              <Button
-                variant="ghost"
-                className={`justify-start gap-2 rounded-full text-sm ${
-                  activeSection === "custom-instructions"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => scrollToSection("custom-instructions")}
-              >
-                Custom instructions
-              </Button>
-              <Button
-                variant="ghost"
-                className={`justify-start gap-2 rounded-full text-sm ${
-                  activeSection === "skills" ? "bg-accent" : "hover:bg-accent"
-                }`}
-                onClick={() => scrollToSection("skills")}
-              >
-                Skills
-              </Button>
-              <Button
-                variant="ghost"
-                className={`justify-start gap-2 rounded-full text-sm ${
-                  activeSection === "mcp-servers"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => scrollToSection("mcp-servers")}
-              >
-                MCP servers
-              </Button>
-              <Button
-                variant="ghost"
-                className={`justify-start gap-2 rounded-full text-sm ${
-                  activeSection === "tool-call-limit"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => scrollToSection("tool-call-limit")}
-              >
-                Tool Call Limit
-              </Button>
-              <Button
-                variant="ghost"
-                className={`justify-start gap-2 rounded-full text-sm ${
-                  activeSection === "oauth-settings"
-                    ? "bg-accent"
-                    : "hover:bg-accent"
-                }`}
-                onClick={() => scrollToSection("oauth-settings")}
-              >
-                User Authentication
-              </Button>
-            </div>
-          </div>
-
-          {/* Scrollable Content */}
-          <div
-            ref={scrollContainerRef}
-            className="h-[calc(100vh-150px)] sm:h-[calc(100vh-200px)] w-full overflow-y-auto pt-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:none]"
-          >
-            <div className="space-y-4">
-              <div ref={apiKeysRef} className="p-2">
-                <InteractableAPIKeyList
-                  projectId={project.id}
-                  onEdited={handleRefreshProject}
-                />
-              </div>
-
-              <div ref={llmProvidersRef} className="p-2">
-                <InteractableProviderKeySection
-                  projectId={project.id}
-                  onEdited={handleRefreshProject}
-                />
-              </div>
-
-              <div ref={customInstructionsRef} className="p-2">
-                <InteractableCustomInstructionsEditor
-                  projectId={project.id}
-                  customInstructions={project.customInstructions}
-                  allowSystemPromptOverride={project.allowSystemPromptOverride}
-                  onEdited={handleRefreshProject}
-                />
-              </div>
-
-              <div ref={skillsRef} className="p-2">
-                <InteractableSkillsSection
-                  projectId={project.id}
-                  defaultLlmProviderName={
-                    project.defaultLlmProviderName ?? undefined
-                  }
-                  defaultLlmModelName={project.defaultLlmModelName ?? undefined}
-                />
-              </div>
-
-              <div ref={mcpServersRef} className="p-2">
-                <InteractableAvailableMcpServers
-                  projectId={project.id}
-                  providerType={project.providerType}
-                  onEdited={handleRefreshProject}
-                />
-              </div>
-
-              <div ref={toolCallLimitRef} className="p-2">
-                <InteractableToolCallLimitEditor
-                  projectId={project.id}
-                  maxToolCallLimit={project.maxToolCallLimit}
-                  onEdited={handleRefreshProject}
-                />
-              </div>
-
-              <div ref={oauthSettingsRef} className="p-2">
-                <InteractableOAuthSettings
-                  projectId={project.id}
-                  isTokenRequired={project.isTokenRequired ?? false}
-                  onEdited={handleRefreshProject}
-                />
-              </div>
-            </div>
-          </div>
+          {/* Danger Zone */}
+          <DangerZoneSection
+            onRequestDelete={() =>
+              setAlertState({
+                show: true,
+                title: "Delete Project",
+                description:
+                  "Are you sure you want to delete this project? This action cannot be undone.",
+              })
+            }
+            isDeleting={isDeleting}
+          />
         </div>
 
         <DeleteConfirmationDialog

--- a/apps/web/components/skeletons/settings-skeletons.tsx
+++ b/apps/web/components/skeletons/settings-skeletons.tsx
@@ -11,54 +11,48 @@ export function SettingsPageSkeleton() {
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="flex flex-col pl-4 pr-4"
+      className="flex flex-col px-2 sm:px-4 max-w-4xl"
     >
-      {/* Header skeleton */}
-      <div className="bg-background w-full">
-        <div className="flex items-center justify-between py-2 px-2">
-          <h1 className="text-4xl font-semibold min-h-[3.5rem] flex items-center">
-            <Skeleton className="h-10 w-48" />
-          </h1>
-          <div className="flex gap-3">
-            <SkeletonButton className="w-16" />
-            <SkeletonButton className="w-16" />
-          </div>
-        </div>
-      </div>
-
-      {/* Main Layout skeleton */}
-      <div className="flex gap-48 w-full">
-        {/* Sidebar Navigation skeleton */}
-        <div className="py-6 w-1/5">
-          <div className="flex flex-col gap-1">
-            {[...Array(5)].map((_, i) => (
-              <Skeleton key={i} className="h-9 w-full rounded-full" />
-            ))}
-          </div>
-        </div>
-
-        {/* Scrollable Content skeleton */}
-        <div className="h-[calc(100vh-200px)] w-full overflow-y-auto pt-2 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:'none'] [scrollbar-width:none]">
-          <div className="space-y-4">
-            <div className="p-2">
-              <APIKeyListSkeleton />
-            </div>
-            <div className="p-2">
-              <ProviderKeySectionSkeleton />
-            </div>
-            <div className="p-2">
-              <CustomInstructionsEditorSkeleton />
-            </div>
-            <div className="p-2">
-              <AvailableMcpServersSkeleton />
-            </div>
-            <div className="p-2">
-              <OAuthSettingsSkeleton />
-            </div>
-          </div>
-        </div>
+      <div className="space-y-6 py-4">
+        <ProjectNameSkeleton />
+        <APIKeyListSkeleton />
+        <OAuthSettingsSkeleton />
+        <DangerZoneSkeleton />
       </div>
     </motion.div>
+  );
+}
+
+export function AgentPageSkeleton() {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="flex flex-col px-2 sm:px-4 max-w-4xl"
+    >
+      <div className="space-y-6 py-4">
+        <ProviderKeySectionSkeleton />
+        <CustomInstructionsEditorSkeleton />
+        <AvailableMcpServersSkeleton />
+      </div>
+    </motion.div>
+  );
+}
+
+function ProjectNameSkeleton() {
+  return (
+    <Card className="border rounded-md overflow-hidden">
+      <CardHeader>
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-3 w-56 mt-1" />
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-40" />
+          <SkeletonButton className="w-16" />
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -67,9 +61,7 @@ function APIKeyListSkeleton() {
     <Card className="border rounded-md overflow-hidden">
       <CardContent className="p-6 space-y-4">
         <div className="flex justify-between items-center">
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-5 w-20" />
-          </div>
+          <Skeleton className="h-5 w-20" />
           <SkeletonButton className="w-20" />
         </div>
         <Skeleton className="h-4 w-96" />
@@ -83,6 +75,20 @@ function APIKeyListSkeleton() {
             </div>
           ))}
         </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DangerZoneSkeleton() {
+  return (
+    <Card className="border-destructive/50 border rounded-md overflow-hidden">
+      <CardHeader>
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-3 w-80 mt-1" />
+      </CardHeader>
+      <CardContent>
+        <SkeletonButton className="w-36" />
       </CardContent>
     </Card>
   );
@@ -193,11 +199,8 @@ function OAuthSettingsSkeleton() {
         <Skeleton className="h-4 w-80 mt-2" />
       </CardHeader>
       <CardContent className="space-y-6">
-        {/* Validation Mode Label */}
         <div className="space-y-4">
           <Skeleton className="h-5 w-32" />
-
-          {/* Radio Group Options */}
           <div className="space-y-3">
             {[...Array(4)].map((_, i) => (
               <div
@@ -213,15 +216,11 @@ function OAuthSettingsSkeleton() {
             ))}
           </div>
         </div>
-
-        {/* Conditional Input Field Area */}
         <div className="space-y-2">
           <Skeleton className="h-4 w-24" />
           <Skeleton className="h-10 w-full" />
           <Skeleton className="h-3 w-64" />
         </div>
-
-        {/* Save Button Area */}
         <div className="flex justify-end pt-4 border-t">
           <SkeletonButton className="w-24" />
         </div>

--- a/apps/web/components/skeletons/settings-skeletons.tsx
+++ b/apps/web/components/skeletons/settings-skeletons.tsx
@@ -33,6 +33,8 @@ export function AgentPageSkeleton() {
       <div className="space-y-6 py-4">
         <ProviderKeySectionSkeleton />
         <CustomInstructionsEditorSkeleton />
+        <SkillsSectionSkeleton />
+        <ToolCallLimitSkeleton />
         <AvailableMcpServersSkeleton />
       </div>
     </motion.div>
@@ -182,6 +184,62 @@ export function AvailableMcpServersSkeleton() {
               </div>
             </div>
           </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SkillsSectionSkeleton() {
+  return (
+    <Card className="border rounded-md overflow-hidden">
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-3 w-64" />
+          </div>
+          <div className="flex gap-2">
+            <SkeletonButton className="w-24" />
+            <SkeletonButton className="w-24" />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {[...Array(2)].map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-3 p-3 border rounded-lg"
+            >
+              <Skeleton className="h-8 w-8 rounded" />
+              <div className="flex-1 space-y-1">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+              <Skeleton className="h-8 w-8" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ToolCallLimitSkeleton() {
+  return (
+    <Card className="border rounded-md overflow-hidden">
+      <CardHeader>
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-3 w-72 mt-1" />
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-end gap-3">
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+          <SkeletonButton className="w-16" />
         </div>
       </CardContent>
     </Card>

--- a/apps/web/components/skeletons/settings-skeletons.tsx
+++ b/apps/web/components/skeletons/settings-skeletons.tsx
@@ -11,13 +11,24 @@ export function SettingsPageSkeleton() {
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="flex flex-col px-2 sm:px-4 max-w-4xl"
+      className="flex gap-8 px-2 sm:px-4 max-w-6xl mx-auto"
     >
-      <div className="space-y-6 py-4">
-        <ProjectNameSkeleton />
-        <APIKeyListSkeleton />
-        <OAuthSettingsSkeleton />
-        <DangerZoneSkeleton />
+      <div className="hidden lg:block w-48 shrink-0 pt-2">
+        <Skeleton className="h-4 w-20 mb-3" />
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 w-28" />
+        </div>
+      </div>
+      <div className="flex-1 min-w-0 max-w-4xl">
+        <div className="space-y-6 py-4">
+          <ProjectNameSkeleton />
+          <APIKeyListSkeleton />
+          <OAuthSettingsSkeleton />
+          <DangerZoneSkeleton />
+        </div>
       </div>
     </motion.div>
   );
@@ -28,14 +39,26 @@ export function AgentPageSkeleton() {
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="flex flex-col px-2 sm:px-4 max-w-4xl"
+      className="flex gap-8 px-2 sm:px-4 max-w-6xl mx-auto"
     >
-      <div className="space-y-6 py-4">
-        <ProviderKeySectionSkeleton />
-        <CustomInstructionsEditorSkeleton />
-        <SkillsSectionSkeleton />
-        <ToolCallLimitSkeleton />
-        <AvailableMcpServersSkeleton />
+      <div className="hidden lg:block w-48 shrink-0 pt-2">
+        <Skeleton className="h-4 w-20 mb-3" />
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-36" />
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+      </div>
+      <div className="flex-1 min-w-0 max-w-4xl">
+        <div className="space-y-6 py-4">
+          <CustomInstructionsEditorSkeleton />
+          <SkillsSectionSkeleton />
+          <ToolCallLimitSkeleton />
+          <AvailableMcpServersSkeleton />
+          <ProviderKeySectionSkeleton />
+        </div>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary

- Adds a new **Agent** top-level tab (`/[projectId]/agent`) for AI agent configuration: model, custom instructions, skills, tool call limit, and MCP servers
- Slims the **Settings** tab to project infrastructure only: project name, API keys, authentication, and danger zone (delete)
- Removes the sidebar navigation in favor of flat card stacks on each page
- Extracts project name editing and project deletion into dedicated section components (`ProjectNameSection`, `DangerZoneSection`)
- Updates the `building-settings-ui` Claude Code skill to reflect the new tab-based architecture

Fixes TAM-1479

## Test plan

- [ ] Navigate to Agent tab; verify Model, Custom Instructions, Skills, Tool Call Limit, and MCP sections render and function
- [ ] Navigate to Settings tab; verify Name, API Keys, Authentication, and Danger Zone sections render and function
- [ ] Edit project name from the Name section card (save/cancel/enter/escape)
- [ ] Delete project from Danger Zone section (confirmation dialog, redirect)
- [ ] Verify tab highlighting tracks correctly when switching between Overview, Observability, Agent, Settings
- [ ] Check mobile viewport for both Agent and Settings pages (no sidebar, cards stack vertically)
- [ ] Verify skeleton loading states render for both pages

| AGENT | SETTINGS |
| --- | --- |
| <img width="1202" height="2368" alt="image" src="https://github.com/user-attachments/assets/c72814c0-ee6d-4442-9443-150b07ca4373" /> | <img width="1212" height="2074" alt="image" src="https://github.com/user-attachments/assets/5a803f1c-292a-41fb-97b5-dad700ad586a" /> |