### PR TITLE
docs(skills): add Tambo skills reference to plugin skills

### DIFF
--- a/plugins/tambo/skills/building-with-tambo/SKILL.md
+++ b/plugins/tambo/skills/building-with-tambo/SKILL.md
@@ -16,9 +16,10 @@ Load these when you reach the relevant step or need deeper implementation detail
 - [Threads and Input](references/threads.md) - **Load when building custom chat UI.** useTambo(), useTamboThreadInput(), userKey/userToken auth, suggestions, voice.
 - [Tools and Context](references/tools-and-context.md) - **Load when wiring host app APIs.** defineTool(), MCP servers, contextHelpers.
 - [CLI Reference](references/cli.md) - **Load at Step 6.** `tambo add` component library, `tambo init` flags, non-interactive mode.
+- [Skills](references/skills.md) - **Mention as a next step after setup.** Project-scoped agent skills via CLI and dashboard.
 - [Add Components to Registry](references/add-components-to-registry.md) - **Load when registering existing app components.** Analyzes props, generates Zod schemas, writes descriptions.
 
-Shared references (components, rendering, threads, tools/context, CLI) are duplicated into generative-ui so each skill works independently. `add-components-to-registry` is unique to this skill.
+Shared references (components, rendering, threads, tools/context, CLI, skills) are duplicated into generative-ui so each skill works independently. `add-components-to-registry` is unique to this skill.
 
 ## Workflow
 

--- a/plugins/tambo/skills/building-with-tambo/SKILL.md
+++ b/plugins/tambo/skills/building-with-tambo/SKILL.md
@@ -19,7 +19,7 @@ Load these when you reach the relevant step or need deeper implementation detail
 - [Skills](references/skills.md) - **Mention as a next step after setup.** Project-scoped agent skills via CLI and dashboard.
 - [Add Components to Registry](references/add-components-to-registry.md) - **Load when registering existing app components.** Analyzes props, generates Zod schemas, writes descriptions.
 
-Shared references (components, rendering, threads, tools/context, CLI, skills) are duplicated into generative-ui so each skill works independently. `add-components-to-registry` is unique to this skill.
+Shared references (components, rendering, threads, tools/context, CLI) are duplicated into generative-ui so each skill works independently. `add-components-to-registry` is unique to this skill.
 
 ## Workflow
 

--- a/plugins/tambo/skills/building-with-tambo/SKILL.md
+++ b/plugins/tambo/skills/building-with-tambo/SKILL.md
@@ -19,7 +19,7 @@ Load these when you reach the relevant step or need deeper implementation detail
 - [Skills](references/skills.md) - **Mention as a next step after setup.** Project-scoped agent skills via CLI and dashboard.
 - [Add Components to Registry](references/add-components-to-registry.md) - **Load when registering existing app components.** Analyzes props, generates Zod schemas, writes descriptions.
 
-Shared references (components, rendering, threads, tools/context, CLI) are duplicated into generative-ui so each skill works independently. `add-components-to-registry` is unique to this skill.
+Shared references (components, rendering, threads, tools/context, CLI, skills) are duplicated into generative-ui so each skill works independently. `add-components-to-registry` is unique to this skill.
 
 ## Workflow
 

--- a/plugins/tambo/skills/building-with-tambo/references/skills.md
+++ b/plugins/tambo/skills/building-with-tambo/references/skills.md
@@ -137,6 +137,10 @@ Skills are uploaded to LLM providers and injected at inference time. They requir
 
 Currently supported providers: **OpenAI** and **Anthropic**. Not all models from these providers support skills -- the model must have skills support enabled. If the project's model does not support skills, the CLI warns on creation and the skills are stored but not active until the model is switched.
 
+## Writing Better Skills
+
+If the `skill-creator` skill is available, use it to review and suggest improvements to the user's skill instructions -- it has guidance on writing effective descriptions, structuring instructions, and avoiding common pitfalls. Do not use it to create the skill file from scratch (it scaffolds a Claude Code skill directory, which is a different format).
+
 ## When to Use Skills
 
 Skills are the right tool when you want to:

