### PR TITLE
feat(web): register Skills component and tools with Tambo

### DIFF
--- a/apps/web/components/dashboard-components/project-details/skill-form.tsx
+++ b/apps/web/components/dashboard-components/project-details/skill-form.tsx
@@ -116,17 +116,15 @@ export function SkillForm({
   // Sync form fields as Tambo streams in updated initialFields
   useEffect(() => {
     if (initialFields?.name !== undefined) setName(initialFields.name);
-  }, [initialFields?.name]);
-
-  useEffect(() => {
     if (initialFields?.description !== undefined)
       setDescription(initialFields.description);
-  }, [initialFields?.description]);
-
-  useEffect(() => {
     if (initialFields?.instructions !== undefined)
       setInstructions(initialFields.instructions);
-  }, [initialFields?.instructions]);
+  }, [
+    initialFields?.name,
+    initialFields?.description,
+    initialFields?.instructions,
+  ]);
 
   const handlePasteWithFrontmatter = useCallback((e: React.ClipboardEvent) => {
     const text = e.clipboardData.getData("text/plain");

--- a/apps/web/components/dashboard-components/project-details/skill-form.tsx
+++ b/apps/web/components/dashboard-components/project-details/skill-form.tsx
@@ -10,7 +10,7 @@ import { api } from "@/trpc/react";
 import { extractErrorMessage } from "@/lib/extract-error-message";
 import { parseSkillContent, toSkillSlug } from "@tambo-ai-cloud/core";
 import { Loader2 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export type SkillSummary = RouterOutputs["skills"]["list"][number];
 
@@ -112,6 +112,21 @@ export function SkillForm({
   const [instructions, setInstructions] = useState(
     initialFields?.instructions ?? skill?.instructions ?? "",
   );
+
+  // Sync form fields as Tambo streams in updated initialFields
+  useEffect(() => {
+    if (initialFields?.name !== undefined) setName(initialFields.name);
+  }, [initialFields?.name]);
+
+  useEffect(() => {
+    if (initialFields?.description !== undefined)
+      setDescription(initialFields.description);
+  }, [initialFields?.description]);
+
+  useEffect(() => {
+    if (initialFields?.instructions !== undefined)
+      setInstructions(initialFields.instructions);
+  }, [initialFields?.instructions]);
 
   const handlePasteWithFrontmatter = useCallback((e: React.ClipboardEvent) => {
     const text = e.clipboardData.getData("text/plain");

--- a/apps/web/components/dashboard-components/project-details/skill-form.tsx
+++ b/apps/web/components/dashboard-components/project-details/skill-form.tsx
@@ -238,7 +238,10 @@ export function SkillForm({
         >
           {saveMutation.isPending ? (
             <>
-              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              <Loader2
+                className="mr-2 h-4 w-4 animate-spin"
+                aria-hidden="true"
+              />
               Saving...
             </>
           ) : (

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -143,21 +143,21 @@ export function SkillsSection({
     isError,
   } = api.skills.list.useQuery({ projectId });
 
-  const [isFormOpen, setIsFormOpen] = useState(!!defaultNewSkill);
+  const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingSkill, setEditingSkill] = useState<SkillSummary | null>(null);
   const [importedFields, setImportedFields] = useState<
     { name: string; description: string; instructions: string } | undefined
-  >(defaultNewSkill);
+  >(undefined);
 
-  // Track the prop reference that was dismissed so we skip re-renders from cache
-  // invalidation but allow new requests from Tambo (which create new object references)
-  const dismissedNewSkillRef = useRef<typeof defaultNewSkill>(undefined);
-  const dismissedEditSkillRef = useRef<typeof defaultEditSkill>(undefined);
+  // Track dismissed Tambo-driven forms by stable string IDs so cache
+  // invalidations (which produce new array refs) don't reopen the form
+  const dismissedNewSkillNameRef = useRef<string | null>(null);
+  const dismissedEditSkillIdRef = useRef<string | null>(null);
 
   // When Tambo streams in a new defaultNewSkill, open the create form automatically
   useEffect(() => {
-    if (!defaultNewSkill || defaultNewSkill === dismissedNewSkillRef.current)
-      return;
+    if (!defaultNewSkill) return;
+    if (dismissedNewSkillNameRef.current === defaultNewSkill.name) return;
     setEditingSkill(null);
     setImportedFields(defaultNewSkill);
     setIsFormOpen(true);
@@ -165,8 +165,8 @@ export function SkillsSection({
 
   // When Tambo streams in a defaultEditSkill, find the existing skill and open the edit form
   useEffect(() => {
-    if (!defaultEditSkill || !skills) return;
-    if (defaultEditSkill === dismissedEditSkillRef.current) return;
+    if (!defaultEditSkill || !skills || isFormOpen) return;
+    if (dismissedEditSkillIdRef.current === defaultEditSkill.skillId) return;
     const existing = skills.find((s) => s.id === defaultEditSkill.skillId);
     if (!existing) return;
     setEditingSkill(existing);
@@ -176,7 +176,8 @@ export function SkillsSection({
       instructions: defaultEditSkill.instructions ?? existing.instructions,
     });
     setIsFormOpen(true);
-  }, [defaultEditSkill, skills]);
+  }, [defaultEditSkill, skills, isFormOpen]);
+
   const [togglingSkillId, setTogglingSkillId] = useState<string | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [alertState, setAlertState] = useState<AlertState>({
@@ -248,10 +249,14 @@ export function SkillsSection({
   };
 
   const closeForm = () => {
-    // Store the current prop references so the useEffects skip re-renders
-    // from cache invalidation but still allow new Tambo requests
-    dismissedNewSkillRef.current = defaultNewSkill;
-    dismissedEditSkillRef.current = defaultEditSkill;
+    // Mark Tambo-driven forms as dismissed by stable string IDs so
+    // cache invalidations don't reopen the form
+    if (defaultNewSkill) {
+      dismissedNewSkillNameRef.current = defaultNewSkill.name;
+    }
+    if (defaultEditSkill) {
+      dismissedEditSkillIdRef.current = defaultEditSkill.skillId;
+    }
     setIsFormOpen(false);
     setEditingSkill(null);
     setImportedFields(undefined);

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -163,9 +163,10 @@ export function SkillsSection({
     setIsFormOpen(true);
   }, [defaultNewSkill]);
 
-  // When Tambo streams in a defaultEditSkill, find the existing skill and open the edit form
+  // When Tambo streams in a defaultEditSkill, find the existing skill and open the edit form.
+  // Keep updating importedFields for the active skillId so streamed field values propagate.
   useEffect(() => {
-    if (!defaultEditSkill || !skills || isFormOpen) return;
+    if (!defaultEditSkill || !skills) return;
     if (dismissedEditSkillIdRef.current === defaultEditSkill.skillId) return;
     const existing = skills.find((s) => s.id === defaultEditSkill.skillId);
     if (!existing) return;
@@ -175,7 +176,9 @@ export function SkillsSection({
       description: defaultEditSkill.description ?? existing.description,
       instructions: defaultEditSkill.instructions ?? existing.instructions,
     });
-    setIsFormOpen(true);
+    if (!isFormOpen) {
+      setIsFormOpen(true);
+    }
   }, [defaultEditSkill, skills, isFormOpen]);
 
   const [togglingSkillId, setTogglingSkillId] = useState<string | null>(null);

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -149,10 +149,10 @@ export function SkillsSection({
     { name: string; description: string; instructions: string } | undefined
   >(undefined);
 
-  // Track the dismissed prop reference so cache invalidations (same ref) are
-  // suppressed but new Tambo requests (new ref, even for the same skill) reopen
-  const dismissedNewSkillRef = useRef<typeof defaultNewSkill>(undefined);
-  const dismissedEditSkillRef = useRef<typeof defaultEditSkill>(undefined);
+  // Track the last-seen prop so we only react to genuine changes, not re-mounts
+  // with stale props from a previous Tambo response
+  const prevNewSkillRef = useRef(defaultNewSkill);
+  const prevEditSkillRef = useRef(defaultEditSkill);
 
   // Keep a ref to the latest skills so the edit effect can look up skills
   // without re-firing on every cache invalidation
@@ -161,8 +161,8 @@ export function SkillsSection({
 
   // When Tambo streams in a new defaultNewSkill, open the create form automatically
   useEffect(() => {
-    if (!defaultNewSkill || defaultNewSkill === dismissedNewSkillRef.current)
-      return;
+    if (!defaultNewSkill || defaultNewSkill === prevNewSkillRef.current) return;
+    prevNewSkillRef.current = defaultNewSkill;
     setEditingSkill(null);
     setImportedFields(defaultNewSkill);
     setIsFormOpen(true);
@@ -171,8 +171,9 @@ export function SkillsSection({
   // When Tambo streams in a defaultEditSkill, find the existing skill and open the edit form.
   // Uses skillsRef to avoid re-firing on cache invalidation of the skills list.
   useEffect(() => {
-    if (!defaultEditSkill) return;
-    if (defaultEditSkill === dismissedEditSkillRef.current) return;
+    if (!defaultEditSkill || defaultEditSkill === prevEditSkillRef.current)
+      return;
+    prevEditSkillRef.current = defaultEditSkill;
     const currentSkills = skillsRef.current;
     if (!currentSkills) return;
     const existing = currentSkills.find(
@@ -262,10 +263,6 @@ export function SkillsSection({
   };
 
   const closeForm = () => {
-    // Store the current prop references so cache invalidation re-renders
-    // (same ref) are suppressed, but new Tambo requests (new ref) reopen
-    dismissedNewSkillRef.current = defaultNewSkill;
-    dismissedEditSkillRef.current = defaultEditSkill;
     setIsFormOpen(false);
     setEditingSkill(null);
     setImportedFields(undefined);

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -154,6 +154,11 @@ export function SkillsSection({
   const dismissedNewSkillRef = useRef<typeof defaultNewSkill>(undefined);
   const dismissedEditSkillRef = useRef<typeof defaultEditSkill>(undefined);
 
+  // Keep a ref to the latest skills so the edit effect can look up skills
+  // without re-firing on every cache invalidation
+  const skillsRef = useRef(skills);
+  skillsRef.current = skills;
+
   // When Tambo streams in a new defaultNewSkill, open the create form automatically
   useEffect(() => {
     if (!defaultNewSkill || defaultNewSkill === dismissedNewSkillRef.current)
@@ -164,11 +169,15 @@ export function SkillsSection({
   }, [defaultNewSkill]);
 
   // When Tambo streams in a defaultEditSkill, find the existing skill and open the edit form.
-  // Keep updating importedFields for the active skillId so streamed field values propagate.
+  // Uses skillsRef to avoid re-firing on cache invalidation of the skills list.
   useEffect(() => {
-    if (!defaultEditSkill || !skills) return;
+    if (!defaultEditSkill) return;
     if (defaultEditSkill === dismissedEditSkillRef.current) return;
-    const existing = skills.find((s) => s.id === defaultEditSkill.skillId);
+    const currentSkills = skillsRef.current;
+    if (!currentSkills) return;
+    const existing = currentSkills.find(
+      (s) => s.id === defaultEditSkill.skillId,
+    );
     if (!existing) return;
     setEditingSkill(existing);
     setImportedFields({
@@ -179,7 +188,7 @@ export function SkillsSection({
     if (!isFormOpen) {
       setIsFormOpen(true);
     }
-  }, [defaultEditSkill, skills, isFormOpen]);
+  }, [defaultEditSkill, isFormOpen]);
 
   const [togglingSkillId, setTogglingSkillId] = useState<string | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -162,18 +162,19 @@ export function SkillsSection({
   // When Tambo streams in a new defaultNewSkill, open the create form automatically
   useEffect(() => {
     if (!defaultNewSkill || defaultNewSkill === prevNewSkillRef.current) return;
-    prevNewSkillRef.current = defaultNewSkill;
     setEditingSkill(null);
     setImportedFields(defaultNewSkill);
     setIsFormOpen(true);
+    prevNewSkillRef.current = defaultNewSkill;
   }, [defaultNewSkill]);
 
   // When Tambo streams in a defaultEditSkill, find the existing skill and open the edit form.
   // Uses skillsRef to avoid re-firing on cache invalidation of the skills list.
+  // The ref is only updated after the success path so that if skills haven't
+  // loaded yet, the effect retries on the next render.
   useEffect(() => {
     if (!defaultEditSkill || defaultEditSkill === prevEditSkillRef.current)
       return;
-    prevEditSkillRef.current = defaultEditSkill;
     const currentSkills = skillsRef.current;
     if (!currentSkills) return;
     const existing = currentSkills.find(
@@ -186,10 +187,9 @@ export function SkillsSection({
       description: defaultEditSkill.description ?? existing.description,
       instructions: defaultEditSkill.instructions ?? existing.instructions,
     });
-    if (!isFormOpen) {
-      setIsFormOpen(true);
-    }
-  }, [defaultEditSkill, isFormOpen]);
+    setIsFormOpen(true);
+    prevEditSkillRef.current = defaultEditSkill;
+  }, [defaultEditSkill]);
 
   const [togglingSkillId, setTogglingSkillId] = useState<string | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -149,13 +149,15 @@ export function SkillsSection({
     { name: string; description: string; instructions: string } | undefined
   >(defaultNewSkill);
 
-  // Track whether Tambo-driven forms have been dismissed so we don't reopen them
-  const dismissedNewSkillRef = useRef(false);
-  const dismissedEditSkillIdRef = useRef<string | null>(null);
+  // Track the prop reference that was dismissed so we skip re-renders from cache
+  // invalidation but allow new requests from Tambo (which create new object references)
+  const dismissedNewSkillRef = useRef<typeof defaultNewSkill>(undefined);
+  const dismissedEditSkillRef = useRef<typeof defaultEditSkill>(undefined);
 
   // When Tambo streams in a new defaultNewSkill, open the create form automatically
   useEffect(() => {
-    if (!defaultNewSkill || dismissedNewSkillRef.current) return;
+    if (!defaultNewSkill || defaultNewSkill === dismissedNewSkillRef.current)
+      return;
     setEditingSkill(null);
     setImportedFields(defaultNewSkill);
     setIsFormOpen(true);
@@ -164,7 +166,7 @@ export function SkillsSection({
   // When Tambo streams in a defaultEditSkill, find the existing skill and open the edit form
   useEffect(() => {
     if (!defaultEditSkill || !skills) return;
-    if (dismissedEditSkillIdRef.current === defaultEditSkill.skillId) return;
+    if (defaultEditSkill === dismissedEditSkillRef.current) return;
     const existing = skills.find((s) => s.id === defaultEditSkill.skillId);
     if (!existing) return;
     setEditingSkill(existing);
@@ -246,13 +248,10 @@ export function SkillsSection({
   };
 
   const closeForm = () => {
-    // Mark Tambo-driven forms as dismissed so the useEffects don't reopen them
-    if (defaultNewSkill) {
-      dismissedNewSkillRef.current = true;
-    }
-    if (defaultEditSkill) {
-      dismissedEditSkillIdRef.current = defaultEditSkill.skillId;
-    }
+    // Store the current prop references so the useEffects skip re-renders
+    // from cache invalidation but still allow new Tambo requests
+    dismissedNewSkillRef.current = defaultNewSkill;
+    dismissedEditSkillRef.current = defaultEditSkill;
     setIsFormOpen(false);
     setEditingSkill(null);
     setImportedFields(undefined);

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -149,15 +149,15 @@ export function SkillsSection({
     { name: string; description: string; instructions: string } | undefined
   >(undefined);
 
-  // Track dismissed Tambo-driven forms by stable string IDs so cache
-  // invalidations (which produce new array refs) don't reopen the form
-  const dismissedNewSkillNameRef = useRef<string | null>(null);
-  const dismissedEditSkillIdRef = useRef<string | null>(null);
+  // Track the dismissed prop reference so cache invalidations (same ref) are
+  // suppressed but new Tambo requests (new ref, even for the same skill) reopen
+  const dismissedNewSkillRef = useRef<typeof defaultNewSkill>(undefined);
+  const dismissedEditSkillRef = useRef<typeof defaultEditSkill>(undefined);
 
   // When Tambo streams in a new defaultNewSkill, open the create form automatically
   useEffect(() => {
-    if (!defaultNewSkill) return;
-    if (dismissedNewSkillNameRef.current === defaultNewSkill.name) return;
+    if (!defaultNewSkill || defaultNewSkill === dismissedNewSkillRef.current)
+      return;
     setEditingSkill(null);
     setImportedFields(defaultNewSkill);
     setIsFormOpen(true);
@@ -167,7 +167,7 @@ export function SkillsSection({
   // Keep updating importedFields for the active skillId so streamed field values propagate.
   useEffect(() => {
     if (!defaultEditSkill || !skills) return;
-    if (dismissedEditSkillIdRef.current === defaultEditSkill.skillId) return;
+    if (defaultEditSkill === dismissedEditSkillRef.current) return;
     const existing = skills.find((s) => s.id === defaultEditSkill.skillId);
     if (!existing) return;
     setEditingSkill(existing);
@@ -253,14 +253,10 @@ export function SkillsSection({
   };
 
   const closeForm = () => {
-    // Mark Tambo-driven forms as dismissed by stable string IDs so
-    // cache invalidations don't reopen the form
-    if (defaultNewSkill) {
-      dismissedNewSkillNameRef.current = defaultNewSkill.name;
-    }
-    if (defaultEditSkill) {
-      dismissedEditSkillIdRef.current = defaultEditSkill.skillId;
-    }
+    // Store the current prop references so cache invalidation re-renders
+    // (same ref) are suppressed, but new Tambo requests (new ref) reopen
+    dismissedNewSkillRef.current = defaultNewSkill;
+    dismissedEditSkillRef.current = defaultEditSkill;
     setIsFormOpen(false);
     setEditingSkill(null);
     setImportedFields(undefined);

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -31,7 +31,7 @@ import { api } from "@/trpc/react";
 import { withTamboInteractable } from "@tambo-ai/react";
 import { AnimatePresence, motion } from "framer-motion";
 import { AlertTriangle, FileText, Import, Plus } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { z } from "zod/v3";
 import {
   type AlertState,
@@ -55,6 +55,12 @@ interface SkillsSectionProps {
     name: string;
     description: string;
     instructions: string;
+  };
+  defaultEditSkill?: {
+    skillId: string;
+    name?: string;
+    description?: string;
+    instructions?: string;
   };
 }
 
@@ -108,6 +114,7 @@ export function SkillsSection({
   defaultLlmProviderName,
   defaultLlmModelName,
   defaultNewSkill,
+  defaultEditSkill,
 }: SkillsSectionProps) {
   const isProviderSupported =
     !defaultLlmProviderName ||
@@ -140,7 +147,34 @@ export function SkillsSection({
   const [editingSkill, setEditingSkill] = useState<SkillSummary | null>(null);
   const [importedFields, setImportedFields] = useState<
     { name: string; description: string; instructions: string } | undefined
-  >(undefined);
+  >(defaultNewSkill);
+
+  // Track whether Tambo-driven forms have been dismissed so we don't reopen them
+  const dismissedNewSkillRef = useRef(false);
+  const dismissedEditSkillIdRef = useRef<string | null>(null);
+
+  // When Tambo streams in a new defaultNewSkill, open the create form automatically
+  useEffect(() => {
+    if (!defaultNewSkill || dismissedNewSkillRef.current) return;
+    setEditingSkill(null);
+    setImportedFields(defaultNewSkill);
+    setIsFormOpen(true);
+  }, [defaultNewSkill]);
+
+  // When Tambo streams in a defaultEditSkill, find the existing skill and open the edit form
+  useEffect(() => {
+    if (!defaultEditSkill || !skills) return;
+    if (dismissedEditSkillIdRef.current === defaultEditSkill.skillId) return;
+    const existing = skills.find((s) => s.id === defaultEditSkill.skillId);
+    if (!existing) return;
+    setEditingSkill(existing);
+    setImportedFields({
+      name: defaultEditSkill.name ?? existing.name,
+      description: defaultEditSkill.description ?? existing.description,
+      instructions: defaultEditSkill.instructions ?? existing.instructions,
+    });
+    setIsFormOpen(true);
+  }, [defaultEditSkill, skills]);
   const [togglingSkillId, setTogglingSkillId] = useState<string | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [alertState, setAlertState] = useState<AlertState>({
@@ -212,6 +246,13 @@ export function SkillsSection({
   };
 
   const closeForm = () => {
+    // Mark Tambo-driven forms as dismissed so the useEffects don't reopen them
+    if (defaultNewSkill) {
+      dismissedNewSkillRef.current = true;
+    }
+    if (defaultEditSkill) {
+      dismissedEditSkillIdRef.current = defaultEditSkill.skillId;
+    }
     setIsFormOpen(false);
     setEditingSkill(null);
     setImportedFields(undefined);
@@ -558,7 +599,7 @@ export function SkillsSection({
   );
 }
 
-const InteractableSkillsSectionProps = z.object({
+export const InteractableSkillsSectionProps = z.object({
   projectId: z.string().describe("The unique identifier for the project."),
   defaultLlmProviderName: z
     .string()
@@ -581,6 +622,23 @@ const InteractableSkillsSectionProps = z.object({
     .optional()
     .describe(
       "Optional default fields for a new skill, used when creating a skill via Tambo.",
+    ),
+  defaultEditSkill: z
+    .object({
+      skillId: z.string().describe("The ID of the existing skill to edit."),
+      name: z.string().optional().describe("The updated name for the skill."),
+      description: z
+        .string()
+        .optional()
+        .describe("The updated description for the skill."),
+      instructions: z
+        .string()
+        .optional()
+        .describe("The updated instructions for the skill."),
+    })
+    .optional()
+    .describe(
+      "Optional fields to edit an existing skill. When set, the edit form opens pre-filled with the updated values. Use fetchProjectSkills first to get the skill ID.",
     ),
 });
 

--- a/apps/web/components/dashboard-components/project-details/skills-section.tsx
+++ b/apps/web/components/dashboard-components/project-details/skills-section.tsx
@@ -188,15 +188,16 @@ export function SkillsSection({
   const [cardDragState, setCardDragState] = useState<DragState>("none");
 
   // Overwrite confirmation state
+  const overwriteDialogClosed = {
+    isOpen: false as const,
+    existingSkill: null,
+    fields: { name: "", description: "", instructions: "" },
+  };
   const [overwriteDialog, setOverwriteDialog] = useState<{
     isOpen: boolean;
     existingSkill: SkillSummary | null;
     fields: { name: string; description: string; instructions: string };
-  }>({
-    isOpen: false,
-    existingSkill: null,
-    fields: { name: "", description: "", instructions: "" },
-  });
+  }>(overwriteDialogClosed);
 
   const toggleMutation = api.skills.update.useMutation({
     onMutate: ({ skillId }) => {
@@ -310,19 +311,11 @@ export function SkillsSection({
 
   const handleOverwriteConfirm = () => {
     openFormWithFields(overwriteDialog.fields, overwriteDialog.existingSkill);
-    setOverwriteDialog({
-      isOpen: false,
-      existingSkill: null,
-      fields: { name: "", description: "", instructions: "" },
-    });
+    setOverwriteDialog(overwriteDialogClosed);
   };
 
   const handleOverwriteCancel = () => {
-    setOverwriteDialog({
-      isOpen: false,
-      existingSkill: null,
-      fields: { name: "", description: "", instructions: "" },
-    });
+    setOverwriteDialog(overwriteDialogClosed);
   };
 
   const handleImportClick = () => {

--- a/apps/web/lib/schemas/skills.ts
+++ b/apps/web/lib/schemas/skills.ts
@@ -1,0 +1,85 @@
+import {
+  SKILL_NAME_MAX_LENGTH,
+  SKILL_NAME_PATTERN,
+  SKILL_DESCRIPTION_MAX_LENGTH,
+  SKILL_INSTRUCTIONS_MAX_LENGTH,
+} from "@tambo-ai-cloud/core";
+import { z } from "zod/v3";
+
+/**
+ * Shared schemas for skill operations.
+ * Used by both tRPC routers and tool definitions.
+ */
+
+// Input schemas
+export const listSkillsInput = z.object({
+  projectId: z.string().describe("The project ID to list skills for"),
+});
+
+export const createSkillInput = z.object({
+  projectId: z.string().describe("The project ID to create the skill in"),
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(SKILL_NAME_MAX_LENGTH)
+    .regex(
+      SKILL_NAME_PATTERN,
+      "Name must be kebab-case (e.g. scheduling-assistant)",
+    )
+    .describe("The skill name in kebab-case (e.g. scheduling-assistant)"),
+  description: z
+    .string()
+    .min(1, "Description is required")
+    .max(SKILL_DESCRIPTION_MAX_LENGTH)
+    .describe("A short description of what the skill does"),
+  instructions: z
+    .string()
+    .max(SKILL_INSTRUCTIONS_MAX_LENGTH)
+    .describe("The full instructions for the skill"),
+});
+
+export const updateSkillInput = z.object({
+  projectId: z.string().describe("The project ID containing the skill"),
+  skillId: z.string().describe("The skill ID to update"),
+  name: z
+    .string()
+    .min(1)
+    .max(SKILL_NAME_MAX_LENGTH)
+    .regex(
+      SKILL_NAME_PATTERN,
+      "Name must be kebab-case (e.g. scheduling-assistant)",
+    )
+    .optional()
+    .describe("New name for the skill (kebab-case)"),
+  description: z
+    .string()
+    .min(1)
+    .max(SKILL_DESCRIPTION_MAX_LENGTH)
+    .optional()
+    .describe("New description for the skill"),
+  instructions: z
+    .string()
+    .max(SKILL_INSTRUCTIONS_MAX_LENGTH)
+    .optional()
+    .describe("New instructions for the skill"),
+  enabled: z.boolean().optional().describe("Whether the skill is enabled"),
+});
+
+export const deleteSkillInput = z.object({
+  projectId: z.string().describe("The project ID containing the skill"),
+  skillId: z.string().describe("The skill ID to delete"),
+});
+
+// Output schemas
+export const skillSchema = z.object({
+  id: z.string().describe("The unique skill identifier"),
+  projectId: z.string().describe("The project this skill belongs to"),
+  name: z.string().describe("The skill name"),
+  description: z.string().describe("The skill description"),
+  instructions: z.string().describe("The skill instructions"),
+  enabled: z.boolean().describe("Whether the skill is enabled"),
+  usageCount: z.number().describe("How many times the skill has been used"),
+  lastUsedAt: z.date().nullable().describe("When the skill was last used"),
+  createdAt: z.date().describe("When the skill was created"),
+  updatedAt: z.date().describe("When the skill was last updated"),
+});

--- a/apps/web/lib/tambo/config.ts
+++ b/apps/web/lib/tambo/config.ts
@@ -37,6 +37,10 @@ import {
   ProjectTableContainerSchema,
 } from "@/components/dashboard-components/project-table-container";
 import {
+  SkillsSection,
+  InteractableSkillsSectionProps,
+} from "@/components/dashboard-components/project-details/skills-section";
+import {
   ThreadTableContainer,
   ThreadTableContainerSchema,
 } from "@/components/observability/thread-table/thread-table-container";
@@ -111,5 +115,12 @@ export const tamboRegisteredComponents = [
       "A component that allows users to manage API keys for their project. Users can view existing API keys, create new keys with custom names, and delete keys they no longer need. Each key is displayed with its creation date and preview, and newly created keys are shown once for copying.",
     component: APIKeyList,
     propsSchema: InteractableAPIKeyListProps,
+  },
+  {
+    name: "Skills",
+    description:
+      "A component that allows users to manage agent skills for their project. Users can create, edit, delete, toggle, and import skills from SKILL.md files. To create a new skill, render with `defaultNewSkill` containing `name`, `description`, and `instructions`. To edit an existing skill, render with `defaultEditSkill` containing `skillId` and the updated fields - the edit form opens pre-filled so the user can review and save. Requires a project ID and optionally accepts default LLM provider/model names to check skill support.",
+    component: SkillsSection,
+    propsSchema: InteractableSkillsSectionProps,
   },
 ];

--- a/apps/web/lib/tambo/tools/helpers.ts
+++ b/apps/web/lib/tambo/tools/helpers.ts
@@ -46,3 +46,13 @@ export async function invalidateMcpServersCache(
 ) {
   await ctx.utils.tools.listMcpServers.invalidate({ projectId });
 }
+
+/**
+ * Helper to invalidate skills cache for a specific project
+ */
+export async function invalidateSkillsCache(
+  ctx: ToolContext,
+  projectId: string,
+) {
+  await ctx.utils.skills.list.invalidate({ projectId });
+}

--- a/apps/web/lib/tambo/tools/skills-tools.ts
+++ b/apps/web/lib/tambo/tools/skills-tools.ts
@@ -10,46 +10,6 @@ import { invalidateSkillsCache } from "./helpers";
 import type { RegisterToolFn, ToolContext } from "./types";
 
 /**
- * Input schema for the `fetchProjectSkills` tool.
- */
-export const fetchProjectSkillsInputSchema = listSkillsInput;
-
-/**
- * Output schema for the `fetchProjectSkills` tool.
- */
-export const fetchProjectSkillsOutputSchema = z.array(skillSchema);
-
-/**
- * Input schema for the `createSkill` tool.
- */
-export const createSkillInputSchema = createSkillInput;
-
-/**
- * Output schema for the `createSkill` tool.
- */
-export const createSkillOutputSchema = skillSchema;
-
-/**
- * Input schema for the `updateSkill` tool.
- */
-export const updateSkillInputSchema = updateSkillInput;
-
-/**
- * Output schema for the `updateSkill` tool.
- */
-export const updateSkillOutputSchema = skillSchema.nullable();
-
-/**
- * Input schema for the `deleteSkill` tool.
- */
-export const deleteSkillInputSchema = deleteSkillInput;
-
-/**
- * Output schema for the `deleteSkill` tool.
- */
-export const deleteSkillOutputSchema = z.void();
-
-/**
  * Register skill management tools
  */
 export function registerSkillTools(
@@ -67,8 +27,8 @@ export function registerSkillTools(
     tool: async (params) => {
       return await ctx.trpcClient.skills.list.query(params);
     },
-    inputSchema: fetchProjectSkillsInputSchema,
-    outputSchema: fetchProjectSkillsOutputSchema,
+    inputSchema: listSkillsInput,
+    outputSchema: z.array(skillSchema),
   });
 
   /**
@@ -84,8 +44,8 @@ export function registerSkillTools(
       await invalidateSkillsCache(ctx, params.projectId);
       return result;
     },
-    inputSchema: createSkillInputSchema,
-    outputSchema: createSkillOutputSchema,
+    inputSchema: createSkillInput,
+    outputSchema: skillSchema,
   });
 
   /**
@@ -101,8 +61,8 @@ export function registerSkillTools(
       await invalidateSkillsCache(ctx, params.projectId);
       return result;
     },
-    inputSchema: updateSkillInputSchema,
-    outputSchema: updateSkillOutputSchema,
+    inputSchema: updateSkillInput,
+    outputSchema: skillSchema.nullable(),
   });
 
   /**
@@ -118,7 +78,7 @@ export function registerSkillTools(
       await ctx.trpcClient.skills.delete.mutate(params);
       await invalidateSkillsCache(ctx, params.projectId);
     },
-    inputSchema: deleteSkillInputSchema,
-    outputSchema: deleteSkillOutputSchema,
+    inputSchema: deleteSkillInput,
+    outputSchema: z.void(),
   });
 }

--- a/apps/web/lib/tambo/tools/skills-tools.ts
+++ b/apps/web/lib/tambo/tools/skills-tools.ts
@@ -18,17 +18,21 @@ export function registerSkillTools(
 ) {
   /**
    * Registers a tool to fetch all skills for a project.
-   * @returns Array of skills for the project
+   * @returns Object with skills array and count
    */
   registerTool({
     name: "fetchProjectSkills",
     description:
       "Fetches all skills for a project. Returns an array of skills with their IDs, names, descriptions, enabled status, and usage counts.",
     tool: async (params) => {
-      return await ctx.trpcClient.skills.list.query(params);
+      const skills = await ctx.trpcClient.skills.list.query(params);
+      return { skills, count: skills.length };
     },
     inputSchema: listSkillsInput,
-    outputSchema: z.array(skillSchema),
+    outputSchema: z.object({
+      skills: z.array(skillSchema),
+      count: z.number().describe("Total number of skills"),
+    }),
   });
 
   /**
@@ -40,12 +44,15 @@ export function registerSkillTools(
     description:
       "Creates a new skill for a project. The name must be kebab-case (e.g. scheduling-assistant). Returns the created skill.",
     tool: async (params) => {
-      const result = await ctx.trpcClient.skills.create.mutate(params);
+      const skill = await ctx.trpcClient.skills.create.mutate(params);
       await invalidateSkillsCache(ctx, params.projectId);
-      return result;
+      return { success: true, skill };
     },
     inputSchema: createSkillInput,
-    outputSchema: skillSchema,
+    outputSchema: z.object({
+      success: z.boolean(),
+      skill: skillSchema,
+    }),
   });
 
   /**
@@ -57,18 +64,21 @@ export function registerSkillTools(
     description:
       "Updates an existing skill for a project. Can update name, description, instructions, or enabled status. Returns the updated skill.",
     tool: async (params) => {
-      const result = await ctx.trpcClient.skills.update.mutate(params);
+      const skill = await ctx.trpcClient.skills.update.mutate(params);
       await invalidateSkillsCache(ctx, params.projectId);
-      return result;
+      return { success: true, skill };
     },
     inputSchema: updateSkillInput,
-    outputSchema: skillSchema.nullable(),
+    outputSchema: z.object({
+      success: z.boolean(),
+      skill: skillSchema.nullable(),
+    }),
   });
 
   /**
    * Registers a tool to delete a skill.
    * IMPORTANT: Always call fetchProjectSkills first to get the correct skill ID.
-   * @returns void
+   * @returns Confirmation of deletion
    */
   registerTool({
     name: "deleteSkill",
@@ -77,8 +87,9 @@ export function registerSkillTools(
     tool: async (params) => {
       await ctx.trpcClient.skills.delete.mutate(params);
       await invalidateSkillsCache(ctx, params.projectId);
+      return { success: true };
     },
     inputSchema: deleteSkillInput,
-    outputSchema: z.void(),
+    outputSchema: z.object({ success: z.boolean() }),
   });
 }

--- a/apps/web/lib/tambo/tools/skills-tools.ts
+++ b/apps/web/lib/tambo/tools/skills-tools.ts
@@ -10,6 +10,46 @@ import { invalidateSkillsCache } from "./helpers";
 import type { RegisterToolFn, ToolContext } from "./types";
 
 /**
+ * Input schema for the `fetchProjectSkills` tool.
+ */
+export const fetchProjectSkillsInputSchema = listSkillsInput;
+
+/**
+ * Output schema for the `fetchProjectSkills` tool.
+ */
+export const fetchProjectSkillsOutputSchema = z.array(skillSchema);
+
+/**
+ * Input schema for the `createSkill` tool.
+ */
+export const createSkillInputSchema = createSkillInput;
+
+/**
+ * Output schema for the `createSkill` tool.
+ */
+export const createSkillOutputSchema = skillSchema;
+
+/**
+ * Input schema for the `updateSkill` tool.
+ */
+export const updateSkillInputSchema = updateSkillInput;
+
+/**
+ * Output schema for the `updateSkill` tool.
+ */
+export const updateSkillOutputSchema = skillSchema.nullable();
+
+/**
+ * Input schema for the `deleteSkill` tool.
+ */
+export const deleteSkillInputSchema = deleteSkillInput;
+
+/**
+ * Output schema for the `deleteSkill` tool.
+ */
+export const deleteSkillOutputSchema = z.void();
+
+/**
  * Register skill management tools
  */
 export function registerSkillTools(
@@ -27,8 +67,8 @@ export function registerSkillTools(
     tool: async (params) => {
       return await ctx.trpcClient.skills.list.query(params);
     },
-    inputSchema: listSkillsInput,
-    outputSchema: z.array(skillSchema),
+    inputSchema: fetchProjectSkillsInputSchema,
+    outputSchema: fetchProjectSkillsOutputSchema,
   });
 
   /**
@@ -44,8 +84,8 @@ export function registerSkillTools(
       await invalidateSkillsCache(ctx, params.projectId);
       return result;
     },
-    inputSchema: createSkillInput,
-    outputSchema: skillSchema,
+    inputSchema: createSkillInputSchema,
+    outputSchema: createSkillOutputSchema,
   });
 
   /**
@@ -61,8 +101,8 @@ export function registerSkillTools(
       await invalidateSkillsCache(ctx, params.projectId);
       return result;
     },
-    inputSchema: updateSkillInput,
-    outputSchema: skillSchema.nullable(),
+    inputSchema: updateSkillInputSchema,
+    outputSchema: updateSkillOutputSchema,
   });
 
   /**
@@ -78,7 +118,7 @@ export function registerSkillTools(
       await ctx.trpcClient.skills.delete.mutate(params);
       await invalidateSkillsCache(ctx, params.projectId);
     },
-    inputSchema: deleteSkillInput,
-    outputSchema: z.void(),
+    inputSchema: deleteSkillInputSchema,
+    outputSchema: deleteSkillOutputSchema,
   });
 }

--- a/apps/web/lib/tambo/tools/skills-tools.ts
+++ b/apps/web/lib/tambo/tools/skills-tools.ts
@@ -1,0 +1,84 @@
+import {
+  createSkillInput,
+  deleteSkillInput,
+  listSkillsInput,
+  skillSchema,
+  updateSkillInput,
+} from "@/lib/schemas/skills";
+import { z } from "zod/v3";
+import { invalidateSkillsCache } from "./helpers";
+import type { RegisterToolFn, ToolContext } from "./types";
+
+/**
+ * Register skill management tools
+ */
+export function registerSkillTools(
+  registerTool: RegisterToolFn,
+  ctx: ToolContext,
+) {
+  /**
+   * Registers a tool to fetch all skills for a project.
+   * @returns Array of skills for the project
+   */
+  registerTool({
+    name: "fetchProjectSkills",
+    description:
+      "Fetches all skills for a project. Returns an array of skills with their IDs, names, descriptions, enabled status, and usage counts.",
+    tool: async (params) => {
+      return await ctx.trpcClient.skills.list.query(params);
+    },
+    inputSchema: listSkillsInput,
+    outputSchema: z.array(skillSchema),
+  });
+
+  /**
+   * Registers a tool to create a new skill for a project.
+   * @returns The created skill
+   */
+  registerTool({
+    name: "createSkill",
+    description:
+      "Creates a new skill for a project. The name must be kebab-case (e.g. scheduling-assistant). Returns the created skill.",
+    tool: async (params) => {
+      const result = await ctx.trpcClient.skills.create.mutate(params);
+      await invalidateSkillsCache(ctx, params.projectId);
+      return result;
+    },
+    inputSchema: createSkillInput,
+    outputSchema: skillSchema,
+  });
+
+  /**
+   * Registers a tool to update an existing skill.
+   * @returns The updated skill
+   */
+  registerTool({
+    name: "updateSkill",
+    description:
+      "Updates an existing skill for a project. Can update name, description, instructions, or enabled status. Returns the updated skill.",
+    tool: async (params) => {
+      const result = await ctx.trpcClient.skills.update.mutate(params);
+      await invalidateSkillsCache(ctx, params.projectId);
+      return result;
+    },
+    inputSchema: updateSkillInput,
+    outputSchema: skillSchema.nullable(),
+  });
+
+  /**
+   * Registers a tool to delete a skill.
+   * IMPORTANT: Always call fetchProjectSkills first to get the correct skill ID.
+   * @returns void
+   */
+  registerTool({
+    name: "deleteSkill",
+    description:
+      "Deletes a skill from a project. MUST call fetchProjectSkills first to get the correct skill ID - never guess the ID.",
+    tool: async (params) => {
+      await ctx.trpcClient.skills.delete.mutate(params);
+      await invalidateSkillsCache(ctx, params.projectId);
+    },
+    inputSchema: deleteSkillInput,
+    outputSchema: z.void(),
+  });
+}

--- a/apps/web/lib/tambo/tools/tool-registry.ts
+++ b/apps/web/lib/tambo/tools/tool-registry.ts
@@ -4,6 +4,7 @@ import { registerDashboardTools } from "./dashboard-tools";
 import { registerLlmTools } from "./llm-tools";
 import { registerMcpTools } from "./mcp-tools";
 import { registerProjectTools } from "./project-tools";
+import { registerSkillTools } from "./skills-tools";
 import type { RegisterToolFn, ToolContext } from "./types";
 import { registerUserTools } from "./user-tools";
 
@@ -38,4 +39,7 @@ export function registerAllTools(
 
   // Agent-specific settings
   registerAgentTools(registerTool, ctx);
+
+  // Skill management
+  registerSkillTools(registerTool, ctx);
 }

--- a/apps/web/server/api/routers/skills.ts
+++ b/apps/web/server/api/routers/skills.ts
@@ -107,9 +107,11 @@ async function updateSkillOnProviderAndPersist(
   existingRef:
     | { skillId: string; uploadedAt: string; version: string }
     | undefined,
+  provider?: { providerName: string; apiKey: string },
 ): Promise<void> {
-  const provider = await getProjectProviderKey(db, projectId);
-  if (!provider) return;
+  const resolvedProvider =
+    provider ?? (await getProjectProviderKey(db, projectId));
+  if (!resolvedProvider) return;
 
   try {
     // If we have an existing provider reference, update via versions.create().
@@ -117,18 +119,18 @@ async function updateSkillOnProviderAndPersist(
     const metadata = existingRef
       ? await updateSkillOnProvider({
           skill: { ...skill, projectId },
-          providerName: provider.providerName,
-          apiKey: provider.apiKey,
+          providerName: resolvedProvider.providerName,
+          apiKey: resolvedProvider.apiKey,
           existingRef,
         })
       : await uploadSkillToProvider({
           skill: { ...skill, projectId },
-          providerName: provider.providerName,
-          apiKey: provider.apiKey,
+          providerName: resolvedProvider.providerName,
+          apiKey: resolvedProvider.apiKey,
         });
 
     await operations.mergeSkillMetadata(db, projectId, skill.id, {
-      [provider.providerName]: metadata,
+      [resolvedProvider.providerName]: metadata,
     });
   } catch (error) {
     throw new TRPCError({
@@ -243,6 +245,7 @@ export const skillsRouter = createTRPCRouter({
             input.projectId,
             updated,
             existingRef,
+            provider ?? undefined,
           );
         } catch (error) {
           // Log but don't throw -- the DB update and metadata clear should

--- a/apps/web/server/api/routers/skills.ts
+++ b/apps/web/server/api/routers/skills.ts
@@ -1,4 +1,10 @@
 import { env } from "@/lib/env";
+import {
+  createSkillInput,
+  deleteSkillInput,
+  listSkillsInput,
+  updateSkillInput,
+} from "@/lib/schemas/skills";
 import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import {
   deleteSkillFromProvider,
@@ -6,17 +12,10 @@ import {
   updateSkillOnProvider,
   providerSupportsSkills,
 } from "@tambo-ai-cloud/backend";
-import {
-  decryptProviderKey,
-  SKILL_NAME_MAX_LENGTH,
-  SKILL_NAME_PATTERN,
-  SKILL_DESCRIPTION_MAX_LENGTH,
-  SKILL_INSTRUCTIONS_MAX_LENGTH,
-} from "@tambo-ai-cloud/core";
+import { decryptProviderKey } from "@tambo-ai-cloud/core";
 import { operations, schema, SkillNameConflictError } from "@tambo-ai-cloud/db";
 import { eq } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
-import { z } from "zod/v3";
 
 /**
  * Get the decrypted provider API key for the project's default LLM provider.
@@ -141,7 +140,7 @@ async function updateSkillOnProviderAndPersist(
 
 export const skillsRouter = createTRPCRouter({
   list: protectedProcedure
-    .input(z.object({ projectId: z.string() }))
+    .input(listSkillsInput)
     .query(async ({ ctx, input }) => {
       await operations.ensureProjectAccess(
         ctx.db,
@@ -152,24 +151,7 @@ export const skillsRouter = createTRPCRouter({
     }),
 
   create: protectedProcedure
-    .input(
-      z.object({
-        projectId: z.string(),
-        name: z
-          .string()
-          .min(1, "Name is required")
-          .max(SKILL_NAME_MAX_LENGTH)
-          .regex(
-            SKILL_NAME_PATTERN,
-            "Name must be kebab-case (e.g. scheduling-assistant)",
-          ),
-        description: z
-          .string()
-          .min(1, "Description is required")
-          .max(SKILL_DESCRIPTION_MAX_LENGTH),
-        instructions: z.string().max(SKILL_INSTRUCTIONS_MAX_LENGTH),
-      }),
-    )
+    .input(createSkillInput)
     .mutation(async ({ ctx, input }) => {
       await operations.ensureProjectAccess(
         ctx.db,
@@ -205,28 +187,7 @@ export const skillsRouter = createTRPCRouter({
     }),
 
   update: protectedProcedure
-    .input(
-      z.object({
-        projectId: z.string(),
-        skillId: z.string(),
-        name: z
-          .string()
-          .min(1)
-          .max(SKILL_NAME_MAX_LENGTH)
-          .regex(
-            SKILL_NAME_PATTERN,
-            "Name must be kebab-case (e.g. scheduling-assistant)",
-          )
-          .optional(),
-        description: z
-          .string()
-          .min(1)
-          .max(SKILL_DESCRIPTION_MAX_LENGTH)
-          .optional(),
-        instructions: z.string().max(SKILL_INSTRUCTIONS_MAX_LENGTH).optional(),
-        enabled: z.boolean().optional(),
-      }),
-    )
+    .input(updateSkillInput)
     .mutation(async ({ ctx, input }) => {
       await operations.ensureProjectAccess(
         ctx.db,
@@ -298,7 +259,7 @@ export const skillsRouter = createTRPCRouter({
     }),
 
   delete: protectedProcedure
-    .input(z.object({ projectId: z.string(), skillId: z.string() }))
+    .input(deleteSkillInput)
     .mutation(async ({ ctx, input }) => {
       await operations.ensureProjectAccess(
         ctx.db,


### PR DESCRIPTION
## Summary
- Register the Skills component with Tambo's component registry and add CRUD tools to the tool registry
- Add visual create/edit support via `defaultNewSkill` and `defaultEditSkill` props with streaming
- Fix SkillForm to sync fields as Tambo streams in updated values

Fixes TAM-1487

## Why
The Skills section was the only settings component not registered with Tambo's component and tool systems. This adds both visual (component rendering with streamed props) and programmatic (API tools) paths for managing skills, matching the pattern used by custom instructions and other settings components.

## Test Plan
- [x] Verify Tambo can render the Skills component with `defaultNewSkill` to open the create form pre-filled
- [x] Verify Tambo can render with `defaultEditSkill` to open the edit form for an existing skill
- [x] Verify closing the form does not cause it to reopen on cache invalidation
- [x] Verify `fetchProjectSkills`, `createSkill`, `updateSkill`, `deleteSkill` tools work via Tambo
- [x] Run `npm run check-types` and `npm run lint` pass