### PR TITLE
docs(memory): add Memory concept page and navigation

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -111,6 +111,7 @@ In general, try to fit changes into the following categories. If you can't find 
    - tools - Function calling, schemas, orchestration
    - additional-context - Configuration, custom helpers, context attachments
    - conversation-storage - Message threads, history management, status tracking
+   - memory - Cross-conversation memory extraction, injection, and management
    - skills - Reusable instruction sets that run in the provider's sandbox
    - agent-configuration - AI personality and behavior
    - user-authentication - OAuth providers, session management, context keys

--- a/docs/content/docs/concepts/agent-configuration.mdx
+++ b/docs/content/docs/concepts/agent-configuration.mdx
@@ -50,6 +50,19 @@ Skills are supported by select OpenAI (GPT-5.2 and newer) and Anthropic (Claude 
 
 For details on how skills work, supported models, and how to manage them, see the [Skills concept page](/concepts/skills) and the [Add a Skill to Your Agent guide](/guides/manage-skills).
 
+## Memory
+
+Memory allows your agent to remember facts, preferences, and goals about individual users across conversations. When enabled, Tambo automatically extracts noteworthy information after each conversation and injects relevant memories into the system prompt for future interactions.
+
+There are two project-level settings that control memory behavior:
+
+- **Memory** enables automatic extraction and injection of memories.
+- **Memory tools** gives the agent explicit `save_memory` and `delete_memory` tools so users can directly control what the agent remembers.
+
+Both are off by default and can be toggled in the Agent tab of your project settings.
+
+For details on how memory works, categories, importance scoring, and capacity limits, see the [Memory concept page](/concepts/memory).
+
 ## MCP Server Connection
 
 Model Context Protocol servers extend your Tambo agent's capabilities by providing access to external tools, data sources, and services. You can connect MCP servers directly from your project settings page, making their capabilities available to all users of your application.

--- a/docs/content/docs/concepts/agent-configuration.mdx
+++ b/docs/content/docs/concepts/agent-configuration.mdx
@@ -52,16 +52,9 @@ For details on how skills work, supported models, and how to manage them, see th
 
 ## Memory
 
-Memory allows your agent to remember facts, preferences, and goals about individual users across conversations. When enabled, Tambo automatically extracts noteworthy information after each conversation and injects relevant memories into the system prompt for future interactions.
+Memory allows your agent to remember facts, preferences, and goals about individual users across conversations. When enabled, Tambo automatically extracts noteworthy information after each conversation and injects relevant memories into the system prompt for future interactions. Memory is off by default and can be toggled in the Agent tab of your project settings.
 
-There are two project-level settings that control memory behavior:
-
-- **Memory** enables automatic extraction and injection of memories.
-- **Memory tools** gives the agent explicit `save_memory` and `delete_memory` tools so users can directly control what the agent remembers.
-
-Both are off by default and can be toggled in the Agent tab of your project settings.
-
-For details on how memory works, categories, importance scoring, and capacity limits, see the [Memory concept page](/concepts/memory).
+For details on how memory works, scoping, and capacity limits, see the [Memory concept page](/concepts/memory).
 
 ## MCP Server Connection
 

--- a/docs/content/docs/concepts/memory.mdx
+++ b/docs/content/docs/concepts/memory.mdx
@@ -13,38 +13,13 @@ Memory operates in two phases: extraction and injection.
 
 ### Extraction
 
-After a conversation completes, Tambo analyzes recent messages and extracts atomic facts worth remembering. Each extracted memory is categorized, assigned an importance score, and stored. Tambo deduplicates against existing memories to avoid storing the same fact twice.
+After a conversation completes, Tambo analyzes recent messages and extracts atomic facts worth remembering. Tambo deduplicates against existing memories to avoid storing the same fact twice.
 
 Extraction happens in the background after the response is delivered, so it never slows down the user's experience.
 
 ### Injection
 
-When a user starts a new conversation, Tambo fetches their stored memories and includes them in the system prompt. The agent sees these memories as context and can reference them naturally in responses. Memories are selected to fit within a token budget, prioritizing the most important ones first.
-
-## Memory Categories
-
-Each memory is assigned one of four categories:
-
-| Category       | Description                                         | Example                                      |
-| -------------- | --------------------------------------------------- | -------------------------------------------- |
-| `preference`   | User preferences and choices                        | "User prefers dark mode"                     |
-| `fact`         | Factual information about the user                  | "User works at Acme Corp as a data engineer" |
-| `goal`         | Active projects, objectives, or aspirations         | "User is building a dashboard for Q2 launch" |
-| `relationship` | Connections between people, teams, or organizations | "User reports to Sarah on the platform team" |
-
-## Importance Scale
-
-Each memory receives an importance score from 1 to 5:
-
-| Score | Meaning                   | Example                                 |
-| ----- | ------------------------- | --------------------------------------- |
-| 5     | Core identity/preference  | "User's name is Alex"                   |
-| 4     | Active project or goal    | "User is migrating to TypeScript"       |
-| 3     | Useful background context | "User attended the React conference"    |
-| 2     | Minor preference          | "User likes bullet-point summaries"     |
-| 1     | Transient detail          | "User asked about pricing on April 3rd" |
-
-When memories exceed the storage cap, Tambo evicts the oldest, lowest-importance memories first.
+Each time a user sends a message, Tambo fetches their stored memories and includes the most relevant ones in the system prompt. The agent sees these memories as context and can reference them naturally in responses.
 
 ## Memory Scoping
 
@@ -52,40 +27,9 @@ Memories are scoped to the combination of your project and a **context key** (`p
 
 The context key comes from exactly one source: either [user authentication](/concepts/user-authentication) (derived automatically from the authenticated user) or a manually passed `contextKey` on threads. You cannot use both at the same time.
 
-## Memory Tools
-
-When memory tools are enabled, the agent gains two additional tools it can call during conversations:
-
-### save_memory
-
-Allows the agent to explicitly save a fact when the user asks it to remember something, or when the agent determines a fact is worth preserving.
-
-Parameters:
-
-- `content` (string) -- the fact to remember, written in third person
-- `category` -- one of `preference`, `fact`, `goal`, or `relationship`
-- `importance` (1-5, optional) -- defaults to 3
-
-### delete_memory
-
-Allows the agent to forget a specific memory when the user asks it to.
-
-Parameters:
-
-- `memory_id` (string) -- the ID of the memory to delete
-
-These tools give users direct control over what the agent remembers. A user can say "remember that I prefer Python over JavaScript" or "forget that I work at Acme Corp" and the agent will act on it.
-
 ## Enabling Memory
 
-Memory is configured at the project level in your Tambo Cloud dashboard under the **Agent** tab.
-
-There are two settings:
-
-1. **Memory** -- enables automatic memory extraction from conversations and injection into the system prompt. This is the main toggle.
-2. **Memory tools** -- enables the `save_memory` and `delete_memory` tools so the agent can explicitly save or delete memories during conversations. Requires memory to be enabled first.
-
-Both settings are off by default.
+Memory is configured at the project level in your Tambo Cloud dashboard under the **Agent** tab. The setting is off by default.
 
 ## Capacity and Limits
 
@@ -93,8 +37,7 @@ Tambo enforces limits to keep memory performant and relevant:
 
 - **Storage cap**: 200 memories per (`projectId`, `contextKey`) scope. When the cap is exceeded, the oldest and least important memories are evicted.
 - **Content length**: Each memory can be up to 1,000 characters.
-- **Injection budget**: Memories injected into the system prompt are capped at approximately 1,000 tokens. The most important memories are selected first.
 
 ## Privacy and Deletion
 
-Memories are soft-deleted. When a memory is removed by the agent's `delete_memory` tool, the content is scrubbed and replaced with `[deleted]`. This ensures deleted content is not recoverable while maintaining referential integrity.
+If a user asks the agent to forget something, the memory is deleted. Tambo ensures deleted content is not recoverable.

--- a/docs/content/docs/concepts/memory.mdx
+++ b/docs/content/docs/concepts/memory.mdx
@@ -50,7 +50,7 @@ When memories exceed the storage cap, Tambo evicts the oldest, lowest-importance
 
 Memories are scoped to a combination of your project and a **context key**. The context key is typically a user identifier, so each user in your application has their own isolated set of memories. Users never see memories belonging to other users.
 
-If you use Tambo's [user authentication](/concepts/user-authentication), the context key is derived automatically from the authenticated user. If you pass a `contextKey` manually on threads, that value is used instead.
+The context key comes from exactly one source: either [user authentication](/concepts/user-authentication) (derived automatically from the authenticated user) or a manually passed `contextKey` on threads. You cannot use both at the same time.
 
 ## Memory Tools
 

--- a/docs/content/docs/concepts/memory.mdx
+++ b/docs/content/docs/concepts/memory.mdx
@@ -48,7 +48,7 @@ When memories exceed the storage cap, Tambo evicts the oldest, lowest-importance
 
 ## Memory Scoping
 
-Memories are scoped to a combination of your project and a **context key**. The context key is typically a user identifier, so each user in your application has their own isolated set of memories. Users never see memories belonging to other users.
+Memories are scoped to the combination of your project and a **context key** (`projectId`, `contextKey`). To isolate memories per user, use a stable per-user context key (for example, a user ID). If multiple users share the same context key, they will share the same memory set.
 
 The context key comes from exactly one source: either [user authentication](/concepts/user-authentication) (derived automatically from the authenticated user) or a manually passed `contextKey` on threads. You cannot use both at the same time.
 
@@ -91,7 +91,7 @@ Both settings are off by default.
 
 Tambo enforces limits to keep memory performant and relevant:
 
-- **Storage cap**: 200 memories per user per project. When the cap is exceeded, the oldest and least important memories are evicted.
+- **Storage cap**: 200 memories per (`projectId`, `contextKey`) scope. When the cap is exceeded, the oldest and least important memories are evicted.
 - **Content length**: Each memory can be up to 1,000 characters.
 - **Injection budget**: Memories injected into the system prompt are capped at approximately 1,000 tokens. The most important memories are selected first.
 

--- a/docs/content/docs/concepts/memory.mdx
+++ b/docs/content/docs/concepts/memory.mdx
@@ -1,7 +1,6 @@
 ---
 title: Memory
 description: How Tambo remembers facts about users across conversations
-icon: Brain
 ---
 
 Tambo can remember facts, preferences, and goals about individual users and use that knowledge in future conversations. When memory is enabled, Tambo automatically extracts noteworthy information from conversations and injects relevant memories into the system prompt for subsequent interactions.

--- a/docs/content/docs/concepts/memory.mdx
+++ b/docs/content/docs/concepts/memory.mdx
@@ -1,0 +1,99 @@
+---
+title: Memory
+description: How Tambo remembers facts about users across conversations
+icon: Brain
+---
+
+Tambo can remember facts, preferences, and goals about individual users and use that knowledge in future conversations. When memory is enabled, Tambo automatically extracts noteworthy information from conversations and injects relevant memories into the system prompt for subsequent interactions.
+
+This means your agent can recall that a user prefers dark mode, works on a specific project, or has a particular goal, without the user needing to repeat themselves.
+
+## How Memory Works
+
+Memory operates in two phases: extraction and injection.
+
+### Extraction
+
+After a conversation completes, Tambo analyzes recent messages and extracts atomic facts worth remembering. Each extracted memory is categorized, assigned an importance score, and stored. Tambo deduplicates against existing memories to avoid storing the same fact twice.
+
+Extraction happens in the background after the response is delivered, so it never slows down the user's experience.
+
+### Injection
+
+When a user starts a new conversation, Tambo fetches their stored memories and includes them in the system prompt. The agent sees these memories as context and can reference them naturally in responses. Memories are selected to fit within a token budget, prioritizing the most important ones first.
+
+## Memory Categories
+
+Each memory is assigned one of four categories:
+
+| Category       | Description                                        | Example                                      |
+| -------------- | -------------------------------------------------- | -------------------------------------------- |
+| `preference`   | User preferences and choices                       | "User prefers dark mode"                     |
+| `fact`         | Factual information about the user                 | "User works at Acme Corp as a data engineer" |
+| `goal`         | Active projects, objectives, or aspirations        | "User is building a dashboard for Q2 launch" |
+| `relationship` | Connections between people, teams, or organizations | "User reports to Sarah on the platform team" |
+
+## Importance Scale
+
+Each memory receives an importance score from 1 to 5:
+
+| Score | Meaning                   | Example                                |
+| ----- | ------------------------- | -------------------------------------- |
+| 5     | Core identity/preference  | "User's name is Alex"                  |
+| 4     | Active project or goal    | "User is migrating to TypeScript"      |
+| 3     | Useful background context | "User attended the React conference"   |
+| 2     | Minor preference          | "User likes bullet-point summaries"    |
+| 1     | Transient detail          | "User asked about pricing on April 3rd" |
+
+When memories exceed the storage cap, Tambo evicts the oldest, lowest-importance memories first.
+
+## Memory Scoping
+
+Memories are scoped to a combination of your project and a **context key**. The context key is typically a user identifier, so each user in your application has their own isolated set of memories. Users never see memories belonging to other users.
+
+If you use Tambo's [user authentication](/concepts/user-authentication), the context key is derived automatically from the authenticated user. If you pass a `contextKey` manually on threads, that value is used instead.
+
+## Memory Tools
+
+When memory tools are enabled, the agent gains two additional tools it can call during conversations:
+
+### save_memory
+
+Allows the agent to explicitly save a fact when the user asks it to remember something, or when the agent determines a fact is worth preserving.
+
+Parameters:
+- `content` (string) -- the fact to remember, written in third person
+- `category` -- one of `preference`, `fact`, `goal`, or `relationship`
+- `importance` (1-5, optional) -- defaults to 3
+
+### delete_memory
+
+Allows the agent to forget a specific memory when the user asks it to.
+
+Parameters:
+- `memory_id` (string) -- the ID of the memory to delete
+
+These tools give users direct control over what the agent remembers. A user can say "remember that I prefer Python over JavaScript" or "forget that I work at Acme Corp" and the agent will act on it.
+
+## Enabling Memory
+
+Memory is configured at the project level in your Tambo Cloud dashboard under the **Agent** tab.
+
+There are two settings:
+
+1. **Memory** -- enables automatic memory extraction from conversations and injection into the system prompt. This is the main toggle.
+2. **Memory tools** -- enables the `save_memory` and `delete_memory` tools so the agent can explicitly save or delete memories during conversations. Requires memory to be enabled first.
+
+Both settings are off by default.
+
+## Capacity and Limits
+
+Tambo enforces limits to keep memory performant and relevant:
+
+- **Storage cap**: 200 memories per user per project. When the cap is exceeded, the oldest and least important memories are evicted.
+- **Content length**: Each memory can be up to 1,000 characters.
+- **Injection budget**: Memories injected into the system prompt are capped at approximately 1,000 tokens. The most important memories are selected first.
+
+## Privacy and Deletion
+
+Memories are soft-deleted. When a memory is removed by the agent's `delete_memory` tool, the content is scrubbed and replaced with `[deleted]`. This ensures deleted content is not recoverable while maintaining referential integrity.

--- a/docs/content/docs/concepts/memory.mdx
+++ b/docs/content/docs/concepts/memory.mdx
@@ -26,23 +26,23 @@ When a user starts a new conversation, Tambo fetches their stored memories and i
 
 Each memory is assigned one of four categories:
 
-| Category       | Description                                        | Example                                      |
-| -------------- | -------------------------------------------------- | -------------------------------------------- |
-| `preference`   | User preferences and choices                       | "User prefers dark mode"                     |
-| `fact`         | Factual information about the user                 | "User works at Acme Corp as a data engineer" |
-| `goal`         | Active projects, objectives, or aspirations        | "User is building a dashboard for Q2 launch" |
+| Category       | Description                                         | Example                                      |
+| -------------- | --------------------------------------------------- | -------------------------------------------- |
+| `preference`   | User preferences and choices                        | "User prefers dark mode"                     |
+| `fact`         | Factual information about the user                  | "User works at Acme Corp as a data engineer" |
+| `goal`         | Active projects, objectives, or aspirations         | "User is building a dashboard for Q2 launch" |
 | `relationship` | Connections between people, teams, or organizations | "User reports to Sarah on the platform team" |
 
 ## Importance Scale
 
 Each memory receives an importance score from 1 to 5:
 
-| Score | Meaning                   | Example                                |
-| ----- | ------------------------- | -------------------------------------- |
-| 5     | Core identity/preference  | "User's name is Alex"                  |
-| 4     | Active project or goal    | "User is migrating to TypeScript"      |
-| 3     | Useful background context | "User attended the React conference"   |
-| 2     | Minor preference          | "User likes bullet-point summaries"    |
+| Score | Meaning                   | Example                                 |
+| ----- | ------------------------- | --------------------------------------- |
+| 5     | Core identity/preference  | "User's name is Alex"                   |
+| 4     | Active project or goal    | "User is migrating to TypeScript"       |
+| 3     | Useful background context | "User attended the React conference"    |
+| 2     | Minor preference          | "User likes bullet-point summaries"     |
 | 1     | Transient detail          | "User asked about pricing on April 3rd" |
 
 When memories exceed the storage cap, Tambo evicts the oldest, lowest-importance memories first.
@@ -62,6 +62,7 @@ When memory tools are enabled, the agent gains two additional tools it can call 
 Allows the agent to explicitly save a fact when the user asks it to remember something, or when the agent determines a fact is worth preserving.
 
 Parameters:
+
 - `content` (string) -- the fact to remember, written in third person
 - `category` -- one of `preference`, `fact`, `goal`, or `relationship`
 - `importance` (1-5, optional) -- defaults to 3
@@ -71,6 +72,7 @@ Parameters:
 Allows the agent to forget a specific memory when the user asks it to.
 
 Parameters:
+
 - `memory_id` (string) -- the ID of the memory to delete
 
 These tools give users direct control over what the agent remembers. A user can say "remember that I prefer Python over JavaScript" or "forget that I work at Acme Corp" and the agent will act on it.

--- a/docs/content/docs/concepts/meta.json
+++ b/docs/content/docs/concepts/meta.json
@@ -5,6 +5,7 @@
     "tools",
     "additional-context",
     "conversation-storage",
+    "memory",
     "skills",
     "agent-configuration",
     "model-context-protocol",


### PR DESCRIPTION
## Summary
- Add a new Memory concept page (`/concepts/memory`) documenting cross-conversation memory: extraction, injection, categories, importance scale, scoping, memory tools, dashboard settings, capacity limits, and privacy
- Add a Memory section to the Agent Configuration concept page with link to the new page
- Update concepts `meta.json` navigation and `AGENTS.md` information architecture

## Why
Memory is a shipped feature with no user-facing documentation. Users need to understand what the two dashboard toggles do, how memories are extracted/injected, and how they can manage them.

Fixes TAM-1497

## Test Plan
- [x] `npm run build` passes in docs/
- [x] Lint and type-check pass
- [x] New page renders at `/concepts/memory` in sidebar after Conversation Storage
- [x] Agent Configuration page shows Memory section with link