### PR TITLE
feat(showcase): add static examples and try-it-yourself guides to generative components

### DIFF
--- a/showcase/src/app/components/(generative)/form/page.tsx
+++ b/showcase/src/app/components/(generative)/form/page.tsx
@@ -3,6 +3,7 @@
 import { ComponentCodePreview } from "@/components/component-code-preview";
 import { FormChatInterface } from "@/components/generative/FormChatInterface";
 import { InstallationSection } from "@/components/installation-section";
+import { SyntaxHighlighter } from "@/components/ui/syntax-highlighter";
 import { FormComponent } from "@tambo-ai/ui-registry/components/form";
 
 export default function FormComponentPage() {
@@ -187,9 +188,9 @@ export function FormDemo() {
             <h3 className="text-lg font-500 text-foreground">
               2. Register with Tambo
             </h3>
-            <pre className="rounded-md border border-border bg-muted/40 p-4">
-              <code className="text-sm text-foreground">
-                {`import { FormComponent, formSchema } from "@/components/tambo/form";
+            <SyntaxHighlighter
+              language="tsx"
+              code={`import { FormComponent, formSchema } from "@/components/tambo/form";
 import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
@@ -208,8 +209,7 @@ export function App() {
 
   return <MessageThreadFull />;
 }`}
-              </code>
-            </pre>
+            />
           </div>
 
           {/* Step 3 */}

--- a/showcase/src/app/components/(generative)/form/page.tsx
+++ b/showcase/src/app/components/(generative)/form/page.tsx
@@ -3,6 +3,7 @@
 import { ComponentCodePreview } from "@/components/component-code-preview";
 import { FormChatInterface } from "@/components/generative/FormChatInterface";
 import { InstallationSection } from "@/components/installation-section";
+import { FormComponent } from "@tambo-ai/ui-registry/components/form";
 
 export default function FormComponentPage() {
   return (
@@ -19,25 +20,60 @@ export default function FormComponentPage() {
         </p>
       </header>
 
-      {/* Examples Section */}
+      {/* Example Section */}
       <section className="space-y-6">
-        <h2 className="text-2xl font-semibold">Examples</h2>
-
-        <p className="text-sm text-muted-foreground">
-          This interactive demo runs inside the showcase&apos;s app-level
-          TamboProvider, which sets a per-user context key (persisted in
-          localStorage).
-        </p>
+        <h2 className="text-2xl font-semibold">Example</h2>
 
         <div className="space-y-6">
           <ComponentCodePreview
             title="Contact Form"
-            component={<FormChatInterface />}
-            code={`import { Form } from "@/components/tambo/form";
+            component={
+              <FormComponent
+                fields={[
+                  {
+                    id: "name",
+                    label: "Name",
+                    type: "text",
+                    required: true,
+                    placeholder: "Enter your name",
+                  },
+                  {
+                    id: "email",
+                    label: "Email",
+                    type: "email",
+                    required: true,
+                    placeholder: "your.email@example.com",
+                  },
+                  {
+                    id: "phone",
+                    label: "Phone",
+                    type: "text",
+                    placeholder: "(555) 123-4567",
+                  },
+                  {
+                    id: "message",
+                    label: "Message",
+                    type: "textarea",
+                    required: true,
+                    placeholder: "How can we help?",
+                  },
+                  {
+                    id: "contactMethod",
+                    label: "Preferred Contact Method",
+                    type: "select",
+                    options: ["Email", "Phone", "Either"],
+                  },
+                ]}
+                variant="bordered"
+                layout="relaxed"
+                onSubmit={(data) => console.log(data)}
+              />
+            }
+            code={`import { FormComponent } from "@/components/tambo/form";
 
 export function ContactForm() {
   return (
-    <Form
+    <FormComponent
       fields={[
         {
           id: "name",
@@ -79,6 +115,44 @@ export function ContactForm() {
     />
   );
 }`}
+            previewClassName="p-8"
+          />
+        </div>
+      </section>
+
+      {/* Interactive Demo Section */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold">Interactive Demo</h2>
+
+        <p className="text-sm text-muted-foreground">
+          Use natural language to generate and modify forms in real time. This
+          interactive demo runs inside the showcase&apos;s app-level
+          TamboProvider, which sets a per-user context key (persisted in
+          localStorage).
+        </p>
+
+        <div className="space-y-6">
+          <ComponentCodePreview
+            title="AI-Generated Form"
+            component={<FormChatInterface />}
+            code={`import { FormComponent, formSchema } from "@/components/tambo/form";
+import { useTambo } from "@tambo-ai/react";
+import { useEffect } from "react";
+
+export function FormDemo() {
+  const { registerComponent } = useTambo();
+
+  useEffect(() => {
+    registerComponent({
+      name: "FormComponent",
+      description: "A dynamic form builder component.",
+      component: FormComponent,
+      propsSchema: formSchema,
+    });
+  }, [registerComponent]);
+
+  return <MessageThreadFull />;
+}`}
             previewClassName="p-0"
             minHeight={700}
           />
@@ -88,6 +162,74 @@ export function ContactForm() {
       {/* Installation */}
       <section>
         <InstallationSection cliCommand="npx tambo add form" />
+      </section>
+
+      {/* Try It Yourself */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold">Try It Yourself</h2>
+
+        <div className="not-prose space-y-6">
+          {/* Step 1 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              1. Install the component
+            </h3>
+            <pre className="rounded-md border border-border bg-muted/40 p-4">
+              <code className="text-sm text-foreground">
+                npx tambo add form
+              </code>
+            </pre>
+          </div>
+
+          {/* Step 2 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              2. Register with Tambo
+            </h3>
+            <pre className="rounded-md border border-border bg-muted/40 p-4">
+              <code className="text-sm text-foreground">
+                {`import { FormComponent, formSchema } from "@/components/tambo/form";
+import { useTambo } from "@tambo-ai/react";
+import { useEffect } from "react";
+
+const { registerComponent } = useTambo();
+
+useEffect(() => {
+  registerComponent({
+    name: "FormComponent",
+    description: "A dynamic form builder component.",
+    component: FormComponent,
+    propsSchema: formSchema,
+  });
+}, [registerComponent]);`}
+              </code>
+            </pre>
+          </div>
+
+          {/* Step 3 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              3. Send a prompt
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Try these example prompts:
+            </p>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              <li>
+                &rarr; &quot;Create a contact form with name, email, and message
+                fields&quot;
+              </li>
+              <li>
+                &rarr; &quot;Build a survey with radio buttons and a dropdown
+                for age range&quot;
+              </li>
+              <li>
+                &rarr; &quot;Make a compact registration form with email and
+                password validation&quot;
+              </li>
+            </ul>
+          </div>
+        </div>
       </section>
 
       {/* Component API */}

--- a/showcase/src/app/components/(generative)/form/page.tsx
+++ b/showcase/src/app/components/(generative)/form/page.tsx
@@ -136,6 +136,7 @@ export function ContactForm() {
             title="AI-Generated Form"
             component={<FormChatInterface />}
             code={`import { FormComponent, formSchema } from "@/components/tambo/form";
+import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
 
@@ -189,19 +190,24 @@ export function FormDemo() {
             <pre className="rounded-md border border-border bg-muted/40 p-4">
               <code className="text-sm text-foreground">
                 {`import { FormComponent, formSchema } from "@/components/tambo/form";
+import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
 
-const { registerComponent } = useTambo();
+export function App() {
+  const { registerComponent } = useTambo();
 
-useEffect(() => {
-  registerComponent({
-    name: "FormComponent",
-    description: "A dynamic form builder component.",
-    component: FormComponent,
-    propsSchema: formSchema,
-  });
-}, [registerComponent]);`}
+  useEffect(() => {
+    registerComponent({
+      name: "FormComponent",
+      description: "A dynamic form builder component.",
+      component: FormComponent,
+      propsSchema: formSchema,
+    });
+  }, [registerComponent]);
+
+  return <MessageThreadFull />;
+}`}
               </code>
             </pre>
           </div>

--- a/showcase/src/app/components/(generative)/graph/page.tsx
+++ b/showcase/src/app/components/(generative)/graph/page.tsx
@@ -3,6 +3,7 @@
 import { ComponentCodePreview } from "@/components/component-code-preview";
 import { InstallationSection } from "@/components/installation-section";
 import { GraphChatInterface } from "@/components/generative/GraphChatInterface";
+import { SyntaxHighlighter } from "@/components/ui/syntax-highlighter";
 import { Graph } from "@tambo-ai/ui-registry/components/graph";
 
 export default function GraphPage() {
@@ -151,9 +152,9 @@ export function GraphDemo() {
             <h3 className="text-lg font-500 text-foreground">
               2. Register with Tambo
             </h3>
-            <pre className="rounded-md border border-border bg-muted/40 p-4">
-              <code className="text-sm text-foreground">
-                {`import { Graph, graphSchema } from "@/components/tambo/graph";
+            <SyntaxHighlighter
+              language="tsx"
+              code={`import { Graph, graphSchema } from "@/components/tambo/graph";
 import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
@@ -172,8 +173,7 @@ export function App() {
 
   return <MessageThreadFull />;
 }`}
-              </code>
-            </pre>
+            />
           </div>
 
           {/* Step 3 */}

--- a/showcase/src/app/components/(generative)/graph/page.tsx
+++ b/showcase/src/app/components/(generative)/graph/page.tsx
@@ -100,6 +100,7 @@ export function QuarterlySalesChart() {
             title="AI-Generated Chart"
             component={<GraphChatInterface />}
             code={`import { Graph, graphSchema } from "@/components/tambo/graph";
+import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
 
@@ -153,19 +154,24 @@ export function GraphDemo() {
             <pre className="rounded-md border border-border bg-muted/40 p-4">
               <code className="text-sm text-foreground">
                 {`import { Graph, graphSchema } from "@/components/tambo/graph";
+import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
 
-const { registerComponent } = useTambo();
+export function App() {
+  const { registerComponent } = useTambo();
 
-useEffect(() => {
-  registerComponent({
-    name: "Graph",
-    description: "A versatile data visualization component.",
-    component: Graph,
-    propsSchema: graphSchema,
-  });
-}, [registerComponent]);`}
+  useEffect(() => {
+    registerComponent({
+      name: "Graph",
+      description: "A versatile data visualization component.",
+      component: Graph,
+      propsSchema: graphSchema,
+    });
+  }, [registerComponent]);
+
+  return <MessageThreadFull />;
+}`}
               </code>
             </pre>
           </div>

--- a/showcase/src/app/components/(generative)/graph/page.tsx
+++ b/showcase/src/app/components/(generative)/graph/page.tsx
@@ -3,6 +3,7 @@
 import { ComponentCodePreview } from "@/components/component-code-preview";
 import { InstallationSection } from "@/components/installation-section";
 import { GraphChatInterface } from "@/components/generative/GraphChatInterface";
+import { Graph } from "@tambo-ai/ui-registry/components/graph";
 
 export default function GraphPage() {
   return (
@@ -19,20 +20,37 @@ export default function GraphPage() {
         </p>
       </header>
 
-      {/* Examples Section */}
+      {/* Example Section */}
       <section className="space-y-6">
-        <h2 className="text-2xl font-semibold">Examples</h2>
-
-        <p className="text-sm text-muted-foreground">
-          This interactive demo runs inside the showcase&apos;s app-level
-          TamboProvider, which sets a per-user context key (persisted in
-          localStorage).
-        </p>
+        <h2 className="text-2xl font-semibold">Example</h2>
 
         <div className="space-y-6">
           <ComponentCodePreview
             title="Quarterly Sales Chart"
-            component={<GraphChatInterface />}
+            component={
+              <Graph
+                title="Quarterly Sales"
+                data={{
+                  type: "bar",
+                  labels: ["Q1", "Q2", "Q3", "Q4"],
+                  datasets: [
+                    {
+                      label: "Revenue",
+                      data: [120000, 150000, 180000, 200000],
+                      color: "hsl(160, 82%, 47%)",
+                    },
+                    {
+                      label: "Expenses",
+                      data: [80000, 95000, 110000, 125000],
+                      color: "hsl(340, 82%, 66%)",
+                    },
+                  ],
+                }}
+                variant="bordered"
+                size="lg"
+                showLegend={true}
+              />
+            }
             code={`import { Graph } from "@/components/tambo/graph";
 
 export function QuarterlySalesChart() {
@@ -61,6 +79,44 @@ export function QuarterlySalesChart() {
     />
   );
 }`}
+            previewClassName="p-8"
+          />
+        </div>
+      </section>
+
+      {/* Interactive Demo Section */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold">Interactive Demo</h2>
+
+        <p className="text-sm text-muted-foreground">
+          Use natural language to generate and modify charts in real time. This
+          interactive demo runs inside the showcase&apos;s app-level
+          TamboProvider, which sets a per-user context key (persisted in
+          localStorage).
+        </p>
+
+        <div className="space-y-6">
+          <ComponentCodePreview
+            title="AI-Generated Chart"
+            component={<GraphChatInterface />}
+            code={`import { Graph, graphSchema } from "@/components/tambo/graph";
+import { useTambo } from "@tambo-ai/react";
+import { useEffect } from "react";
+
+export function GraphDemo() {
+  const { registerComponent } = useTambo();
+
+  useEffect(() => {
+    registerComponent({
+      name: "Graph",
+      description: "A versatile data visualization component.",
+      component: Graph,
+      propsSchema: graphSchema,
+    });
+  }, [registerComponent]);
+
+  return <MessageThreadFull />;
+}`}
             previewClassName="p-0"
             minHeight={700}
           />
@@ -70,6 +126,73 @@ export function QuarterlySalesChart() {
       {/* Installation */}
       <section>
         <InstallationSection cliCommand="npx tambo add graph" />
+      </section>
+
+      {/* Try It Yourself */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold">Try It Yourself</h2>
+
+        <div className="not-prose space-y-6">
+          {/* Step 1 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              1. Install the component
+            </h3>
+            <pre className="rounded-md border border-border bg-muted/40 p-4">
+              <code className="text-sm text-foreground">
+                npx tambo add graph
+              </code>
+            </pre>
+          </div>
+
+          {/* Step 2 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              2. Register with Tambo
+            </h3>
+            <pre className="rounded-md border border-border bg-muted/40 p-4">
+              <code className="text-sm text-foreground">
+                {`import { Graph, graphSchema } from "@/components/tambo/graph";
+import { useTambo } from "@tambo-ai/react";
+import { useEffect } from "react";
+
+const { registerComponent } = useTambo();
+
+useEffect(() => {
+  registerComponent({
+    name: "Graph",
+    description: "A versatile data visualization component.",
+    component: Graph,
+    propsSchema: graphSchema,
+  });
+}, [registerComponent]);`}
+              </code>
+            </pre>
+          </div>
+
+          {/* Step 3 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              3. Send a prompt
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Try these example prompts:
+            </p>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              <li>
+                &rarr; &quot;Create a bar chart of monthly revenue for Q1&quot;
+              </li>
+              <li>
+                &rarr; &quot;Show a line chart comparing signups vs activations
+                over 6 months&quot;
+              </li>
+              <li>
+                &rarr; &quot;Make a pie chart of traffic sources: organic, paid,
+                and referral&quot;
+              </li>
+            </ul>
+          </div>
+        </div>
       </section>
 
       {/* Component API */}

--- a/showcase/src/app/components/(generative)/input-fields/page.tsx
+++ b/showcase/src/app/components/(generative)/input-fields/page.tsx
@@ -3,6 +3,7 @@
 import { ComponentCodePreview } from "@/components/component-code-preview";
 import { InstallationSection } from "@/components/installation-section";
 import { InputFieldsChatInterface } from "@/components/generative/InputFieldsChatInterface";
+import { SyntaxHighlighter } from "@/components/ui/syntax-highlighter";
 import { InputFields } from "@tambo-ai/ui-registry/components/input-fields";
 
 export default function InputFieldsComponentPage() {
@@ -205,9 +206,12 @@ export function InputFieldsDemo() {
             <h3 className="text-lg font-500 text-foreground">
               2. Register with Tambo
             </h3>
-            <pre className="rounded-md border border-border bg-muted/40 p-4">
-              <code className="text-sm text-foreground">
-                {`import { InputFields, inputFieldsSchema } from "@/components/tambo/input-fields";
+            <SyntaxHighlighter
+              language="tsx"
+              code={`import {
+  InputFields,
+  inputFieldsSchema,
+} from "@/components/tambo/input-fields";
 import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
@@ -226,8 +230,7 @@ export function App() {
 
   return <MessageThreadFull />;
 }`}
-              </code>
-            </pre>
+            />
           </div>
 
           {/* Step 3 */}

--- a/showcase/src/app/components/(generative)/input-fields/page.tsx
+++ b/showcase/src/app/components/(generative)/input-fields/page.tsx
@@ -3,6 +3,7 @@
 import { ComponentCodePreview } from "@/components/component-code-preview";
 import { InstallationSection } from "@/components/installation-section";
 import { InputFieldsChatInterface } from "@/components/generative/InputFieldsChatInterface";
+import { InputFields } from "@tambo-ai/ui-registry/components/input-fields";
 
 export default function InputFieldsComponentPage() {
   return (
@@ -20,20 +21,62 @@ export default function InputFieldsComponentPage() {
         </p>
       </header>
 
-      {/* Examples Section */}
+      {/* Example Section */}
       <section className="space-y-6">
-        <h2 className="text-2xl font-semibold">Examples</h2>
-
-        <p className="text-sm text-muted-foreground">
-          This interactive demo runs inside the showcase&apos;s app-level
-          TamboProvider, which sets a per-user context key (persisted in
-          localStorage).
-        </p>
+        <h2 className="text-2xl font-semibold">Example</h2>
 
         <div className="space-y-6">
           <ComponentCodePreview
             title="User Registration Fields"
-            component={<InputFieldsChatInterface />}
+            component={
+              <InputFields
+                fields={[
+                  {
+                    id: "username",
+                    label: "Username",
+                    type: "text",
+                    required: true,
+                    placeholder: "Enter username",
+                    minLength: 3,
+                    maxLength: 20,
+                    pattern: "^[a-zA-Z0-9]+$",
+                    description: "Must be 3-20 alphanumeric characters",
+                    autoComplete: "username",
+                  },
+                  {
+                    id: "email",
+                    label: "Email",
+                    type: "email",
+                    required: true,
+                    placeholder: "your.email@example.com",
+                    description: "We'll use this for account notifications",
+                    autoComplete: "email",
+                  },
+                  {
+                    id: "password",
+                    label: "Password",
+                    type: "password",
+                    required: true,
+                    placeholder: "Create strong password",
+                    minLength: 8,
+                    maxLength: 128,
+                    description: "Must be at least 8 characters long",
+                    autoComplete: "new-password",
+                  },
+                  {
+                    id: "age",
+                    label: "Age",
+                    type: "number",
+                    placeholder: "25",
+                    minLength: 1,
+                    maxLength: 3,
+                    description: "Must be between 1-150",
+                  },
+                ]}
+                variant="solid"
+                layout="compact"
+              />
+            }
             code={`import { InputFields } from "@/components/tambo/input-fields";
 
 export function UserRegistrationFields() {
@@ -73,15 +116,6 @@ export function UserRegistrationFields() {
           autoComplete: "new-password",
         },
         {
-          id: "phone",
-          label: "Phone",
-          type: "text",
-          placeholder: "(555) 123-4567",
-          pattern: "^\\([0-9]{3}\\) [0-9]{3}-[0-9]{4}$",
-          description: "Optional: for account recovery",
-          autoComplete: "tel",
-        },
-        {
           id: "age",
           label: "Age",
           type: "number",
@@ -96,6 +130,47 @@ export function UserRegistrationFields() {
     />
   );
 }`}
+            previewClassName="p-8"
+          />
+        </div>
+      </section>
+
+      {/* Interactive Demo Section */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold">Interactive Demo</h2>
+
+        <p className="text-sm text-muted-foreground">
+          Use natural language to generate and modify input fields in real time.
+          This interactive demo runs inside the showcase&apos;s app-level
+          TamboProvider, which sets a per-user context key (persisted in
+          localStorage).
+        </p>
+
+        <div className="space-y-6">
+          <ComponentCodePreview
+            title="AI-Generated Input Fields"
+            component={<InputFieldsChatInterface />}
+            code={`import {
+  InputFields,
+  inputFieldsSchema,
+} from "@/components/tambo/input-fields";
+import { useTambo } from "@tambo-ai/react";
+import { useEffect } from "react";
+
+export function InputFieldsDemo() {
+  const { registerComponent } = useTambo();
+
+  useEffect(() => {
+    registerComponent({
+      name: "InputFields",
+      description: "A focused collection of input fields.",
+      component: InputFields,
+      propsSchema: inputFieldsSchema,
+    });
+  }, [registerComponent]);
+
+  return <MessageThreadFull />;
+}`}
             previewClassName="p-0"
             minHeight={700}
           />
@@ -105,6 +180,74 @@ export function UserRegistrationFields() {
       {/* Installation */}
       <section>
         <InstallationSection cliCommand="npx tambo add input-fields" />
+      </section>
+
+      {/* Try It Yourself */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold">Try It Yourself</h2>
+
+        <div className="not-prose space-y-6">
+          {/* Step 1 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              1. Install the component
+            </h3>
+            <pre className="rounded-md border border-border bg-muted/40 p-4">
+              <code className="text-sm text-foreground">
+                npx tambo add input-fields
+              </code>
+            </pre>
+          </div>
+
+          {/* Step 2 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              2. Register with Tambo
+            </h3>
+            <pre className="rounded-md border border-border bg-muted/40 p-4">
+              <code className="text-sm text-foreground">
+                {`import { InputFields, inputFieldsSchema } from "@/components/tambo/input-fields";
+import { useTambo } from "@tambo-ai/react";
+import { useEffect } from "react";
+
+const { registerComponent } = useTambo();
+
+useEffect(() => {
+  registerComponent({
+    name: "InputFields",
+    description: "A focused collection of input fields.",
+    component: InputFields,
+    propsSchema: inputFieldsSchema,
+  });
+}, [registerComponent]);`}
+              </code>
+            </pre>
+          </div>
+
+          {/* Step 3 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              3. Send a prompt
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Try these example prompts:
+            </p>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              <li>
+                &rarr; &quot;Create sign-up fields with email and password
+                validation&quot;
+              </li>
+              <li>
+                &rarr; &quot;Add a phone field with pattern validation and
+                helper text&quot;
+              </li>
+              <li>
+                &rarr; &quot;Build a profile editor with username, email, and
+                age inputs&quot;
+              </li>
+            </ul>
+          </div>
+        </div>
       </section>
 
       {/* Component API */}

--- a/showcase/src/app/components/(generative)/input-fields/page.tsx
+++ b/showcase/src/app/components/(generative)/input-fields/page.tsx
@@ -154,6 +154,7 @@ export function UserRegistrationFields() {
   InputFields,
   inputFieldsSchema,
 } from "@/components/tambo/input-fields";
+import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
 
@@ -207,19 +208,24 @@ export function InputFieldsDemo() {
             <pre className="rounded-md border border-border bg-muted/40 p-4">
               <code className="text-sm text-foreground">
                 {`import { InputFields, inputFieldsSchema } from "@/components/tambo/input-fields";
+import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
 
-const { registerComponent } = useTambo();
+export function App() {
+  const { registerComponent } = useTambo();
 
-useEffect(() => {
-  registerComponent({
-    name: "InputFields",
-    description: "A focused collection of input fields.",
-    component: InputFields,
-    propsSchema: inputFieldsSchema,
-  });
-}, [registerComponent]);`}
+  useEffect(() => {
+    registerComponent({
+      name: "InputFields",
+      description: "A focused collection of input fields.",
+      component: InputFields,
+      propsSchema: inputFieldsSchema,
+    });
+  }, [registerComponent]);
+
+  return <MessageThreadFull />;
+}`}
               </code>
             </pre>
           </div>

--- a/showcase/src/app/components/(generative)/map/page.tsx
+++ b/showcase/src/app/components/(generative)/map/page.tsx
@@ -3,6 +3,12 @@
 import { ComponentCodePreview } from "@/components/component-code-preview";
 import { InstallationSection } from "@/components/installation-section";
 import { MapChatInterface } from "@/components/generative/MapChatInterface";
+import dynamic from "next/dynamic";
+
+const Map = dynamic(
+  async () => (await import("@tambo-ai/ui-registry/components/map")).Map,
+  { ssr: false },
+);
 
 export default function MapPage() {
   return (
@@ -19,23 +25,51 @@ export default function MapPage() {
         </p>
       </header>
 
-      {/* Examples Section */}
+      {/* Example Section */}
       <section className="space-y-6">
-        <h2 className="text-2xl font-semibold">Examples</h2>
-
-        <p className="text-sm text-muted-foreground">
-          This interactive demo runs inside the showcase&apos;s app-level
-          TamboProvider, which sets a per-user context key (persisted in
-          localStorage).
-        </p>
+        <h2 className="text-2xl font-semibold">Example</h2>
 
         <div className="space-y-6">
           <ComponentCodePreview
-            title="Seattle Coffee Map"
-            component={<MapChatInterface />}
+            title="Seattle Landmarks"
+            component={
+              <Map
+                center={{ lat: 47.6062, lng: -122.3321 }}
+                zoom={12}
+                markers={[
+                  {
+                    lat: 47.6097,
+                    lng: -122.3417,
+                    label: "Pike Place Market",
+                  },
+                  {
+                    lat: 47.6205,
+                    lng: -122.3493,
+                    label: "Space Needle",
+                  },
+                  {
+                    lat: 47.6553,
+                    lng: -122.3035,
+                    label: "University of Washington",
+                  },
+                  {
+                    lat: 47.6247,
+                    lng: -122.3207,
+                    label: "Capitol Hill",
+                  },
+                  {
+                    lat: 47.6513,
+                    lng: -122.3471,
+                    label: "Fremont Troll",
+                  },
+                ]}
+                size="lg"
+                zoomControl={true}
+              />
+            }
             code={`import { Map } from "@/components/tambo/map";
 
-export function SeattleCoffeeMap() {
+export function SeattleLandmarks() {
   return (
     <Map
       center={{ lat: 47.6062, lng: -122.3321 }}
@@ -52,8 +86,47 @@ export function SeattleCoffeeMap() {
         { lat: 47.6513, lng: -122.3471, label: "Fremont Troll" },
       ]}
       size="lg"
+      zoomControl={true}
     />
   );
+}`}
+            previewClassName="p-8"
+          />
+        </div>
+      </section>
+
+      {/* Interactive Demo Section */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold">Interactive Demo</h2>
+
+        <p className="text-sm text-muted-foreground">
+          Use natural language to generate and modify maps in real time. This
+          interactive demo runs inside the showcase&apos;s app-level
+          TamboProvider, which sets a per-user context key (persisted in
+          localStorage).
+        </p>
+
+        <div className="space-y-6">
+          <ComponentCodePreview
+            title="AI-Generated Map"
+            component={<MapChatInterface />}
+            code={`import { Map, mapSchema } from "@/components/tambo/map";
+import { useTambo } from "@tambo-ai/react";
+import { useEffect } from "react";
+
+export function MapDemo() {
+  const { registerComponent } = useTambo();
+
+  useEffect(() => {
+    registerComponent({
+      name: "Map",
+      description: "Interactive map for visualizing geographic data.",
+      component: Map,
+      propsSchema: mapSchema,
+    });
+  }, [registerComponent]);
+
+  return <MessageThreadFull />;
 }`}
             previewClassName="p-0"
             minHeight={700}
@@ -64,6 +137,71 @@ export function SeattleCoffeeMap() {
       {/* Installation */}
       <section>
         <InstallationSection cliCommand="npx tambo add map" />
+      </section>
+
+      {/* Try It Yourself */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold">Try It Yourself</h2>
+
+        <div className="not-prose space-y-6">
+          {/* Step 1 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              1. Install the component
+            </h3>
+            <pre className="rounded-md border border-border bg-muted/40 p-4">
+              <code className="text-sm text-foreground">npx tambo add map</code>
+            </pre>
+          </div>
+
+          {/* Step 2 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              2. Register with Tambo
+            </h3>
+            <pre className="rounded-md border border-border bg-muted/40 p-4">
+              <code className="text-sm text-foreground">
+                {`import { Map, mapSchema } from "@/components/tambo/map";
+import { useTambo } from "@tambo-ai/react";
+import { useEffect } from "react";
+
+const { registerComponent } = useTambo();
+
+useEffect(() => {
+  registerComponent({
+    name: "Map",
+    description: "Interactive map for visualizing geographic data.",
+    component: Map,
+    propsSchema: mapSchema,
+  });
+}, [registerComponent]);`}
+              </code>
+            </pre>
+          </div>
+
+          {/* Step 3 */}
+          <div className="space-y-3">
+            <h3 className="text-lg font-500 text-foreground">
+              3. Send a prompt
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Try these example prompts:
+            </p>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              <li>
+                &rarr; &quot;Plot offices in New York, Austin, and Seattle&quot;
+              </li>
+              <li>
+                &rarr; &quot;Show a map of coffee shops around downtown
+                Portland&quot;
+              </li>
+              <li>
+                &rarr; &quot;Create a heatmap of support ticket hotspots in San
+                Francisco&quot;
+              </li>
+            </ul>
+          </div>
+        </div>
       </section>
 
       {/* Component API */}

--- a/showcase/src/app/components/(generative)/map/page.tsx
+++ b/showcase/src/app/components/(generative)/map/page.tsx
@@ -111,6 +111,7 @@ export function SeattleLandmarks() {
             title="AI-Generated Map"
             component={<MapChatInterface />}
             code={`import { Map, mapSchema } from "@/components/tambo/map";
+import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
 
@@ -162,19 +163,24 @@ export function MapDemo() {
             <pre className="rounded-md border border-border bg-muted/40 p-4">
               <code className="text-sm text-foreground">
                 {`import { Map, mapSchema } from "@/components/tambo/map";
+import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
 
-const { registerComponent } = useTambo();
+export function App() {
+  const { registerComponent } = useTambo();
 
-useEffect(() => {
-  registerComponent({
-    name: "Map",
-    description: "Interactive map for visualizing geographic data.",
-    component: Map,
-    propsSchema: mapSchema,
-  });
-}, [registerComponent]);`}
+  useEffect(() => {
+    registerComponent({
+      name: "Map",
+      description: "Interactive map for visualizing geographic data.",
+      component: Map,
+      propsSchema: mapSchema,
+    });
+  }, [registerComponent]);
+
+  return <MessageThreadFull />;
+}`}
               </code>
             </pre>
           </div>

--- a/showcase/src/app/components/(generative)/map/page.tsx
+++ b/showcase/src/app/components/(generative)/map/page.tsx
@@ -3,6 +3,7 @@
 import { ComponentCodePreview } from "@/components/component-code-preview";
 import { InstallationSection } from "@/components/installation-section";
 import { MapChatInterface } from "@/components/generative/MapChatInterface";
+import { SyntaxHighlighter } from "@/components/ui/syntax-highlighter";
 import dynamic from "next/dynamic";
 
 const Map = dynamic(
@@ -160,9 +161,9 @@ export function MapDemo() {
             <h3 className="text-lg font-500 text-foreground">
               2. Register with Tambo
             </h3>
-            <pre className="rounded-md border border-border bg-muted/40 p-4">
-              <code className="text-sm text-foreground">
-                {`import { Map, mapSchema } from "@/components/tambo/map";
+            <SyntaxHighlighter
+              language="tsx"
+              code={`import { Map, mapSchema } from "@/components/tambo/map";
 import { MessageThreadFull } from "@/components/tambo/message-thread-full";
 import { useTambo } from "@tambo-ai/react";
 import { useEffect } from "react";
@@ -181,8 +182,7 @@ export function App() {
 
   return <MessageThreadFull />;
 }`}
-              </code>
-            </pre>
+            />
           </div>
 
           {/* Step 3 */}


### PR DESCRIPTION
## Summary
- Adds static rendered examples to each generative component page (form, graph, input-fields, map) so users see the component immediately without interacting with the AI chat
- Adds "Try It Yourself" sections with step-by-step instructions: install via CLI, register with `useTambo`/`registerComponent`, and example prompts to send
- Relabels existing chat interfaces as "Interactive Demo" with context about natural language usage

Fixes TAM-846

## Test plan
- [ ] Visit each component page in showcase (`/components/form`, `/components/graph`, `/components/input-fields`, `/components/map`, `/components/canvas-space`) and verify:
  - Static example renders immediately with correct props
  - Interactive demo still works (chat interface functional)
  - Try It Yourself steps show correct install command, registration code, and example prompts
- [ ] Verify map page handles SSR correctly (uses `next/dynamic` with `ssr: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)