### PR TITLE
fix(web): update observability to extract components from content array

### DIFF
--- a/apps/web/__fixtures__/thread-factories.ts
+++ b/apps/web/__fixtures__/thread-factories.ts
@@ -270,6 +270,37 @@ export function createMockThreadWithNonFirstSystemMessage(
 }
 
 /**
+ * Creates a thread with a component stored in the content array (V1 API format)
+ * rather than in componentDecision (legacy format)
+ */
+export function createMockThreadWithContentArrayComponent(
+  threadId: string = "thread-content-component",
+  projectId: string = "project-1",
+): ThreadType {
+  const messages: MessageType[] = [
+    createMockThreadMessage("msg-1", threadId, MessageRole.User, {
+      content: [{ type: "text", text: "Show me a table" }],
+      createdAt: new Date("2024-01-01T10:00:00Z"),
+    }),
+    createMockThreadMessage("msg-2", threadId, MessageRole.Assistant, {
+      content: [
+        { type: "text", text: "Here is your table" },
+        {
+          type: "component",
+          id: "comp_table_1",
+          name: "DataTable",
+          props: { rows: [{ name: "Alice" }], columns: ["name"] },
+          state: { selectedRow: 0 },
+        },
+      ] as MessageType["content"],
+      createdAt: new Date("2024-01-01T10:01:00Z"),
+    }),
+  ];
+
+  return createMockThread(threadId, projectId, { messages });
+}
+
+/**
  * Creates search matches for testing search functionality
  */
 export function createMockSearchMatches(): Array<{

--- a/apps/web/components/observability/messages/component-message.tsx
+++ b/apps/web/components/observability/messages/component-message.tsx
@@ -3,7 +3,7 @@ import { type RouterOutputs } from "@/trpc/react";
 import { motion } from "framer-motion";
 import { Monitor } from "lucide-react";
 import { memo } from "react";
-import { formatTime } from "../utils";
+import { type ExtractedComponent, formatTime } from "../utils";
 import { ComponentPropsSection } from "./component-props-section";
 import { HighlightText } from "./highlight";
 import { MessageIdCopyButton } from "./message-id-copy-button";
@@ -13,15 +13,21 @@ type MessageType = ThreadType["messages"][0];
 
 interface ComponentMessageProps {
   message: MessageType;
+  componentData: ExtractedComponent;
   isHighlighted?: boolean;
   searchQuery?: string;
 }
 
 export const ComponentMessage = memo(
-  ({ message, isHighlighted = false, searchQuery }: ComponentMessageProps) => {
-    const componentName =
-      message.componentDecision?.componentName || "Unknown Component";
-    const componentProps = message.componentDecision?.props || {};
+  ({
+    message,
+    componentData,
+    isHighlighted = false,
+    searchQuery,
+  }: ComponentMessageProps) => {
+    const componentName = componentData.name;
+    const componentProps = componentData.props;
+    const componentState = componentData.state;
 
     return (
       <>
@@ -73,6 +79,15 @@ export const ComponentMessage = memo(
                 componentProps={componentProps}
                 searchQuery={searchQuery}
               />
+
+              {/* View State Dropdown */}
+              {componentState && Object.keys(componentState).length > 0 && (
+                <ComponentPropsSection
+                  componentProps={componentState}
+                  searchQuery={searchQuery}
+                  label="View State"
+                />
+              )}
             </div>
           </div>
         </motion.div>

--- a/apps/web/components/observability/messages/component-props-section.tsx
+++ b/apps/web/components/observability/messages/component-props-section.tsx
@@ -8,11 +8,13 @@ import { HighlightedJson } from "./highlight";
 interface ComponentPropsSectionProps {
   componentProps: Record<string, unknown>;
   searchQuery?: string;
+  label?: string;
 }
 
 export function ComponentPropsSection({
   componentProps,
   searchQuery,
+  label = "View Props",
 }: ComponentPropsSectionProps) {
   const [showProps, setShowProps] = useState(false);
 
@@ -34,7 +36,7 @@ export function ComponentPropsSection({
         className="w-full flex items-center justify-between p-2 sm:p-3 bg-muted/30 hover:bg-muted/50 transition-colors text-primary"
       >
         <span className="font-medium text-xs sm:text-sm text-primary">
-          View Props
+          {label}
         </span>
         <div className="flex items-center gap-1 sm:gap-2">
           <span

--- a/apps/web/components/observability/messages/thread-messages-modal.tsx
+++ b/apps/web/components/observability/messages/thread-messages-modal.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   calculateThreadStats,
   createMessageItems,
+  extractComponentsFromMessage,
   formatToolParameters,
   formatToolResponseContent,
 } from "../utils";
@@ -52,10 +53,14 @@ function searchInMessage(message: MessageType, query: string): boolean {
     if (formattedParams.toLowerCase().includes(lowerQuery)) return true;
   }
 
-  // Search in component props
-  if (message.componentDecision?.props) {
-    const propsStr = JSON.stringify(message.componentDecision.props, null, 2);
+  // Search in component props (content array + legacy componentDecision)
+  for (const comp of extractComponentsFromMessage(message)) {
+    const propsStr = JSON.stringify(comp.props, null, 2);
     if (propsStr.toLowerCase().includes(lowerQuery)) return true;
+    if (comp.state) {
+      const stateStr = JSON.stringify(comp.state, null, 2);
+      if (stateStr.toLowerCase().includes(lowerQuery)) return true;
+    }
   }
 
   // Search in additional context
@@ -153,10 +158,14 @@ function findAllMatches(thread: ThreadType, query: string): SearchMatch[] {
       }
     }
 
-    // Check component decisions
-    if (message.componentDecision?.componentName) {
-      const propsStr = JSON.stringify(message.componentDecision.props, null, 2);
-      if (propsStr.toLowerCase().includes(query.toLowerCase())) {
+    // Check components (content array + legacy componentDecision)
+    for (const comp of extractComponentsFromMessage(message)) {
+      const propsStr = JSON.stringify(comp.props, null, 2);
+      const stateStr = comp.state ? JSON.stringify(comp.state, null, 2) : "";
+      if (
+        propsStr.toLowerCase().includes(query.toLowerCase()) ||
+        stateStr.toLowerCase().includes(query.toLowerCase())
+      ) {
         matches.push({
           messageId: message.id,
           messageType: "component",

--- a/apps/web/components/observability/messages/thread-messages.test.tsx
+++ b/apps/web/components/observability/messages/thread-messages.test.tsx
@@ -1,8 +1,11 @@
 import { ThreadMessages } from "@/components/observability/messages/thread-messages";
 import {
   createMockSearchMatches,
+  createMockThread,
   createMockThreadDifferentDays,
+  createMockThreadMessage,
   createMockThreadSameDay,
+  createMockThreadWithContentArrayComponent,
   createMockThreadWithLargeSystemMessage,
   createMockThreadWithMessages,
   createMockThreadWithNonFirstSystemMessage,
@@ -11,18 +14,45 @@ import {
 } from "@/__fixtures__/thread-factories";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MessageRole } from "@tambo-ai-cloud/core";
 import React from "react";
 
-// Mock the utils
+// Mock the utils - provide extractComponentsFromMessage inline, mock isSameDay
 jest.mock("../utils", () => ({
   isSameDay: (date1: Date, date2: Date) =>
     date1.toDateString() === date2.toDateString(),
+  extractComponentsFromMessage: (message: any) => {
+    const components: any[] = [];
+    if (Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (part?.type === "component" && part.name) {
+          components.push({
+            id: part.id ?? `comp_${message.id}`,
+            name: part.name,
+            props: part.props ?? {},
+            state: part.state ?? message.componentState ?? undefined,
+          });
+        }
+      }
+    }
+    if (components.length === 0 && message.componentDecision?.componentName) {
+      components.push({
+        id: `comp_${message.id}`,
+        name: message.componentDecision.componentName,
+        props: message.componentDecision.props ?? {},
+        state: message.componentState ?? undefined,
+      });
+    }
+    return components;
+  },
 }));
 
 // Mock the child components
 jest.mock("./component-message", () => ({
-  ComponentMessage: ({ message }: any) => (
-    <div data-testid="component-message">{message.id}</div>
+  ComponentMessage: ({ message, componentData }: any) => (
+    <div data-testid="component-message">
+      {componentData?.name ?? message.id}
+    </div>
   ),
 }));
 
@@ -395,5 +425,63 @@ describe("ThreadMessages", () => {
     expect(
       screen.queryByText("System prompt (click to expand)"),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders component messages from content array (not just componentDecision)", () => {
+    const mockMessageRefs = createMessageRefs();
+    const threadWithContentComponent =
+      createMockThreadWithContentArrayComponent();
+
+    render(
+      <ThreadMessages
+        thread={threadWithContentComponent}
+        messageRefs={mockMessageRefs}
+      />,
+    );
+
+    // Should detect and render the component from the content array
+    expect(screen.getByTestId("component-message")).toBeInTheDocument();
+    // The mock renders componentData.name
+    expect(screen.getByText("DataTable")).toBeInTheDocument();
+  });
+
+  it("hides empty assistant message bubble when it only has a tool call", () => {
+    const mockMessageRefs = createMessageRefs();
+    const thread = createMockThread("thread-empty-tool", "project-1", {
+      messages: [
+        createMockThreadMessage(
+          "msg-1",
+          "thread-empty-tool",
+          MessageRole.User,
+          {
+            content: [{ type: "text", text: "Do something" }],
+            createdAt: new Date("2024-01-01T10:00:00Z"),
+          },
+        ),
+        createMockThreadMessage(
+          "msg-2",
+          "thread-empty-tool",
+          MessageRole.Assistant,
+          {
+            content: [],
+            createdAt: new Date("2024-01-01T10:01:00Z"),
+            toolCallRequest: {
+              tool_call_id: "tool-1",
+              toolName: "test-tool",
+              parameters: [],
+            },
+            toolCallId: "tool-1",
+          },
+        ),
+      ],
+    });
+
+    render(<ThreadMessages thread={thread} messageRefs={mockMessageRefs} />);
+
+    // Should show user message but not an empty assistant message bubble
+    expect(screen.getAllByTestId("message-content")).toHaveLength(1);
+    expect(screen.getByText("user: Do something")).toBeInTheDocument();
+    // Tool call should still be shown
+    expect(screen.getByTestId("tool-call-message")).toBeInTheDocument();
   });
 });

--- a/apps/web/components/observability/messages/thread-messages.test.tsx
+++ b/apps/web/components/observability/messages/thread-messages.test.tsx
@@ -17,34 +17,11 @@ import userEvent from "@testing-library/user-event";
 import { MessageRole } from "@tambo-ai-cloud/core";
 import React from "react";
 
-// Mock the utils - provide extractComponentsFromMessage inline, mock isSameDay
+// Mock only isSameDay, use real extractComponentsFromMessage
 jest.mock("../utils", () => ({
+  ...jest.requireActual("../utils"),
   isSameDay: (date1: Date, date2: Date) =>
     date1.toDateString() === date2.toDateString(),
-  extractComponentsFromMessage: (message: any) => {
-    const components: any[] = [];
-    if (Array.isArray(message.content)) {
-      for (const part of message.content) {
-        if (part?.type === "component" && part.name) {
-          components.push({
-            id: part.id ?? `comp_${message.id}`,
-            name: part.name,
-            props: part.props ?? {},
-            state: part.state ?? message.componentState ?? undefined,
-          });
-        }
-      }
-    }
-    if (components.length === 0 && message.componentDecision?.componentName) {
-      components.push({
-        id: `comp_${message.id}`,
-        name: message.componentDecision.componentName,
-        props: message.componentDecision.props ?? {},
-        state: message.componentState ?? undefined,
-      });
-    }
-    return components;
-  },
 }));
 
 // Mock the child components

--- a/apps/web/components/observability/messages/thread-messages.tsx
+++ b/apps/web/components/observability/messages/thread-messages.tsx
@@ -8,7 +8,11 @@ import { type RouterOutputs } from "@/trpc/react";
 import { AnimatePresence, motion } from "framer-motion";
 import { ChevronDown } from "lucide-react";
 import { FC, ReactNode, useCallback, useMemo, useState } from "react";
-import { isSameDay } from "../utils";
+import {
+  type ExtractedComponent,
+  extractComponentsFromMessage,
+  isSameDay,
+} from "../utils";
 import { ComponentMessage } from "./component-message";
 import { DateSeparator } from "./date-separator";
 import { MessageContent } from "./message-content";
@@ -21,7 +25,24 @@ type MessageGroup = {
   type: "message" | "tool_call" | "component";
   message: MessageType;
   toolResponse?: MessageType;
+  componentData?: ExtractedComponent;
 };
+
+/**
+ * Checks if a message has displayable text or image content.
+ * Component content parts are displayed separately via ComponentMessage,
+ * so they don't count as displayable content here.
+ */
+function hasDisplayableContent(content: MessageType["content"]): boolean {
+  if (!Array.isArray(content)) return false;
+  return content.some((part) => {
+    if (!part || typeof part !== "object" || !("type" in part)) return false;
+    if (part.type === "text" && "text" in part) return !!part.text?.trim();
+    if (part.type === "image_url") return true;
+    if (part.type === "resource") return true;
+    return false;
+  });
+}
 
 // Helper function to determine alignment classes
 const getAlignmentClasses = (
@@ -40,7 +61,7 @@ const getMessageKey = (group: MessageGroup): string => {
     return `tool-${group.message.id}`;
   }
   if (group.type === "component") {
-    return `component-${group.message.id}`;
+    return `component-${group.componentData?.id ?? group.message.id}`;
   }
   return `msg-${group.message.id}`;
 };
@@ -88,10 +109,11 @@ const MessageRenderer: FC<MessageRendererProps> = ({
     );
   }
 
-  if (group.type === "component") {
+  if (group.type === "component" && group.componentData) {
     return (
       <ComponentMessage
         message={group.message}
+        componentData={group.componentData}
         isHighlighted={isHighlighted}
         searchQuery={searchQuery}
       />
@@ -176,14 +198,24 @@ export function ThreadMessages({
         continue;
       }
 
-      // Always add the message first (user or assistant)
-      groups.push({
-        type: "message",
-        message,
-      });
+      const hasToolCall = !!message.toolCallRequest;
+      const components = extractComponentsFromMessage(message);
+      const hasComponent = components.length > 0;
+
+      // Only add a message bubble if there's displayable text/image content,
+      // or if the message has no tool call or component to represent it
+      if (
+        hasDisplayableContent(message.content) ||
+        (!hasToolCall && !hasComponent)
+      ) {
+        groups.push({
+          type: "message",
+          message,
+        });
+      }
 
       // If this message has a tool call, add a separate tool call entry
-      if (message.toolCallRequest) {
+      if (hasToolCall) {
         // Look for the corresponding tool response
         const toolResponse = messages.find(
           (msg, idx) =>
@@ -199,11 +231,13 @@ export function ThreadMessages({
         });
       }
 
-      // If this message has a component decision, add a separate component entry
-      if (message.componentDecision?.componentName) {
+      // If this message has components (in content array or legacy componentDecision),
+      // add a separate component entry for each
+      for (const comp of components) {
         groups.push({
           type: "component",
           message,
+          componentData: comp,
         });
       }
     }

--- a/apps/web/components/observability/messages/thread-messages.tsx
+++ b/apps/web/components/observability/messages/thread-messages.tsx
@@ -21,12 +21,14 @@ import { ToolCallMessage } from "./tool-call-message";
 type ThreadType = RouterOutputs["thread"]["getThread"];
 type MessageType = ThreadType["messages"][0];
 
-type MessageGroup = {
-  type: "message" | "tool_call" | "component";
-  message: MessageType;
-  toolResponse?: MessageType;
-  componentData?: ExtractedComponent;
-};
+type MessageGroup =
+  | { type: "message"; message: MessageType }
+  | { type: "tool_call"; message: MessageType; toolResponse?: MessageType }
+  | {
+      type: "component";
+      message: MessageType;
+      componentData: ExtractedComponent;
+    };
 
 /**
  * Checks if a message has displayable text or image content.
@@ -61,7 +63,7 @@ const getMessageKey = (group: MessageGroup): string => {
     return `tool-${group.message.id}`;
   }
   if (group.type === "component") {
-    return `component-${group.componentData?.id ?? group.message.id}`;
+    return `component-${group.componentData.id}`;
   }
   return `msg-${group.message.id}`;
 };
@@ -109,7 +111,7 @@ const MessageRenderer: FC<MessageRendererProps> = ({
     );
   }
 
-  if (group.type === "component" && group.componentData) {
+  if (group.type === "component") {
     return (
       <ComponentMessage
         message={group.message}

--- a/apps/web/components/observability/utils.ts
+++ b/apps/web/components/observability/utils.ts
@@ -1,5 +1,9 @@
 import { getSafeContent } from "@/lib/thread-hooks";
 import { type RouterOutputs } from "@/trpc/react";
+import {
+  type ChatCompletionContentPart,
+  type ChatCompletionContentPartComponent,
+} from "@tambo-ai-cloud/core";
 import { SortDirection, SortField } from "./hooks/useThreadList";
 import { MessageItem, ThreadStats } from "./messages/stats-header";
 
@@ -83,6 +87,17 @@ export interface ExtractedComponent {
   state?: Record<string, unknown>;
 }
 
+function isComponentContentPart(
+  part: ChatCompletionContentPart,
+): part is ChatCompletionContentPartComponent {
+  return (
+    typeof part === "object" &&
+    part !== null &&
+    "type" in part &&
+    part.type === "component"
+  );
+}
+
 /**
  * Extracts components from a message, checking the content array first
  * (new format with type: "component" content parts) and falling back
@@ -97,28 +112,15 @@ export function extractComponentsFromMessage(
 
   if (Array.isArray(message.content)) {
     for (const part of message.content) {
-      if (
-        part &&
-        typeof part === "object" &&
-        "type" in part &&
-        part.type === "component"
-      ) {
-        const compPart = part as {
-          id?: string;
-          name?: string;
-          props?: Record<string, unknown>;
-          state?: Record<string, unknown>;
-        };
-        if (compPart.name) {
-          components.push({
-            id: compPart.id ?? `comp_${message.id}`,
-            name: compPart.name,
-            props: compPart.props ?? {},
-            state:
-              compPart.state ??
-              (message.componentState as Record<string, unknown> | undefined),
-          });
-        }
+      if (isComponentContentPart(part)) {
+        components.push({
+          id: part.id ?? `comp_${message.id}`,
+          name: part.name,
+          props: part.props ?? {},
+          state:
+            part.state ??
+            (message.componentState as Record<string, unknown> | undefined),
+        });
       }
     }
   }

--- a/apps/web/components/observability/utils.ts
+++ b/apps/web/components/observability/utils.ts
@@ -71,6 +71,71 @@ export const getRoleColor = (role: string) => {
   }
 };
 
+// Component Extraction ---------------------------------------------------------
+
+/**
+ * Represents a component extracted from a message, regardless of storage format.
+ */
+export interface ExtractedComponent {
+  id: string;
+  name: string;
+  props: Record<string, unknown>;
+  state?: Record<string, unknown>;
+}
+
+/**
+ * Extracts components from a message, checking the content array first
+ * (new format with type: "component" content parts) and falling back
+ * to the legacy componentDecision field.
+ * @param message - The thread message to extract components from
+ * @returns Array of extracted components (empty if none found)
+ */
+export function extractComponentsFromMessage(
+  message: MessageType,
+): ExtractedComponent[] {
+  const components: ExtractedComponent[] = [];
+
+  if (Array.isArray(message.content)) {
+    for (const part of message.content) {
+      if (
+        part &&
+        typeof part === "object" &&
+        "type" in part &&
+        part.type === "component"
+      ) {
+        const compPart = part as {
+          id?: string;
+          name?: string;
+          props?: Record<string, unknown>;
+          state?: Record<string, unknown>;
+        };
+        if (compPart.name) {
+          components.push({
+            id: compPart.id ?? `comp_${message.id}`,
+            name: compPart.name,
+            props: compPart.props ?? {},
+            state:
+              compPart.state ??
+              (message.componentState as Record<string, unknown> | undefined),
+          });
+        }
+      }
+    }
+  }
+
+  // Fall back to componentDecision (legacy storage)
+  if (components.length === 0 && message.componentDecision?.componentName) {
+    components.push({
+      id: `comp_${message.id}`,
+      name: message.componentDecision.componentName,
+      props: message.componentDecision.props ?? {},
+      state: message.componentState as Record<string, unknown> | undefined,
+    });
+  }
+
+  return components;
+}
+
 // Thread Stats -----------------------------------------------------------------
 
 export const calculateThreadStats = (messages: MessageType[]): ThreadStats => {
@@ -82,9 +147,7 @@ export const calculateThreadStats = (messages: MessageType[]): ThreadStats => {
   };
 
   messages.forEach((message: MessageType) => {
-    if (message.componentDecision?.componentName) {
-      stats.components++;
-    }
+    stats.components += extractComponentsFromMessage(message).length;
 
     if (isErrorMessage(message)) {
       stats.errors++;
@@ -158,12 +221,12 @@ export const createMessageItems = (
       messageId: message.id,
     });
 
-    // Components
-    if (message.componentDecision?.componentName) {
+    // Components (from content array or legacy componentDecision)
+    for (const comp of extractComponentsFromMessage(message)) {
       componentItems.push({
-        id: `comp-${message.id}`,
+        id: `comp-${comp.id}`,
         type: "component",
-        title: message.componentDecision.componentName,
+        title: comp.name,
         subtitle: `Used in ${message.role} message`,
         messageId: message.id,
       });

--- a/apps/web/components/observability/utils.ts
+++ b/apps/web/components/observability/utils.ts
@@ -114,7 +114,7 @@ export function extractComponentsFromMessage(
     for (const part of message.content) {
       if (isComponentContentPart(part)) {
         components.push({
-          id: part.id ?? `comp_${message.id}`,
+          id: part.id ?? `comp_${message.id}_${components.length}`,
           name: part.name,
           props: part.props ?? {},
           state:


### PR DESCRIPTION
## Summary
- Observability now extracts component data from the V1 API content array (`type: "component"` content parts) in addition to the legacy `componentDecision` field
- Empty assistant message bubbles before tool calls/components are hidden when there's no text content
- Component state is now displayed alongside props in the observability view

## Why
When a thread renders a table component (or any component stored in the content array rather than `componentDecision`), the observability view didn't show it. This is because observability exclusively read from `componentDecision`, missing the newer V1 API storage format.

## Changes
- **`utils.ts`** -- Added `extractComponentsFromMessage()` helper that checks content array first, falls back to `componentDecision`. Updated `calculateThreadStats` and `createMessageItems` to use it.
- **`thread-messages.tsx`** -- Updated grouping logic to use the helper. Added `hasDisplayableContent()` to skip empty message bubbles. Added `componentData` to `MessageGroup` type.
- **`component-message.tsx`** -- `componentData` is now a required prop (no more redundant fallback). Shows component state via reusable `ComponentPropsSection`.
- **`component-props-section.tsx`** -- Added configurable `label` prop.
- **`thread-messages-modal.tsx`** -- Search now finds components in content array too.
- **Test coverage** -- New factory, 2 new test cases (content array detection, empty bubble hiding).

## Test Plan
- [x] All 246 web app tests pass (including 2 new ones)
- [x] TypeScript type-check passes
- [x] ESLint passes
- [ ] Manual: Open observability for a thread with a table component rendered via V1 API -- component should now appear
- [ ] Manual: Verify empty assistant bubbles before tool calls are no longer shown

Fixes TAM-1480