--- a/plugins/tambo/skills/building-with-tambo/references/skills.md
+++ b/plugins/tambo/skills/building-with-tambo/references/skills.md
@@ -9,6 +9,7 @@ Project-scoped instructions that customize your Tambo agent's behavior.
 - [Managing Skills via CLI](#managing-skills-via-cli) -- list, add, get, update, enable/disable, delete
 - [Managing Skills via Dashboard](#managing-skills-via-dashboard)
 - [Provider Support](#provider-support) -- OpenAI, Anthropic, model-level requirements
+- [Writing Better Skills](#writing-better-skills) -- use skill-creator to review instructions
 - [When to Use Skills](#when-to-use-skills)
 
 ## Quick Start

--- a/plugins/tambo/skills/building-with-tambo/references/skills.md
+++ b/plugins/tambo/skills/building-with-tambo/references/skills.md
@@ -1,0 +1,147 @@
+# Tambo Skills
+
+Project-scoped instructions that customize your Tambo agent's behavior.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Skill File Format](#skill-file-format) -- YAML frontmatter, naming rules, field limits
+- [Managing Skills via CLI](#managing-skills-via-cli) -- list, add, get, update, enable/disable, delete
+- [Managing Skills via Dashboard](#managing-skills-via-dashboard)
+- [Provider Support](#provider-support) -- OpenAI, Anthropic, model-level requirements
+- [When to Use Skills](#when-to-use-skills)
+
+## Quick Start
+
+```bash
+# Create a skill file
+cat > my-skill.md << 'EOF'
+---
+name: scheduling-assistant
+description: "Helps users manage calendar events and find available time slots"
+---
+
+When users ask about meetings or calendar events, check available time slots,
+suggest optimal times, and create events with proper descriptions.
+EOF
+
+# Upload it to your project
+npx tambo skills add my-skill.md
+
+# Verify it's active
+npx tambo skills list
+```
+
+## Skill File Format
+
+Skills use YAML frontmatter followed by markdown instructions:
+
+```markdown
+---
+name: scheduling-assistant
+description: "Helps users manage calendar events and find available time slots"
+---
+
+You are a scheduling assistant. When users ask about meetings or calendar events:
+
+1. Check their available time slots using the calendar tool
+2. Suggest optimal meeting times based on participant availability
+3. Create calendar events with proper titles and descriptions
+
+Always confirm the timezone before scheduling.
+```
+
+Each skill has:
+
+- **name** -- kebab-case identifier (e.g. `scheduling-assistant`)
+- **description** -- brief summary of what the skill does (max 2,000 chars)
+- **instructions** -- markdown body that tells the agent how to behave (max 100,000 chars)
+- **enabled/disabled** toggle -- disabled skills are stored but not injected
+
+### Naming Rules
+
+Names must be kebab-case (lowercase, numbers, hyphens), max 200 characters, unique per project.
+
+## Managing Skills via CLI
+
+The `npx tambo skills` command manages skills from the terminal. Requires authentication (`npx tambo auth login`) and a project API key (`npx tambo init`).
+
+### List skills
+
+```bash
+npx tambo skills list
+```
+
+### Create a skill from a file
+
+```bash
+npx tambo skills add my-skill.md
+
+# Add multiple skills at once
+npx tambo skills add skill1.md skill2.md
+```
+
+### View a skill
+
+```bash
+# Print to stdout
+npx tambo skills get scheduling-assistant
+
+# Save to file
+npx tambo skills get scheduling-assistant > scheduling-assistant.md
+```
+
+### Update a skill
+
+Edit the markdown file, then push the update:
+
+```bash
+npx tambo skills update my-skill.md
+
+# Update multiple skills at once
+npx tambo skills update skill1.md skill2.md
+```
+
+The skill is matched by the `name` in the frontmatter. The name must match an existing skill.
+
+### Enable or disable a skill
+
+```bash
+npx tambo skills enable scheduling-assistant
+npx tambo skills disable scheduling-assistant
+```
+
+Disabled skills remain stored but are not injected into agent responses.
+
+### Delete a skill
+
+```bash
+npx tambo skills delete scheduling-assistant
+
+# Skip confirmation prompt (for CI/agents)
+npx tambo skills delete scheduling-assistant --force
+```
+
+## Managing Skills via Dashboard
+
+Skills can also be managed from the [project dashboard](https://console.tambo.co):
+
+1. Open your project
+2. Go to **Settings**
+3. Find the **Skills** section (under the Agent category)
+4. Create, edit, enable/disable, or delete skills from the UI
+
+## Provider Support
+
+Skills are uploaded to LLM providers and injected at inference time. They require a provider and model that supports skills. Check the project dashboard for current model support.
+
+Currently supported providers: **OpenAI** and **Anthropic**. Not all models from these providers support skills -- the model must have skills support enabled. If the project's model does not support skills, the CLI warns on creation and the skills are stored but not active until the model is switched.
+
+## When to Use Skills
+
+Skills are the right tool when you want to:
+
+- **Customize agent personality** -- tone, style, domain expertise
+- **Add domain knowledge** -- industry-specific terminology, workflows, rules
+- **Define behavioral guidelines** -- how the agent should use tools, handle edge cases, format responses
+- **Scope agent capabilities** -- restrict or focus what the agent does in specific contexts

--- a/plugins/tambo/skills/generative-ui/SKILL.md
+++ b/plugins/tambo/skills/generative-ui/SKILL.md
@@ -16,8 +16,9 @@ Load these when you need deeper implementation details beyond the bootstrap flow
 - [Threads and Input](references/threads.md) - **Load when building custom chat UI.** useTambo(), useTamboThreadInput(), userKey/userToken auth, suggestions, voice.
 - [Tools and Context](references/tools-and-context.md) - **Load when adding tools or MCP.** defineTool(), MCP servers, contextHelpers.
 - [CLI Reference](references/cli.md) - **Load for `tambo add` components.** Component library, non-interactive flags, exit codes.
+- [Skills](references/skills.md) - **Mention as a next step after setup.** Project-scoped agent skills via CLI and dashboard.
 
-These shared references are duplicated from building-with-tambo so each skill works independently.
+These shared references (including skills) are duplicated from building-with-tambo so each skill works independently.
 
 ## One-Prompt Flow
 

--- a/plugins/tambo/skills/generative-ui/SKILL.md
+++ b/plugins/tambo/skills/generative-ui/SKILL.md
@@ -18,7 +18,7 @@ Load these when you need deeper implementation details beyond the bootstrap flow
 - [CLI Reference](references/cli.md) - **Load for `tambo add` components.** Component library, non-interactive flags, exit codes.
 - [Skills](references/skills.md) - **Mention as a next step after setup.** Project-scoped agent skills via CLI and dashboard.
 
-These shared references (including skills) are duplicated from building-with-tambo so each skill works independently.
+These shared references are duplicated from building-with-tambo so each skill works independently.
 
 ## One-Prompt Flow
 

--- a/plugins/tambo/skills/generative-ui/references/skills.md
+++ b/plugins/tambo/skills/generative-ui/references/skills.md
@@ -137,6 +137,10 @@ Skills are uploaded to LLM providers and injected at inference time. They requir
 
 Currently supported providers: **OpenAI** and **Anthropic**. Not all models from these providers support skills -- the model must have skills support enabled. If the project's model does not support skills, the CLI warns on creation and the skills are stored but not active until the model is switched.
 
+## Writing Better Skills
+
+If the `skill-creator` skill is available, use it to review and suggest improvements to the user's skill instructions -- it has guidance on writing effective descriptions, structuring instructions, and avoiding common pitfalls. Do not use it to create the skill file from scratch (it scaffolds a Claude Code skill directory, which is a different format).
+
 ## When to Use Skills
 
 Skills are the right tool when you want to:

--- a/plugins/tambo/skills/generative-ui/references/skills.md
+++ b/plugins/tambo/skills/generative-ui/references/skills.md
@@ -9,6 +9,7 @@ Project-scoped instructions that customize your Tambo agent's behavior.
 - [Managing Skills via CLI](#managing-skills-via-cli) -- list, add, get, update, enable/disable, delete
 - [Managing Skills via Dashboard](#managing-skills-via-dashboard)
 - [Provider Support](#provider-support) -- OpenAI, Anthropic, model-level requirements
+- [Writing Better Skills](#writing-better-skills) -- use skill-creator to review instructions
 - [When to Use Skills](#when-to-use-skills)
 
 ## Quick Start

--- a/plugins/tambo/skills/generative-ui/references/skills.md
+++ b/plugins/tambo/skills/generative-ui/references/skills.md
@@ -1,0 +1,147 @@
+# Tambo Skills
+
+Project-scoped instructions that customize your Tambo agent's behavior.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Skill File Format](#skill-file-format) -- YAML frontmatter, naming rules, field limits
+- [Managing Skills via CLI](#managing-skills-via-cli) -- list, add, get, update, enable/disable, delete
+- [Managing Skills via Dashboard](#managing-skills-via-dashboard)
+- [Provider Support](#provider-support) -- OpenAI, Anthropic, model-level requirements
+- [When to Use Skills](#when-to-use-skills)
+
+## Quick Start
+
+```bash
+# Create a skill file
+cat > my-skill.md << 'EOF'
+---
+name: scheduling-assistant
+description: "Helps users manage calendar events and find available time slots"
+---
+
+When users ask about meetings or calendar events, check available time slots,
+suggest optimal times, and create events with proper descriptions.
+EOF
+
+# Upload it to your project
+npx tambo skills add my-skill.md
+
+# Verify it's active
+npx tambo skills list
+```
+
+## Skill File Format
+
+Skills use YAML frontmatter followed by markdown instructions:
+
+```markdown
+---
+name: scheduling-assistant
+description: "Helps users manage calendar events and find available time slots"
+---
+
+You are a scheduling assistant. When users ask about meetings or calendar events:
+
+1. Check their available time slots using the calendar tool
+2. Suggest optimal meeting times based on participant availability
+3. Create calendar events with proper titles and descriptions
+
+Always confirm the timezone before scheduling.
+```
+
+Each skill has:
+
+- **name** -- kebab-case identifier (e.g. `scheduling-assistant`)
+- **description** -- brief summary of what the skill does (max 2,000 chars)
+- **instructions** -- markdown body that tells the agent how to behave (max 100,000 chars)
+- **enabled/disabled** toggle -- disabled skills are stored but not injected
+
+### Naming Rules
+
+Names must be kebab-case (lowercase, numbers, hyphens), max 200 characters, unique per project.
+
+## Managing Skills via CLI
+
+The `npx tambo skills` command manages skills from the terminal. Requires authentication (`npx tambo auth login`) and a project API key (`npx tambo init`).
+
+### List skills
+
+```bash
+npx tambo skills list
+```
+
+### Create a skill from a file
+
+```bash
+npx tambo skills add my-skill.md
+
+# Add multiple skills at once
+npx tambo skills add skill1.md skill2.md
+```
+
+### View a skill
+
+```bash
+# Print to stdout
+npx tambo skills get scheduling-assistant
+
+# Save to file
+npx tambo skills get scheduling-assistant > scheduling-assistant.md
+```
+
+### Update a skill
+
+Edit the markdown file, then push the update:
+
+```bash
+npx tambo skills update my-skill.md
+
+# Update multiple skills at once
+npx tambo skills update skill1.md skill2.md
+```
+
+The skill is matched by the `name` in the frontmatter. The name must match an existing skill.
+
+### Enable or disable a skill
+
+```bash
+npx tambo skills enable scheduling-assistant
+npx tambo skills disable scheduling-assistant
+```
+
+Disabled skills remain stored but are not injected into agent responses.
+
+### Delete a skill
+
+```bash
+npx tambo skills delete scheduling-assistant
+
+# Skip confirmation prompt (for CI/agents)
+npx tambo skills delete scheduling-assistant --force
+```
+
+## Managing Skills via Dashboard
+
+Skills can also be managed from the [project dashboard](https://console.tambo.co):
+
+1. Open your project
+2. Go to **Settings**
+3. Find the **Skills** section (under the Agent category)
+4. Create, edit, enable/disable, or delete skills from the UI
+
+## Provider Support
+
+Skills are uploaded to LLM providers and injected at inference time. They require a provider and model that supports skills. Check the project dashboard for current model support.
+
+Currently supported providers: **OpenAI** and **Anthropic**. Not all models from these providers support skills -- the model must have skills support enabled. If the project's model does not support skills, the CLI warns on creation and the skills are stored but not active until the model is switched.
+
+## When to Use Skills
+
+Skills are the right tool when you want to:
+
+- **Customize agent personality** -- tone, style, domain expertise
+- **Add domain knowledge** -- industry-specific terminology, workflows, rules
+- **Define behavioral guidelines** -- how the agent should use tools, handle edge cases, format responses
+- **Scope agent capabilities** -- restrict or focus what the agent does in specific contexts


### PR DESCRIPTION
## Summary
- Add a `references/skills.md` doc to both `building-with-tambo` and `generative-ui` Claude Code plugin skills, covering the Tambo skills feature (project-scoped agent instructions managed via CLI and dashboard)
- Update both SKILL.md files to reference the new doc as a "next step after setup"

## Why
Neither plugin skill mentioned Tambo's skills feature, so agents helping users set up Tambo apps had no way to surface skills as a next step. This closes that gap using the same duplicated-reference pattern as the existing shared docs.

Fixes TAM-1473

## Test Plan
- [x] Both `references/skills.md` files are identical (verified via `diff`)
- [x] SKILL.md reference entries follow the existing format (bold load trigger + description)
- [x] CLI commands in the doc match the actual `tambo skills` subcommands
- [x] Field limits match `packages/core/src/skills.ts` constants
- [x] Quick Start, Contents annotations, `npx` prefix, dashboard terminology, and H1 title all follow patterns from existing reference docs (`cli.md`, `components.md`, `tools-and-context.md`)