### PR TITLE
fix(cli): fix Expo project setup in create-app and init

### DIFF
--- a/cli/src/commands/create-app.ts
+++ b/cli/src/commands/create-app.ts
@@ -361,7 +361,7 @@ export async function handleCreateApp(
         // - Project selection
         // - Installation path
         // - Agent docs creation
-        execSync("npx tambo init", {
+        execSync("npx tambo@latest init", {
           stdio: "inherit", // Allow user interaction for all prompts
           allowNonInteractive: true,
         });
@@ -373,7 +373,7 @@ export async function handleCreateApp(
         console.error(chalk.red("✗ Failed to run tambo init\n"));
         console.warn(
           chalk.yellow(
-            "Warning: Tambo initialization failed. You can run 'npx tambo init' manually to complete setup.\n",
+            "Warning: Tambo initialization failed. You can run 'npx tambo@latest init' manually to complete setup.\n",
           ),
         );
       }
@@ -420,7 +420,7 @@ export async function handleCreateApp(
       } else {
         reason = chalk.gray("(failed, run manually to complete setup)");
       }
-      setupSteps.push(`${chalk.cyan("npx tambo init")} ${reason}`);
+      setupSteps.push(`${chalk.cyan("npx tambo@latest init")} ${reason}`);
     }
 
     // Show appropriate message based on setup status

--- a/cli/src/commands/init.test.ts
+++ b/cli/src/commands/init.test.ts
@@ -1049,6 +1049,37 @@ describe("handleInit", () => {
       expect(output).toContain("Created new .env.local file");
     });
 
+    it("should write to .env instead of .env.local for Expo projects", async () => {
+      // Override framework to Expo
+      mockDetectedFramework = {
+        name: "expo",
+        displayName: "Expo",
+        envPrefix: "EXPO_PUBLIC_",
+      };
+
+      // Setup: basic project with no env files
+      vol.fromJSON(createBasicProject());
+
+      // Set up device auth mock
+      mockGeneratedApiKey = "expo-key-123";
+
+      // Set inquirer responses
+      inquirerResponses = {
+        hostingChoice: "cloud",
+        projectName: "test-project",
+        confirmReplace: true,
+      };
+
+      // Execute
+      await handleInit({});
+
+      // Verify .env was created (not .env.local)
+      expect(vol.existsSync("/mock-project/.env")).toBe(true);
+      expect(vol.existsSync("/mock-project/.env.local")).toBe(false);
+      const content = vol.readFileSync("/mock-project/.env", "utf-8") as string;
+      expect(content).toContain("EXPO_PUBLIC_TAMBO_API_KEY=expo-key-123");
+    });
+
     it("should use .env.local over .env when both exist", async () => {
       // Setup: Next.js project with both env files (uses NEXT_PUBLIC_TAMBO_API_KEY)
       vol.fromJSON({

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -80,14 +80,19 @@ async function writeApiKeyToEnv(
   { force = false }: { force?: boolean } = {},
 ): Promise<boolean> {
   try {
-    // use `.env.local` by default or fall back to .env if it exists and .env.local does not
-    let targetEnvFile = ".env.local";
-    if (fs.existsSync(".env") && !fs.existsSync(".env.local")) {
-      targetEnvFile = ".env";
-    }
-
     // Detect framework and get appropriate env var name
     const framework = detectFramework();
+
+    // Expo only reads from .env (doesn't support .env.local)
+    // For other frameworks, use .env.local by default or fall back to .env if it exists and .env.local does not
+    let targetEnvFile: string;
+    if (framework?.name === "expo") {
+      targetEnvFile = ".env";
+    } else if (fs.existsSync(".env") && !fs.existsSync(".env.local")) {
+      targetEnvFile = ".env";
+    } else {
+      targetEnvFile = ".env.local";
+    }
     const envVarName = getTamboApiKeyEnvVar() as TamboApiKeyName;
 
     if (framework) {

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -71,7 +71,7 @@ interface InitOptions {
 }
 
 /**
- * Writes the provided API key to .env.local, creating the file if necessary
+ * Writes the provided API key to the appropriate env file (.env for Expo, .env.local for others)
  * Handles overwrite confirmation when a key already exists
  * Automatically detects framework and uses appropriate env var prefix
  */


### PR DESCRIPTION
## Summary
- Use `npx tambo@latest init` instead of `npx tambo init` in `create-app` so users don't get a stale cached CLI version during setup
- Write API key to `.env` instead of `.env.local` for Expo projects, since Expo doesn't support `.env.local`

## Why
Both bugs break the Expo create-app flow: the first causes stale CLI behavior during init, the second writes the API key to a file Expo never reads, resulting in 403 errors.

Fixes TAM-1475
Fixes TAM-1476

## Test Plan
- [x] Run `npx tambo create-app test-app --template=expo` and verify `npx tambo@latest init` is invoked
- [x] Verify the API key is written to `.env` (not `.env.local`) in the Expo project
- [x] Run `npx tambo create-app test-app --template=standard` and verify `.env.local` is still used for Next.js projects