### PR TITLE
fix(web): hide memory tools toggle from project settings UI

### DIFF
--- a/apps/web/components/dashboard-components/agent-settings.tsx
+++ b/apps/web/components/dashboard-components/agent-settings.tsx
@@ -83,7 +83,6 @@ export function AgentSettings({ projectId }: AgentSettingsProps) {
           <MemorySettings
             projectId={project.id}
             memoryEnabled={project.memoryEnabled}
-            memoryToolsEnabled={project.memoryToolsEnabled}
             onEdited={handleRefreshProject}
           />
 

--- a/apps/web/components/dashboard-components/project-details/memory-settings.tsx
+++ b/apps/web/components/dashboard-components/project-details/memory-settings.tsx
@@ -10,21 +10,16 @@ import { useState } from "react";
 interface MemorySettingsProps {
   projectId: string;
   memoryEnabled: boolean;
-  memoryToolsEnabled: boolean;
   onEdited: () => void;
 }
 
 export function MemorySettings({
   projectId,
   memoryEnabled: memoryEnabledProp,
-  memoryToolsEnabled: memoryToolsEnabledProp,
   onEdited,
 }: MemorySettingsProps) {
   const { toast } = useToast();
   const [memoryEnabled, setMemoryEnabled] = useState(memoryEnabledProp);
-  const [memoryToolsEnabled, setMemoryToolsEnabled] = useState(
-    memoryToolsEnabledProp,
-  );
 
   const updateProject = api.project.updateProject.useMutation({
     onSuccess: () => {
@@ -36,30 +31,13 @@ export function MemorySettings({
         description: error.message,
         variant: "destructive",
       });
-      // Revert optimistic state
       setMemoryEnabled(memoryEnabledProp);
-      setMemoryToolsEnabled(memoryToolsEnabledProp);
     },
   });
 
   const handleMemoryEnabledChange = (checked: boolean) => {
     setMemoryEnabled(checked);
-    // If disabling memory, also disable tools
-    if (!checked && memoryToolsEnabled) {
-      setMemoryToolsEnabled(false);
-      updateProject.mutate({
-        projectId,
-        memoryEnabled: checked,
-        memoryToolsEnabled: false,
-      });
-    } else {
-      updateProject.mutate({ projectId, memoryEnabled: checked });
-    }
-  };
-
-  const handleMemoryToolsEnabledChange = (checked: boolean) => {
-    setMemoryToolsEnabled(checked);
-    updateProject.mutate({ projectId, memoryToolsEnabled: checked });
+    updateProject.mutate({ projectId, memoryEnabled: checked });
   };
 
   return (
@@ -81,23 +59,6 @@ export function MemorySettings({
             checked={memoryEnabled}
             onCheckedChange={handleMemoryEnabledChange}
             disabled={updateProject.isPending}
-          />
-        </div>
-
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="memory-tools-enabled">Enable memory tools</Label>
-            <p className="text-sm text-muted-foreground">
-              Give the agent save_memory and delete_memory tools so it can
-              explicitly save or forget information during conversations.
-              Requires memory to be enabled.
-            </p>
-          </div>
-          <Switch
-            id="memory-tools-enabled"
-            checked={memoryToolsEnabled}
-            onCheckedChange={handleMemoryToolsEnabledChange}
-            disabled={!memoryEnabled || updateProject.isPending}
           />
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary
- Remove the "Enable memory tools" toggle from the Memory settings card in project settings
- Backend support for `memoryToolsEnabled` is retained — this is a UI-only change to hide the feature for MVP
- The "Enable memory" toggle remains visible and functional

## Test plan
- [ ] Open project settings and verify the Memory card only shows the "Enable memory" toggle
- [ ] Verify toggling "Enable memory" still works correctly
- [ ] Verify no type errors in `apps/web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)