### PR TITLE
feat(api,backend): capture provider skill tool usage as load_skill events

### DIFF
--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -1981,6 +1981,89 @@ export class ThreadsService {
         },
       });
 
+      // Persist provider skill tool call messages post-stream, BEFORE the
+      // tool-limit check so early returns don't skip skill persistence.
+      // Each skill call produces an assistant message (with toolCallRequest)
+      // and a tool response message, both tagged with providerSkill metadata.
+      // TOOL_CALL_RESULT events are collected here and emitted with the final response.
+      const skillResultEvents: BaseEvent[] = [];
+      if (allCompletedSkillCalls.length > 0) {
+        const providerSkillMetadata = {
+          _tambo: { providerSkill: true },
+        };
+
+        for (const skillCall of allCompletedSkillCalls) {
+          try {
+            // Save assistant message for the tool call
+            await addMessage(
+              db,
+              threadId,
+              {
+                role: MessageRole.Assistant,
+                content: [
+                  {
+                    type: ContentPartType.Text,
+                    text: "",
+                  },
+                ],
+                toolCallRequest: {
+                  toolName: skillCall.toolName,
+                  parameters: jsonArgsToParameters(skillCall.args),
+                },
+                tool_call_id: skillCall.toolCallId,
+                actionType: ActionType.ToolCall,
+                metadata: providerSkillMetadata,
+              },
+              sdkVersion,
+            );
+
+            // Save tool response message
+            const resultContent =
+              typeof skillCall.result === "string"
+                ? skillCall.result
+                : JSON.stringify(skillCall.result);
+            const toolResponseMsg = await addMessage(
+              db,
+              threadId,
+              {
+                role: MessageRole.Tool,
+                content: [
+                  {
+                    type: ContentPartType.Text,
+                    text: resultContent,
+                  },
+                ],
+                tool_call_id: skillCall.toolCallId,
+                actionType: ActionType.ToolResponse,
+                metadata: providerSkillMetadata,
+              },
+              sdkVersion,
+            );
+
+            skillResultEvents.push({
+              type: EventType.TOOL_CALL_RESULT,
+              toolCallId: skillCall.toolCallId,
+              messageId: toolResponseMsg.id,
+              content: resultContent,
+              timestamp: Date.now(),
+            } as ToolCallResultEvent);
+          } catch (error) {
+            // Skill persistence is for observability — don't crash the stream
+            Sentry.captureException(error, {
+              tags: {
+                threadId,
+                projectId,
+                operation: "persistProviderSkillCall",
+              },
+              extra: { toolCallId: skillCall.toolCallId },
+            });
+            this.logger.error(
+              `Failed to persist provider skill call ${skillCall.toolCallId}: ${error}`,
+            );
+          }
+        }
+      }
+
       // The tool call request has already been unstrictified in the streaming loop above,
       // so we just extract it here for the tool limit check
       const toolCallRequest = finalThreadMessage.toolCallRequest;
@@ -2020,72 +2103,6 @@ export class ThreadsService {
             finalThreadMessage,
             logger,
           ));
-      }
-      // Persist provider skill tool call messages post-stream.
-      // Each skill call produces an assistant message (with toolCallRequest)
-      // and a tool response message, both tagged with providerSkill metadata.
-      // TOOL_CALL_RESULT events are collected here and emitted with the final response.
-      const skillResultEvents: BaseEvent[] = [];
-      if (allCompletedSkillCalls.length > 0) {
-        const providerSkillMetadata = {
-          _tambo: { providerSkill: true },
-        };
-
-        for (const skillCall of allCompletedSkillCalls) {
-          // Save assistant message for the tool call
-          await addMessage(
-            db,
-            threadId,
-            {
-              role: MessageRole.Assistant,
-              content: [
-                {
-                  type: ContentPartType.Text,
-                  text: "",
-                },
-              ],
-              toolCallRequest: {
-                toolName: skillCall.toolName,
-                parameters: jsonArgsToParameters(skillCall.args),
-              },
-              tool_call_id: skillCall.toolCallId,
-              actionType: ActionType.ToolCall,
-              metadata: providerSkillMetadata,
-            },
-            sdkVersion,
-          );
-
-          // Save tool response message
-          const resultContent =
-            typeof skillCall.result === "string"
-              ? skillCall.result
-              : JSON.stringify(skillCall.result);
-          const toolResponseMsg = await addMessage(
-            db,
-            threadId,
-            {
-              role: MessageRole.Tool,
-              content: [
-                {
-                  type: ContentPartType.Text,
-                  text: resultContent,
-                },
-              ],
-              tool_call_id: skillCall.toolCallId,
-              actionType: ActionType.ToolResponse,
-              metadata: providerSkillMetadata,
-            },
-            sdkVersion,
-          );
-
-          skillResultEvents.push({
-            type: EventType.TOOL_CALL_RESULT,
-            toolCallId: skillCall.toolCallId,
-            messageId: toolResponseMsg.id,
-            content: resultContent,
-            timestamp: Date.now(),
-          } as ToolCallResultEvent);
-        }
       }
 
       // skillResultEvents will be attached to the next queue push below
@@ -2169,6 +2186,7 @@ export class ThreadsService {
             statusMessage: resultingStatusMessage,
             ...(mcpAccessToken && { mcpAccessToken }),
           },
+          aguiEvents: skillResultEvents,
         });
 
         // `tool_call_id` can be missing in edge cases, but UI tools should never be client-invokable.
@@ -2694,6 +2712,9 @@ function jsonArgsToParameters(
       parsed === null ||
       Array.isArray(parsed)
     ) {
+      console.warn(
+        `[Skills] jsonArgsToParameters: parsed JSON is not a plain object (type=${typeof parsed}), using raw fallback`,
+      );
       return [{ parameterName: "raw", parameterValue: json }];
     }
     return Object.entries(parsed as Record<string, unknown>).map(
@@ -2702,7 +2723,11 @@ function jsonArgsToParameters(
         parameterValue,
       }),
     );
-  } catch {
+  } catch (error) {
+    console.warn(
+      `[Skills] jsonArgsToParameters: failed to parse JSON args, using raw fallback:`,
+      error,
+    );
     return [{ parameterName: "raw", parameterValue: json }];
   }
 }

--- a/apps/api/src/threads/threads.service.ts
+++ b/apps/api/src/threads/threads.service.ts
@@ -1,5 +1,10 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import {
+  EventType,
+  type BaseEvent,
+  type ToolCallResultEvent,
+} from "@ag-ui/client";
 import * as Sentry from "@sentry/nestjs";
 import {
   convertMetadataToTools,
@@ -12,6 +17,7 @@ import {
   ModelOptions,
   Provider,
   ToolRegistry,
+  type ProviderSkillCall,
 } from "@tambo-ai-cloud/backend";
 import {
   ActionType,
@@ -1791,6 +1797,10 @@ export class ThreadsService {
         updateIntervalMs,
       );
 
+      // Collect provider-managed skill tool calls during streaming.
+      // Persisted post-stream to avoid blocking the hot path with DB writes.
+      const allCompletedSkillCalls: ProviderSkillCall[] = [];
+
       let currentLegacyDecisionId: string | undefined = undefined;
       for await (const streamItem of fixStreamedToolCalls(stream)) {
         const legacyDecision = streamItem.decision;
@@ -1911,6 +1921,13 @@ export class ThreadsService {
           return;
         }
 
+        // Collect completed provider skill calls for post-stream persistence.
+        if (streamItem.completedProviderSkillCalls?.length) {
+          allCompletedSkillCalls.push(
+            ...streamItem.completedProviderSkillCalls,
+          );
+        }
+
         // This is kind of a hack: when we have a tool call, but we might not want to
         // emit it all the way to the frontend, because that is how the frontend
         // knows to actually call a tool.. but the tool here might be an
@@ -2004,6 +2021,74 @@ export class ThreadsService {
             logger,
           ));
       }
+      // Persist provider skill tool call messages post-stream.
+      // Each skill call produces an assistant message (with toolCallRequest)
+      // and a tool response message, both tagged with providerSkill metadata.
+      // TOOL_CALL_RESULT events are collected here and emitted with the final response.
+      const skillResultEvents: BaseEvent[] = [];
+      if (allCompletedSkillCalls.length > 0) {
+        const providerSkillMetadata = {
+          _tambo: { providerSkill: true },
+        };
+
+        for (const skillCall of allCompletedSkillCalls) {
+          // Save assistant message for the tool call
+          await addMessage(
+            db,
+            threadId,
+            {
+              role: MessageRole.Assistant,
+              content: [
+                {
+                  type: ContentPartType.Text,
+                  text: "",
+                },
+              ],
+              toolCallRequest: {
+                toolName: skillCall.toolName,
+                parameters: jsonArgsToParameters(skillCall.args),
+              },
+              tool_call_id: skillCall.toolCallId,
+              actionType: ActionType.ToolCall,
+              metadata: providerSkillMetadata,
+            },
+            sdkVersion,
+          );
+
+          // Save tool response message
+          const resultContent =
+            typeof skillCall.result === "string"
+              ? skillCall.result
+              : JSON.stringify(skillCall.result);
+          const toolResponseMsg = await addMessage(
+            db,
+            threadId,
+            {
+              role: MessageRole.Tool,
+              content: [
+                {
+                  type: ContentPartType.Text,
+                  text: resultContent,
+                },
+              ],
+              tool_call_id: skillCall.toolCallId,
+              actionType: ActionType.ToolResponse,
+              metadata: providerSkillMetadata,
+            },
+            sdkVersion,
+          );
+
+          skillResultEvents.push({
+            type: EventType.TOOL_CALL_RESULT,
+            toolCallId: skillCall.toolCallId,
+            messageId: toolResponseMsg.id,
+            content: resultContent,
+            timestamp: Date.now(),
+          } as ToolCallResultEvent);
+        }
+      }
+
+      // skillResultEvents will be attached to the next queue push below
       const componentDecision = finalThreadMessage.component;
       if (componentDecision && isSystemToolCall(toolCallRequest, allTools)) {
         // Track system tool call within stream
@@ -2031,7 +2116,7 @@ export class ThreadsService {
             statusMessage: resultingStatusMessage,
             ...(mcpAccessToken && { mcpAccessToken }),
           },
-          aguiEvents: [], // System tool call handling, no AG-UI events
+          aguiEvents: skillResultEvents,
         });
 
         const toolCallId = finalThreadMessage.tool_call_id;
@@ -2184,7 +2269,7 @@ export class ThreadsService {
             statusMessage: resultingStatusMessage,
             ...(mcpAccessToken && { mcpAccessToken }),
           },
-          aguiEvents: [],
+          aguiEvents: skillResultEvents,
         });
 
         // Continue the decision loop with the tool response
@@ -2229,7 +2314,7 @@ export class ThreadsService {
           statusMessage: resultingStatusMessage,
           ...(mcpAccessToken && { mcpAccessToken }),
         },
-        aguiEvents: [], // Final response after tool call, no more AG-UI events
+        aguiEvents: skillResultEvents,
       });
     } catch (error) {
       // Capture streaming errors with full context
@@ -2593,4 +2678,31 @@ function deriveToolLimitsFromDto(
   }
 
   return limits;
+}
+
+/**
+ * Parse a raw JSON args string into the ToolCallRequest parameters format.
+ * @returns Array of { parameterName, parameterValue } entries
+ */
+function jsonArgsToParameters(
+  json: string,
+): { parameterName: string; parameterValue: unknown }[] {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return [{ parameterName: "raw", parameterValue: json }];
+    }
+    return Object.entries(parsed as Record<string, unknown>).map(
+      ([parameterName, parameterValue]) => ({
+        parameterName,
+        parameterValue,
+      }),
+    );
+  } catch {
+    return [{ parameterName: "raw", parameterValue: json }];
+  }
 }

--- a/devdocs/solutions/architecture/provider-managed-skill-tool-calls.md
+++ b/devdocs/solutions/architecture/provider-managed-skill-tool-calls.md
@@ -1,113 +1,90 @@
 ---
-title: Provider-Managed Skill Tool Calls - Suppress, Don't Integrate
+title: Provider-Managed Skill Tool Calls - Normalize and Emit
 category: architecture
 tags: [skills, streaming, ai-sdk, tool-calls, anthropic, openai]
 module: packages/backend
 created: 2026-04-06
-pr: "#TAM-1470, #TAM-1471"
+updated: 2026-04-09
+pr: "#TAM-1470, #TAM-1471, #TAM-1486"
 ---
 
-# Provider-Managed Skill Tool Calls - Suppress, Don't Integrate
+# Provider-Managed Skill Tool Calls - Normalize and Emit
 
-When providers (Anthropic, OpenAI) execute skills, they emit tool call events (`code_execution`, `shell`) through the AI SDK streaming pipeline. These are internal to the provider and should not flow through Tambo's tool call pipeline.
+When providers (Anthropic, OpenAI) execute skills, they emit tool call events (`code_execution`, `shell`) through the AI SDK streaming pipeline. These events are normalized to `load_skill` and emitted as standard AG-UI tool call events for observability, while being filtered out of conversations sent back to the LLM.
 
-## Problem
+## History
 
-Skill execution generates tool events that look identical to user-registered tool calls in the streaming pipeline. Naively letting them through causes:
+### Original approach: Suppress (TAM-1470, TAM-1471)
 
-- UI showing "code_execution" as a tool name
-- Internal paths like `/skills/my-skill/SKILL.md` leaking to end users
-- Tool calls appearing/disappearing on page refresh (provider-executed tools get cleared at `tool-result`)
-- Multiple tool calls within one turn overwriting each other (single `toolCallRequest` per message)
+The original implementation completely suppressed skill tool events at the streaming boundary. This was the right call at the time — the requirement was to prevent internal provider details from leaking to the client, and suppression accomplished that with a boolean flag and three `break` statements.
 
-## Approaches Tried (and Why They Failed)
+### Why it changed: Observability (TAM-1486)
 
-### 1. Rename + Sanitize (Too Brittle)
+Suppression meant zero visibility into skill usage. Developers had no way to know through observability whether a skill was loaded, making debugging skill updates difficult. The new requirement: capture skill tool usage for each provider.
 
-Renamed `code_execution` to `skill`, sanitized args, accumulated skill names across calls. Required special cases in 7 files:
+## Current Approach: Normalize and Emit
 
-- Streaming handler: 5 tracking variables, coordinated event emission
-- Decision loop: conditional spreads to preserve data across yields
-- Tool service: early returns for unknown tools
-- Threads service: 40-line detection block
-- V1 conversions: skip skill tool_use blocks
-- Observability UI: reorder skill cards before text
-- Core package: new shared constants
+### Overview
 
-Each fix created a new edge case downstream.
+1. Provider skill tool events (`code_execution`, `shell`) are detected in the streaming handler
+2. The tool name is normalized to `load_skill`
+3. Standard AG-UI events (`TOOL_CALL_START`, `TOOL_CALL_ARGS`, `TOOL_CALL_END`) are emitted during streaming
+4. Completed skill calls are captured as `ProviderSkillCall` objects on the stream item
+5. Post-stream, skill call messages are persisted to the DB with `metadata._tambo.providerSkill = true`
+6. A `TOOL_CALL_RESULT` AG-UI event is emitted after persistence
+7. When building the conversation for the next LLM call, skill messages are filtered out
 
-### 2. Metadata-Based Tracking (Still Overengineered)
-
-Tracked skill executions as `metadata._tambo.skillExecutions` instead of tool calls. Cleaner, but still added:
-
-- New field on `LLMStreamItem` and `DecisionStreamItem` interfaces
-- Skill name extraction with regex parsing
-- Metadata storage in threads service
-- New UI component to render skill badges
-- Core package with `isSkillToolName` helper
-
-For one provider's tool call that nobody needs to see.
-
-### 3. Just Suppress (The Right Answer)
-
-A boolean flag and three `break` statements in `ai-sdk-client.ts`. Skill tool events are completely invisible to the tool call accumulator. The LLM describes what the skill did in its text response (enforced by a system prompt addition).
-
-## Working Solution
-
-### `ai-sdk-client.ts` (streaming handler)
+### Detection
 
 ```typescript
-// Provider-specific: only suppress the tool name injected by the active provider
 const PROVIDER_SKILL_TOOL_NAME: Record<string, string> = {
   anthropic: "code_execution",
   openai: "shell",
 };
 
-// In callLLM(), resolve the skill tool name for this request:
-const skillToolName = params.providerSkills?.skills.length
-  ? PROVIDER_SKILL_TOOL_NAME[providerKey]
-  : undefined;
-
 // In the streaming loop:
-case "tool-input-start":
-  isProviderSkillTool = !!skillToolName && delta.toolName === skillToolName;
-  if (isProviderSkillTool) {
-    componentTracker = undefined;
-    break; // Skip entirely
-  }
-  // ... normal tool handling ...
-
-case "tool-input-delta":
-  if (isProviderSkillTool) break;
-  // ... normal tool handling ...
-
-case "tool-call":
-  // ... google metadata handling ...
-  if (isProviderSkillTool) break;
-  // ... normal tool handling ...
+isProviderSkillTool = !!skillToolName && delta.toolName === skillToolName;
 ```
 
-### `decision-loop-prompts.ts` (system prompt)
+A user tool that happens to share a name with a provider's skill tool (e.g. user tool "shell" on Anthropic) is not affected — only the matching provider's skill tool name is normalized.
 
-```
-### Skills (Internal Implementation Detail)
+### `ai-sdk-client.ts` (streaming handler)
 
-You may have access to skills that run in a secure container environment.
-These skills are an internal implementation detail and must be treated as opaque.
+Instead of suppressing, the handler:
 
-- Do NOT mention skill file names, skill IDs, SKILL.md files, or any internal skill structure
-- Do NOT describe how skills are loaded, structured, or executed
-- When you use a skill, briefly mention which skill you are using by its name (e.g. "Using the data-analyzer skill...") so the user knows what is happening, then describe what it accomplished in plain language
-- Treat skill capabilities as your own built-in abilities
-```
+- Emits `TOOL_CALL_START` with `toolCallName: "load_skill"` (normalized)
+- Accumulates args via `TOOL_CALL_ARGS` events
+- Emits `TOOL_CALL_END` on `tool-call`
+- At `tool-result`, captures a `ProviderSkillCall` with the tool call ID, raw args, and result
+- Yields `completedProviderSkillCalls` on the `LLMStreamItem`
 
-## Key Lesson
+Text stitching (reusing `textMessageId` across skill boundaries with `"\n\n"` separator) is preserved.
 
-When provider internals leak into your pipeline, the answer is almost always "suppress at the source" rather than "integrate and then special-case everywhere downstream." The cost of a clean suppression is O(1) lines at the boundary. The cost of integration-then-special-casing grows with every downstream consumer.
+### `threads.service.ts` (persistence)
 
-## Prevention
+Skill calls are accumulated during streaming and persisted post-stream to avoid blocking the hot path with DB writes. For each completed skill call:
 
-When new provider-managed tools are added (beyond `code_execution` and `shell`):
+1. An assistant message is saved with `toolCallRequest` and `metadata._tambo.providerSkill = true`
+2. A tool response message is saved with the result and the same metadata
+3. A `TOOL_CALL_RESULT` AG-UI event is emitted with the persisted message ID
+
+### `thread-to-model-message-conversion.ts` (filtering)
+
+Messages with `metadata._tambo.providerSkill === true` are skipped when building the conversation for the next LLM call. This prevents skill tool call/response pairs from polluting the LLM context.
+
+## Key Design Decisions
+
+1. **Normalize tool name**: `"shell"` / `"code_execution"` -> `"load_skill"` so clients see a consistent tool name regardless of provider.
+
+2. **Separate accumulator**: Skill calls use `accumulatedSkillCall` instead of `accumulatedToolCall` to keep the main tool call pipeline clean. The two never interact.
+
+3. **Post-stream persistence**: DB writes happen after the streaming loop, not during it. This avoids injecting latency into the real-time stream.
+
+4. **Metadata-based filtering**: `metadata._tambo.providerSkill = true` is used to identify skill messages for filtering. This is checked by `isProviderSkillMessage()` in `llm-client.ts`.
+
+## Adding New Providers
+
+When a new provider adds skill support with a different tool name:
 
 1. Add the provider and tool name to `PROVIDER_SKILL_TOOL_NAME` in `ai-sdk-client.ts`
-2. That's it. The flag handles the rest.
+2. The normalization, emission, and persistence all apply automatically

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -37,7 +37,7 @@ export { type DecisionStreamItem } from "./services/decision-loop/decision-loop-
 export {
   type ProviderSkillCall,
   isProviderSkillMessage,
-} from "./services/llm/llm-client";
+} from "./util/provider-skill";
 export { sanitizeEvent } from "./util/event-sanitization";
 export {
   deleteSkillFromProvider,

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -34,6 +34,10 @@ export {
   type ModelOptions,
 } from "./tambo-backend";
 export { type DecisionStreamItem } from "./services/decision-loop/decision-loop-service";
+export {
+  type ProviderSkillCall,
+  isProviderSkillMessage,
+} from "./services/llm/llm-client";
 export { sanitizeEvent } from "./util/event-sanitization";
 export {
   deleteSkillFromProvider,

--- a/packages/backend/src/services/decision-loop/decision-loop-service.ts
+++ b/packages/backend/src/services/decision-loop/decision-loop-service.ts
@@ -23,6 +23,7 @@ import {
   getLLMResponseMessage,
   getLLMResponseToolCallId,
   LLMClient,
+  type ProviderSkillCall,
 } from "../llm/llm-client";
 import {
   addParametersToTools,
@@ -52,6 +53,12 @@ export interface DecisionStreamItem {
 
   /** Provider options to persist on tool calls (e.g. Gemini thought signatures). */
   toolCallProviderOptionsById?: Record<string, ProviderOptions>;
+
+  /**
+   * Provider-managed skill tool calls that completed during this streaming delta.
+   * Passed through from LLMStreamItem for threads.service.ts to persist.
+   */
+  completedProviderSkillCalls?: ProviderSkillCall[];
 }
 
 const TOOL_CHOICE_KEYWORDS = ["auto", "required", "none"] as const;
@@ -302,6 +309,7 @@ export async function* runDecisionLoop(
         decision: accumulatedDecision,
         aguiEvents: streamItem.aguiEvents,
         toolCallProviderOptionsById: streamItem.toolCallProviderOptionsById,
+        completedProviderSkillCalls: streamItem.completedProviderSkillCalls,
       };
     } catch (e) {
       console.error("Error parsing stream chunk:", e);

--- a/packages/backend/src/services/decision-loop/decision-loop-service.ts
+++ b/packages/backend/src/services/decision-loop/decision-loop-service.ts
@@ -23,8 +23,8 @@ import {
   getLLMResponseMessage,
   getLLMResponseToolCallId,
   LLMClient,
-  type ProviderSkillCall,
 } from "../llm/llm-client";
+import type { ProviderSkillCall } from "../../util/provider-skill";
 import {
   addParametersToTools,
   filterOutStandardToolParameters,

--- a/packages/backend/src/services/llm/ai-sdk-client.test.ts
+++ b/packages/backend/src/services/llm/ai-sdk-client.test.ts
@@ -67,7 +67,7 @@ type StreamDelta =
   | {
       type: "tool-result";
       toolCallId: string;
-      result: unknown;
+      output: unknown;
       providerExecuted: boolean;
     }
   | { type: "text-start" }
@@ -578,7 +578,7 @@ describe("AISdkClient", () => {
     });
   });
 
-  describe("handleStreamingResponse - skill tool suppression", () => {
+  describe("handleStreamingResponse - skill tool emission", () => {
     function createClient() {
       return new AISdkClient(
         "test-api-key",
@@ -601,7 +601,7 @@ describe("AISdkClient", () => {
       );
     }
 
-    it("suppresses skill tool calls when provider skills are configured", async () => {
+    it("emits load_skill TOOL_CALL events and captures completedProviderSkillCalls", async () => {
       const client = createClient();
       const mockDeltas: StreamDelta[] = [
         { type: "text-start" },
@@ -626,7 +626,7 @@ describe("AISdkClient", () => {
         {
           type: "tool-result",
           toolCallId: "call-skill",
-          result: "ok",
+          output: "ok",
           providerExecuted: true,
         },
         { type: "text-start" },
@@ -635,7 +635,7 @@ describe("AISdkClient", () => {
       ];
 
       const mockStream = createMockStreamResponse(mockDeltas);
-      const chunks = [];
+      const chunks: any[] = [];
       for await (const chunk of callHandleStreamingResponse(
         client,
         mockStream,
@@ -644,12 +644,51 @@ describe("AISdkClient", () => {
         chunks.push(chunk);
       }
 
-      // No chunk should have tool_calls set
+      // No chunk should have tool_calls on the llmResponse (skill calls bypass that pipeline)
       for (const chunk of chunks) {
         expect(chunk.llmResponse.message?.tool_calls).toBeUndefined();
       }
 
-      // The final accumulated message should contain both text segments
+      // AG-UI events should include TOOL_CALL_START with "load_skill" name
+      const allEvents = chunks.flatMap((c: any) => c.aguiEvents);
+      const startEvents = allEvents.filter(
+        (e: any) => e.type === EventType.TOOL_CALL_START,
+      );
+      expect(startEvents.length).toBe(1);
+      expect(startEvents[0].toolCallName).toBe("load_skill");
+      expect(startEvents[0].toolCallId).toBe("call-skill");
+
+      // Should have TOOL_CALL_ARGS and TOOL_CALL_END
+      const argsEvents = allEvents.filter(
+        (e: any) => e.type === EventType.TOOL_CALL_ARGS,
+      );
+      expect(argsEvents.length).toBe(1);
+      expect(argsEvents[0].delta).toBe('{"path":"/skills/foo/SKILL.md"}');
+
+      const endEvents = allEvents.filter(
+        (e: any) => e.type === EventType.TOOL_CALL_END,
+      );
+      expect(endEvents.length).toBe(1);
+
+      // Should NOT have TOOL_CALL_RESULT (emitted by threads.service.ts, not ai-sdk-client)
+      const resultEvents = allEvents.filter(
+        (e: any) => e.type === EventType.TOOL_CALL_RESULT,
+      );
+      expect(resultEvents.length).toBe(0);
+
+      // completedProviderSkillCalls should be populated on the tool-result chunk
+      const skillCallChunks = chunks.filter(
+        (c: any) => c.completedProviderSkillCalls?.length,
+      );
+      expect(skillCallChunks.length).toBe(1);
+      expect(skillCallChunks[0].completedProviderSkillCalls[0]).toEqual({
+        toolCallId: "call-skill",
+        toolName: "load_skill",
+        args: '{"path":"/skills/foo/SKILL.md"}',
+        result: "ok",
+      });
+
+      // Text should still be stitched
       const lastChunk = chunks[chunks.length - 1];
       expect(lastChunk.llmResponse.message?.content).toContain(
         "Using skill...",
@@ -723,7 +762,7 @@ describe("AISdkClient", () => {
       expect(startEvents[0].toolCallName).toBe("code_execution");
     });
 
-    it("suppresses all TOOL_CALL events for the matching skill tool name", async () => {
+    it("emits normalized load_skill TOOL_CALL events for the matching skill tool name", async () => {
       const client = createClient();
       const mockDeltas: StreamDelta[] = [
         {
@@ -741,7 +780,7 @@ describe("AISdkClient", () => {
         {
           type: "tool-result",
           toolCallId: "call-1",
-          result: "ok",
+          output: "ok",
           providerExecuted: true,
         },
       ];
@@ -756,14 +795,22 @@ describe("AISdkClient", () => {
         allEvents.push(...chunk.aguiEvents);
       }
 
-      // No TOOL_CALL events at all
-      const toolEvents = allEvents.filter(
-        (e: any) =>
-          e.type === EventType.TOOL_CALL_START ||
-          e.type === EventType.TOOL_CALL_ARGS ||
-          e.type === EventType.TOOL_CALL_END,
+      // Should have TOOL_CALL_START, TOOL_CALL_ARGS, and TOOL_CALL_END with normalized name
+      const startEvents = allEvents.filter(
+        (e: any) => e.type === EventType.TOOL_CALL_START,
       );
-      expect(toolEvents.length).toBe(0);
+      expect(startEvents.length).toBe(1);
+      expect(startEvents[0].toolCallName).toBe("load_skill");
+
+      const argsEvents = allEvents.filter(
+        (e: any) => e.type === EventType.TOOL_CALL_ARGS,
+      );
+      expect(argsEvents.length).toBe(1);
+
+      const endEvents = allEvents.filter(
+        (e: any) => e.type === EventType.TOOL_CALL_END,
+      );
+      expect(endEvents.length).toBe(1);
     });
 
     it("stitches text segments with separator when text resumes after skill", async () => {
@@ -786,7 +833,7 @@ describe("AISdkClient", () => {
         {
           type: "tool-result",
           toolCallId: "call-1",
-          result: "ok",
+          output: "ok",
           providerExecuted: true,
         },
         { type: "text-start" },

--- a/packages/backend/src/services/llm/ai-sdk-client.test.ts
+++ b/packages/backend/src/services/llm/ai-sdk-client.test.ts
@@ -861,6 +861,103 @@ describe("AISdkClient", () => {
       const uniqueIds = new Set(startEvents.map((e: any) => e.messageId));
       expect(uniqueIds.size).toBe(1);
     });
+
+    it("handles multiple skill tool calls in one stream", async () => {
+      const client = createClient();
+      const mockDeltas: StreamDelta[] = [
+        { type: "text-start" },
+        { type: "text-delta", text: "Loading skills..." },
+        { type: "text-end" },
+        // First skill
+        {
+          type: "tool-input-start",
+          id: "call-a",
+          toolName: "code_execution",
+        },
+        {
+          type: "tool-input-delta",
+          id: "call-a",
+          delta: '{"skill":"alpha"}',
+        },
+        {
+          type: "tool-call",
+          toolCallId: "call-a",
+          toolName: "code_execution",
+          args: {},
+        },
+        {
+          type: "tool-result",
+          toolCallId: "call-a",
+          output: "alpha-result",
+          providerExecuted: true,
+        },
+        // Second skill
+        {
+          type: "tool-input-start",
+          id: "call-b",
+          toolName: "code_execution",
+        },
+        {
+          type: "tool-input-delta",
+          id: "call-b",
+          delta: '{"skill":"beta"}',
+        },
+        {
+          type: "tool-call",
+          toolCallId: "call-b",
+          toolName: "code_execution",
+          args: {},
+        },
+        {
+          type: "tool-result",
+          toolCallId: "call-b",
+          output: "beta-result",
+          providerExecuted: true,
+        },
+        { type: "text-start" },
+        { type: "text-delta", text: "Done." },
+        { type: "text-end" },
+      ];
+
+      const mockStream = createMockStreamResponse(mockDeltas);
+      const chunks: any[] = [];
+      for await (const chunk of callHandleStreamingResponse(
+        client,
+        mockStream,
+        "code_execution",
+      )) {
+        chunks.push(chunk);
+      }
+
+      // Collect all completed skill calls across all chunks
+      const allSkillCalls = chunks.flatMap(
+        (c: any) => c.completedProviderSkillCalls ?? [],
+      );
+      expect(allSkillCalls.length).toBe(2);
+      expect(allSkillCalls[0].toolCallId).toBe("call-a");
+      expect(allSkillCalls[0].args).toBe('{"skill":"alpha"}');
+      expect(allSkillCalls[0].result).toBe("alpha-result");
+      expect(allSkillCalls[1].toolCallId).toBe("call-b");
+      expect(allSkillCalls[1].args).toBe('{"skill":"beta"}');
+      expect(allSkillCalls[1].result).toBe("beta-result");
+
+      // Should have 2 TOOL_CALL_START events, both with "load_skill"
+      const allEvents = chunks.flatMap((c: any) => c.aguiEvents);
+      const startEvents = allEvents.filter(
+        (e: any) => e.type === EventType.TOOL_CALL_START,
+      );
+      expect(startEvents.length).toBe(2);
+      expect(
+        startEvents.every((e: any) => e.toolCallName === "load_skill"),
+      ).toBe(true);
+
+      // Text should be stitched across both skill boundaries
+      const lastChunk = chunks[chunks.length - 1];
+      expect(lastChunk.llmResponse.message?.content).toContain(
+        "Loading skills...",
+      );
+      expect(lastChunk.llmResponse.message?.content).toContain("Done.");
+    });
   });
 
   describe("template substitution via complete()", () => {

--- a/packages/backend/src/services/llm/ai-sdk-client.ts
+++ b/packages/backend/src/services/llm/ai-sdk-client.ts
@@ -55,9 +55,9 @@ import {
   LLMClient,
   LLMResponse,
   LLMStreamItem,
-  type ProviderSkillCall,
   StreamingCompleteParams,
 } from "./llm-client";
+import type { ProviderSkillCall } from "../../util/provider-skill";
 import { generateMessageId } from "./message-id-generator";
 import { limitTokens } from "./token-limiter";
 

--- a/packages/backend/src/services/llm/ai-sdk-client.ts
+++ b/packages/backend/src/services/llm/ai-sdk-client.ts
@@ -767,11 +767,6 @@ export class AISdkClient implements LLMClient {
           accumulatedSkillCall.id = undefined;
           accumulatedSkillCall.arguments = "";
           isProviderSkillTool = false;
-          // Clear accumulated tool call so subsequent chunks don't carry
-          // the provider-executed tool as an unresolved client tool call.
-          accumulatedToolCall.name = undefined;
-          accumulatedToolCall.arguments = "";
-          accumulatedToolCall.id = undefined;
           break;
         case "tool-error":
           throw delta.error;

--- a/packages/backend/src/services/llm/ai-sdk-client.ts
+++ b/packages/backend/src/services/llm/ai-sdk-client.ts
@@ -55,6 +55,7 @@ import {
   LLMClient,
   LLMResponse,
   LLMStreamItem,
+  type ProviderSkillCall,
   StreamingCompleteParams,
 } from "./llm-client";
 import { generateMessageId } from "./message-id-generator";
@@ -545,10 +546,13 @@ export class AISdkClient implements LLMClient {
     // Track component streaming for UI tools (show_component_*)
     let componentTracker: ComponentStreamTracker | undefined;
 
-    // Provider-managed skill tools are completely ignored during streaming.
-    // The provider handles execution internally; the LLM describes what
-    // the skill accomplished in its text response.
+    // Provider-managed skill tools emit AG-UI events and are captured for
+    // persistence, but do not flow through the main accumulatedToolCall pipeline.
     let isProviderSkillTool = false;
+    const accumulatedSkillCall: { id?: string; arguments: string } = {
+      arguments: "",
+    };
+    const completedSkillCalls: ProviderSkillCall[] = [];
 
     for await (const delta of result.fullStream) {
       // Collect AG-UI events for this delta
@@ -630,13 +634,18 @@ export class AISdkClient implements LLMClient {
           isProviderSkillTool =
             !!skillToolName && delta.toolName === skillToolName;
           if (isProviderSkillTool) {
-            // Skill tools are fully handled by the provider. Ignore.
-            // Clear accumulated tool state to prevent stale data from a
-            // previous tool call leaking if tool-result doesn't fire.
+            // Skill tools are handled by the provider but we emit AG-UI events
+            // and capture the call for persistence. Keep the main pipeline clean.
             componentTracker = undefined;
-            accumulatedToolCall.name = undefined;
-            accumulatedToolCall.arguments = "";
-            accumulatedToolCall.id = undefined;
+            accumulatedSkillCall.id = delta.id;
+            accumulatedSkillCall.arguments = "";
+            aguiEvents.push({
+              type: EventType.TOOL_CALL_START,
+              toolCallId: delta.id,
+              toolCallName: "load_skill",
+              parentMessageId: textMessageId,
+              timestamp: Date.now(),
+            } as ToolCallStartEvent);
             break;
           }
 
@@ -672,7 +681,16 @@ export class AISdkClient implements LLMClient {
           break;
         }
         case "tool-input-delta":
-          if (isProviderSkillTool) break;
+          if (isProviderSkillTool) {
+            accumulatedSkillCall.arguments += delta.delta;
+            aguiEvents.push({
+              type: EventType.TOOL_CALL_ARGS,
+              toolCallId: delta.id,
+              delta: delta.delta,
+              timestamp: Date.now(),
+            } as ToolCallArgsEvent);
+            break;
+          }
           accumulatedToolCall.arguments += delta.delta;
           if (componentTracker) {
             const componentEvents = componentTracker.processJsonDelta(
@@ -692,7 +710,15 @@ export class AISdkClient implements LLMClient {
         case "tool-input-end":
           break;
         case "tool-call":
-          if (isProviderSkillTool) break;
+          if (isProviderSkillTool) {
+            accumulatedSkillCall.id = delta.toolCallId;
+            aguiEvents.push({
+              type: EventType.TOOL_CALL_END,
+              toolCallId: delta.toolCallId,
+              timestamp: Date.now(),
+            } as ToolCallEndEvent);
+            break;
+          }
           if (delta.providerMetadata?.google?.thoughtSignature) {
             toolCallProviderOptionsById = {
               ...(toolCallProviderOptionsById ?? {}),
@@ -727,6 +753,20 @@ export class AISdkClient implements LLMClient {
               "Tool result should not be emitted during streaming",
             );
           }
+          if (!accumulatedSkillCall.id) {
+            throw new Error(
+              "Provider skill tool-result received without a tool call ID",
+            );
+          }
+          completedSkillCalls.push({
+            toolCallId: accumulatedSkillCall.id,
+            toolName: "load_skill",
+            args: accumulatedSkillCall.arguments,
+            result: delta.output,
+          });
+          accumulatedSkillCall.id = undefined;
+          accumulatedSkillCall.arguments = "";
+          isProviderSkillTool = false;
           // Clear accumulated tool call so subsequent chunks don't carry
           // the provider-executed tool as an unresolved client tool call.
           accumulatedToolCall.name = undefined;
@@ -815,6 +855,9 @@ export class AISdkClient implements LLMClient {
         },
         aguiEvents,
         toolCallProviderOptionsById,
+        ...(completedSkillCalls.length > 0 && {
+          completedProviderSkillCalls: completedSkillCalls.splice(0),
+        }),
       };
     }
 

--- a/packages/backend/src/services/llm/llm-client.ts
+++ b/packages/backend/src/services/llm/llm-client.ts
@@ -87,6 +87,36 @@ interface LLMResponseExtras {
 export type LLMResponse = Omit<LLMChatCompletionChoice, "finish_reason"> &
   LLMResponseExtras;
 
+/** A completed provider-managed skill tool invocation. */
+export interface ProviderSkillCall {
+  readonly toolCallId: string;
+  readonly toolName: "load_skill";
+  /** Raw JSON arguments string as accumulated from the provider's tool-input-delta events. */
+  readonly args: string;
+  /**
+   * The provider's tool execution result. Shape varies by provider:
+   * OpenAI shell returns a string; Anthropic code_execution returns
+   * a structured object.
+   */
+  readonly result: unknown;
+}
+
+/**
+ * Check whether a message was created to record a provider-managed skill tool call.
+ * Used to filter these messages out of the LLM conversation history.
+ * @returns true when the message has `metadata._tambo.providerSkill === true`
+ */
+export function isProviderSkillMessage(msg: {
+  metadata?: Record<string, unknown> | null;
+}): boolean {
+  const tambo = (msg.metadata as Record<string, unknown> | undefined)?._tambo;
+  return (
+    typeof tambo === "object" &&
+    tambo !== null &&
+    (tambo as Record<string, unknown>).providerSkill === true
+  );
+}
+
 /**
  * Extended stream item that includes both the LLM response and AG-UI events.
  * This allows consumers to either:
@@ -118,6 +148,12 @@ export interface LLMStreamItem {
    * in a follow-up request.
    */
   toolCallProviderOptionsById?: Record<string, ProviderOptions>;
+
+  /**
+   * Provider-managed skill tool calls that completed during this streaming delta.
+   * Populated at `tool-result` time; only present when non-empty.
+   */
+  completedProviderSkillCalls?: ProviderSkillCall[];
 }
 
 /** Get the string response from the LLM response */

--- a/packages/backend/src/services/llm/llm-client.ts
+++ b/packages/backend/src/services/llm/llm-client.ts
@@ -87,35 +87,12 @@ interface LLMResponseExtras {
 export type LLMResponse = Omit<LLMChatCompletionChoice, "finish_reason"> &
   LLMResponseExtras;
 
-/** A completed provider-managed skill tool invocation. */
-export interface ProviderSkillCall {
-  readonly toolCallId: string;
-  readonly toolName: "load_skill";
-  /** Raw JSON arguments string as accumulated from the provider's tool-input-delta events. */
-  readonly args: string;
-  /**
-   * The provider's tool execution result. Shape varies by provider:
-   * OpenAI shell returns a string; Anthropic code_execution returns
-   * a structured object.
-   */
-  readonly result: unknown;
-}
-
-/**
- * Check whether a message was created to record a provider-managed skill tool call.
- * Used to filter these messages out of the LLM conversation history.
- * @returns true when the message has `metadata._tambo.providerSkill === true`
- */
-export function isProviderSkillMessage(msg: {
-  metadata?: Record<string, unknown> | null;
-}): boolean {
-  const tambo = (msg.metadata as Record<string, unknown> | undefined)?._tambo;
-  return (
-    typeof tambo === "object" &&
-    tambo !== null &&
-    (tambo as Record<string, unknown>).providerSkill === true
-  );
-}
+import type { ProviderSkillCall } from "../../util/provider-skill";
+// Re-export from canonical location so existing consumers don't break.
+export {
+  type ProviderSkillCall,
+  isProviderSkillMessage,
+} from "../../util/provider-skill";
 
 /**
  * Extended stream item that includes both the LLM response and AG-UI events.

--- a/packages/backend/src/services/llm/llm-client.ts
+++ b/packages/backend/src/services/llm/llm-client.ts
@@ -88,11 +88,6 @@ export type LLMResponse = Omit<LLMChatCompletionChoice, "finish_reason"> &
   LLMResponseExtras;
 
 import type { ProviderSkillCall } from "../../util/provider-skill";
-// Re-export from canonical location so existing consumers don't break.
-export {
-  type ProviderSkillCall,
-  isProviderSkillMessage,
-} from "../../util/provider-skill";
 
 /**
  * Extended stream item that includes both the LLM response and AG-UI events.

--- a/packages/backend/src/util/provider-skill.ts
+++ b/packages/backend/src/util/provider-skill.ts
@@ -1,0 +1,29 @@
+/** A completed provider-managed skill tool invocation. */
+export interface ProviderSkillCall {
+  readonly toolCallId: string;
+  readonly toolName: "load_skill";
+  /** Raw JSON arguments string as accumulated from the provider's tool-input-delta events. */
+  readonly args: string;
+  /**
+   * The provider's tool execution result. Shape varies by provider:
+   * OpenAI shell returns a string; Anthropic code_execution returns
+   * a structured object.
+   */
+  readonly result: unknown;
+}
+
+/**
+ * Check whether a message was created to record a provider-managed skill tool call.
+ * Used to filter these messages out of the LLM conversation history.
+ * @returns true when the message has `metadata._tambo.providerSkill === true`
+ */
+export function isProviderSkillMessage(msg: {
+  metadata?: Record<string, unknown> | null;
+}): boolean {
+  const tambo = (msg.metadata as Record<string, unknown> | undefined)?._tambo;
+  return (
+    typeof tambo === "object" &&
+    tambo !== null &&
+    (tambo as Record<string, unknown>).providerSkill === true
+  );
+}

--- a/packages/backend/src/util/thread-to-model-message-conversion.test.ts
+++ b/packages/backend/src/util/thread-to-model-message-conversion.test.ts
@@ -8,6 +8,7 @@ import {
   convertAssistantMessage,
   threadMessagesToModelMessages,
 } from "./thread-to-model-message-conversion";
+import type { ThreadMessage } from "@tambo-ai-cloud/core";
 
 const baseAssistantMessage: Omit<
   ThreadAssistantMessage,
@@ -314,11 +315,11 @@ describe("convertAssistantMessage", () => {
 
 describe("threadMessagesToModelMessages - provider skill filtering", () => {
   it("should exclude messages with metadata._tambo.providerSkill = true", () => {
-    const messages = [
+    const messages: ThreadMessage[] = [
       {
         id: "msg_user",
         threadId: "thread_1",
-        role: MessageRole.User,
+        role: MessageRole.User as const,
         content: [{ type: ContentPartType.Text, text: "Hello" }],
         createdAt: new Date(),
         componentState: {},
@@ -326,7 +327,7 @@ describe("threadMessagesToModelMessages - provider skill filtering", () => {
       {
         id: "msg_skill_assistant",
         threadId: "thread_1",
-        role: MessageRole.Assistant,
+        role: MessageRole.Assistant as const,
         content: [{ type: ContentPartType.Text, text: "" }],
         createdAt: new Date(),
         componentState: {},
@@ -337,7 +338,7 @@ describe("threadMessagesToModelMessages - provider skill filtering", () => {
       {
         id: "msg_skill_tool",
         threadId: "thread_1",
-        role: MessageRole.Tool,
+        role: MessageRole.Tool as const,
         content: [{ type: ContentPartType.Text, text: "result" }],
         createdAt: new Date(),
         componentState: {},
@@ -347,7 +348,7 @@ describe("threadMessagesToModelMessages - provider skill filtering", () => {
       {
         id: "msg_assistant",
         threadId: "thread_1",
-        role: MessageRole.Assistant,
+        role: MessageRole.Assistant as const,
         content: [{ type: ContentPartType.Text, text: "Here is the answer" }],
         createdAt: new Date(),
         componentState: {},
@@ -366,11 +367,11 @@ describe("threadMessagesToModelMessages - provider skill filtering", () => {
   });
 
   it("should keep non-skill tool messages", () => {
-    const messages = [
+    const messages: ThreadMessage[] = [
       {
         id: "msg_user",
         threadId: "thread_1",
-        role: MessageRole.User,
+        role: MessageRole.User as const,
         content: [{ type: ContentPartType.Text, text: "Hello" }],
         createdAt: new Date(),
         componentState: {},
@@ -378,7 +379,7 @@ describe("threadMessagesToModelMessages - provider skill filtering", () => {
       {
         id: "msg_assistant_tool",
         threadId: "thread_1",
-        role: MessageRole.Assistant,
+        role: MessageRole.Assistant as const,
         content: [{ type: ContentPartType.Text, text: "" }],
         createdAt: new Date(),
         componentState: {},
@@ -388,7 +389,7 @@ describe("threadMessagesToModelMessages - provider skill filtering", () => {
       {
         id: "msg_tool",
         threadId: "thread_1",
-        role: MessageRole.Tool,
+        role: MessageRole.Tool as const,
         content: [{ type: ContentPartType.Text, text: "sunny" }],
         createdAt: new Date(),
         componentState: {},

--- a/packages/backend/src/util/thread-to-model-message-conversion.test.ts
+++ b/packages/backend/src/util/thread-to-model-message-conversion.test.ts
@@ -4,7 +4,10 @@ import {
   LegacyComponentDecision,
   ThreadAssistantMessage,
 } from "@tambo-ai-cloud/core";
-import { convertAssistantMessage } from "./thread-to-model-message-conversion";
+import {
+  convertAssistantMessage,
+  threadMessagesToModelMessages,
+} from "./thread-to-model-message-conversion";
 
 const baseAssistantMessage: Omit<
   ThreadAssistantMessage,
@@ -306,5 +309,99 @@ describe("convertAssistantMessage", () => {
         },
       ]);
     });
+  });
+});
+
+describe("threadMessagesToModelMessages - provider skill filtering", () => {
+  it("should exclude messages with metadata._tambo.providerSkill = true", () => {
+    const messages = [
+      {
+        id: "msg_user",
+        threadId: "thread_1",
+        role: MessageRole.User,
+        content: [{ type: ContentPartType.Text, text: "Hello" }],
+        createdAt: new Date(),
+        componentState: {},
+      },
+      {
+        id: "msg_skill_assistant",
+        threadId: "thread_1",
+        role: MessageRole.Assistant,
+        content: [{ type: ContentPartType.Text, text: "" }],
+        createdAt: new Date(),
+        componentState: {},
+        metadata: { _tambo: { providerSkill: true } },
+        toolCallRequest: { toolName: "load_skill", parameters: [] },
+        tool_call_id: "call-1",
+      },
+      {
+        id: "msg_skill_tool",
+        threadId: "thread_1",
+        role: MessageRole.Tool,
+        content: [{ type: ContentPartType.Text, text: "result" }],
+        createdAt: new Date(),
+        componentState: {},
+        metadata: { _tambo: { providerSkill: true } },
+        tool_call_id: "call-1",
+      },
+      {
+        id: "msg_assistant",
+        threadId: "thread_1",
+        role: MessageRole.Assistant,
+        content: [{ type: ContentPartType.Text, text: "Here is the answer" }],
+        createdAt: new Date(),
+        componentState: {},
+      },
+    ];
+
+    const result = threadMessagesToModelMessages(
+      messages,
+      testMimeTypePredicate,
+    );
+
+    // Should have 2 messages: user + final assistant (skill messages filtered out)
+    expect(result.length).toBe(2);
+    expect(result[0].role).toBe("user");
+    expect(result[1].role).toBe("assistant");
+  });
+
+  it("should keep non-skill tool messages", () => {
+    const messages = [
+      {
+        id: "msg_user",
+        threadId: "thread_1",
+        role: MessageRole.User,
+        content: [{ type: ContentPartType.Text, text: "Hello" }],
+        createdAt: new Date(),
+        componentState: {},
+      },
+      {
+        id: "msg_assistant_tool",
+        threadId: "thread_1",
+        role: MessageRole.Assistant,
+        content: [{ type: ContentPartType.Text, text: "" }],
+        createdAt: new Date(),
+        componentState: {},
+        toolCallRequest: { toolName: "get_weather", parameters: [] },
+        tool_call_id: "call-2",
+      },
+      {
+        id: "msg_tool",
+        threadId: "thread_1",
+        role: MessageRole.Tool,
+        content: [{ type: ContentPartType.Text, text: "sunny" }],
+        createdAt: new Date(),
+        componentState: {},
+        tool_call_id: "call-2",
+      },
+    ];
+
+    const result = threadMessagesToModelMessages(
+      messages,
+      testMimeTypePredicate,
+    );
+
+    // All 3 messages should be present (no filtering)
+    expect(result.length).toBe(3);
   });
 });

--- a/packages/backend/src/util/thread-to-model-message-conversion.ts
+++ b/packages/backend/src/util/thread-to-model-message-conversion.ts
@@ -18,6 +18,7 @@ import type {
   UserModelMessage,
 } from "ai";
 import type { ProviderOptions } from "@ai-sdk/provider-utils";
+import { isProviderSkillMessage } from "../services/llm/llm-client";
 import * as mimeTypes from "mime-types";
 import { formatFunctionCall, generateAdditionalContext } from "./tools";
 
@@ -103,6 +104,10 @@ export function threadMessagesToModelMessages(
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
+
+    // Skip provider skill tool call/response messages — these are stored
+    // for observability but should not be sent back to the LLM.
+    if (isProviderSkillMessage(message)) continue;
 
     switch (message.role) {
       case MessageRole.Tool: {

--- a/packages/backend/src/util/thread-to-model-message-conversion.ts
+++ b/packages/backend/src/util/thread-to-model-message-conversion.ts
@@ -18,7 +18,7 @@ import type {
   UserModelMessage,
 } from "ai";
 import type { ProviderOptions } from "@ai-sdk/provider-utils";
-import { isProviderSkillMessage } from "../services/llm/llm-client";
+import { isProviderSkillMessage } from "./provider-skill";
 import * as mimeTypes from "mime-types";
 import { formatFunctionCall, generateAdditionalContext } from "./tools";
 

--- a/plans/tam-1486-capture-skill-usage.md
+++ b/plans/tam-1486-capture-skill-usage.md
@@ -1,0 +1,374 @@
+# TAM-1486: Capture Skill Usage for Each Provider
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-09
+**Agents used:** architecture-strategist, performance-oracle, type-design-analyzer
+
+### Key Improvements from Review
+
+1. Resolved plan contradiction: TOOL_CALL_RESULT emitted only from threads.service.ts (not ai-sdk-client.ts)
+2. DB writes moved to post-stream batch to avoid blocking the streaming hot path
+3. ProviderSkillCall type tightened: literal `"load_skill"` type, readonly fields, fail-fast on missing ID
+4. Eliminated double-write (appendNewMessageToThread + updateMessage) in favor of single addMessage
+5. Added `isProviderSkillMessage` type guard for DRY metadata filtering
+
+## Summary
+
+When a provider-managed skill tool fires during streaming (`shell` for OpenAI, `code_execution` for Anthropic), normalize it to `load_skill`, emit standard AG-UI tool call events + `TOOL_CALL_RESULT`, store as messages in the DB, and filter them out of conversations sent to the LLM.
+
+## Requirements
+
+1. **Normalize tool name**: `"shell"` / `"code_execution"` -> `"load_skill"` (only when tool name matches `PROVIDER_SKILL_TOOL_NAME` and skills are configured)
+2. **Emit AG-UI events**: `TOOL_CALL_START`, `TOOL_CALL_ARGS`, `TOOL_CALL_END`, `TOOL_CALL_RESULT` -- identical to how a server-side (system) tool call looks to the client
+3. **Store in DB**: assistant message with `toolCallRequest` + tool response message with provider result verbatim. Both get `metadata: { _tambo: { providerSkill: true } }`
+4. **Store raw args**: no skill name extraction yet -- pass through whatever the provider sends
+5. **Filter from LLM conversation**: when building messages for the next LLM run, skip messages where `metadata._tambo.providerSkill === true`
+6. **Separate pairs**: each skill tool call gets its own `load_skill` tool call + response pair
+7. **V1 API**: let `load_skill` tool_use blocks through (no special filtering)
+
+## Architecture
+
+### How system tool calls work today
+
+From the client's perspective, system (MCP) tool calls look like server-handled tool calls. The implementation:
+
+1. The LLM generates text, then stops to make a tool call
+2. During streaming, AG-UI events (`TOOL_CALL_START/ARGS/END`) flow to the client, but `toolCallRequest` is stripped from the message DTO
+3. The stream ends; post-stream branching detects the system tool call
+4. The tool is executed server-side, a tool response message is created, and `advanceThread` recurses
+5. A new decision loop starts, streaming more chunks to the same `AsyncQueue`
+6. The client sees one continuous stream
+
+### How provider skill tools differ
+
+1. The LLM generates text, the provider loads a skill (emitting `shell`/`code_execution` tool events), returns a result, and the LLM continues generating text -- all within **one** LLM stream
+2. There is no recursive `advanceThread` -- the provider handles execution internally
+3. The tool call + result happen **mid-stream**, not at stream end
+4. After `tool-result`, the `accumulatedToolCall` state is cleared, so `finalThreadMessage.toolCallRequest` will be `undefined` when the stream ends
+5. The post-stream branching won't see the skill tool call
+
+### Key design decision: carry completed skill calls on stream items
+
+Because skill tool calls happen mid-stream and get cleared before the stream ends, we carry completed skill calls on a separate field:
+
+```typescript
+/** A completed provider-managed skill tool invocation. */
+interface ProviderSkillCall {
+  readonly toolCallId: string;
+  readonly toolName: "load_skill";
+  /** Raw JSON arguments string as accumulated from the provider's tool-input-delta events. */
+  readonly args: string;
+  /**
+   * The provider's tool execution result. Shape varies by provider:
+   * OpenAI shell returns a string; Anthropic code_execution returns
+   * a structured object.
+   */
+  readonly result: unknown;
+}
+```
+
+Added to both `LLMStreamItem` and `DecisionStreamItem` as `completedProviderSkillCalls?: ProviderSkillCall[]`.
+
+This field is populated once per skill call, on the `tool-result` delta. AG-UI events (`TOOL_CALL_START/ARGS/END`) flow via `aguiEvents` during the stream. `TOOL_CALL_RESULT` is emitted by `threads.service.ts` after the DB write (not from `ai-sdk-client.ts`), so the messageId matches the persisted tool response message.
+
+### Research Insights
+
+**Layer separation**: `TOOL_CALL_RESULT` must be emitted from `threads.service.ts` (not `ai-sdk-client.ts`) because the event requires a `messageId` that matches the persisted tool response message. Emitting from the LLM layer would require pre-generating message IDs and a new `addMessageWithId` DB operation, coupling the LLM layer to DB identity concerns.
+
+**Immutability**: Do not mutate `streamItem.aguiEvents` when adding `TOOL_CALL_RESULT`. Create a new array: `const eventsWithResult = [...streamItem.aguiEvents, resultEvent]`.
+
+**Architectural reversal**: The existing architecture doc (`provider-managed-skill-tool-calls.md`) explicitly documents suppression as the "right answer." The update should frame this as a deliberate reversal based on new observability requirements, not a refutation of the original reasoning.
+
+## Implementation Steps
+
+### Step 1: Types
+
+**File**: `packages/backend/src/services/llm/llm-client.ts`
+
+Add `ProviderSkillCall` interface (readonly fields, literal `"load_skill"` type). Add `completedProviderSkillCalls?: ProviderSkillCall[]` to `LLMStreamItem`.
+
+**File**: `packages/backend/src/services/decision-loop/decision-loop-service.ts`
+
+Add `completedProviderSkillCalls?: ProviderSkillCall[]` to `DecisionStreamItem`.
+
+**File**: `packages/core/src/` (or `packages/backend/src/util/`)
+
+Add `isProviderSkillMessage` type guard:
+
+```typescript
+function isProviderSkillMessage(msg: {
+  metadata?: Record<string, unknown>;
+}): boolean {
+  const tambo = msg.metadata?._tambo;
+  return (
+    typeof tambo === "object" &&
+    tambo !== null &&
+    (tambo as Record<string, unknown>).providerSkill === true
+  );
+}
+```
+
+### Step 2: `ai-sdk-client.ts` -- Emit events + accumulate skill calls
+
+**File**: `packages/backend/src/services/llm/ai-sdk-client.ts`
+
+Add a skill call accumulator alongside the existing `accumulatedToolCall`:
+
+```typescript
+const accumulatedSkillCall: { id?: string; arguments: string } = {
+  arguments: "",
+};
+const completedSkillCalls: ProviderSkillCall[] = [];
+```
+
+**`tool-input-start` (~line 625)**:
+
+- Still set `isProviderSkillTool` flag via `!!skillToolName && delta.toolName === skillToolName`
+- When true:
+  - Set `accumulatedSkillCall.id = delta.id`, reset `accumulatedSkillCall.arguments = ""`
+  - Emit `TOOL_CALL_START` with `toolCallName: "load_skill"`, `toolCallId: delta.id`, `parentMessageId: textMessageId`
+  - Do NOT touch `accumulatedToolCall` (keep the main pipeline clean)
+  - Do NOT create a `ComponentStreamTracker`
+
+**`tool-input-delta` (~line 674)**:
+
+- When `isProviderSkillTool`:
+  - `accumulatedSkillCall.arguments += delta.delta`
+  - Emit `TOOL_CALL_ARGS` with `toolCallId: delta.id`, `delta: delta.delta`
+
+**`tool-call` (~line 695)**:
+
+- When `isProviderSkillTool`:
+  - `accumulatedSkillCall.id = delta.toolCallId` (may differ from input-start id)
+  - Emit `TOOL_CALL_END` with `toolCallId: delta.toolCallId`
+
+**`tool-result` (~line 722)**:
+
+- When `providerExecuted`:
+  - **Fail fast** if ID is missing:
+    ```typescript
+    if (!accumulatedSkillCall.id) {
+      throw new Error(
+        "Provider skill tool-result received without a tool call ID",
+      );
+    }
+    ```
+  - Push to `completedSkillCalls`:
+    ```typescript
+    completedSkillCalls.push({
+      toolCallId: accumulatedSkillCall.id,
+      toolName: "load_skill",
+      args: accumulatedSkillCall.arguments,
+      result: delta.result,
+    });
+    ```
+  - Do NOT emit `TOOL_CALL_RESULT` here (emitted by threads.service.ts after DB write)
+  - Reset `accumulatedSkillCall`
+  - Reset `isProviderSkillTool = false`
+
+**Yield** (bottom of loop): include `completedProviderSkillCalls` when non-empty, then clear:
+
+```typescript
+yield {
+  llmResponse: { ... },
+  aguiEvents,
+  toolCallProviderOptionsById,
+  ...(completedSkillCalls.length > 0 && {
+    completedProviderSkillCalls: completedSkillCalls.splice(0),
+  }),
+};
+```
+
+**Text stitching**: Keep the existing logic. The `wasProviderSkillTool` check at `text-start` (line ~559) still triggers, reusing `textMessageId` and prepending `"\n\n"`. The main assistant text message remains continuous.
+
+### Step 3: `decision-loop-service.ts` -- Pass through
+
+**File**: `packages/backend/src/services/decision-loop/decision-loop-service.ts`
+
+In the `for await` loop (~line 215), pass `completedProviderSkillCalls` through:
+
+```typescript
+yield {
+  decision: accumulatedDecision,
+  aguiEvents: streamItem.aguiEvents,
+  toolCallProviderOptionsById: streamItem.toolCallProviderOptionsById,
+  completedProviderSkillCalls: streamItem.completedProviderSkillCalls,
+};
+```
+
+No changes to `buildToolCallRequest` -- skill calls don't flow through `accumulatedToolCall` / `tool_calls`, so it never sees `"load_skill"`.
+
+### Step 4: `threads.service.ts` -- Accumulate during streaming, persist post-stream
+
+**File**: `apps/api/src/threads/threads.service.ts`
+
+#### During streaming: accumulate skill calls
+
+In the streaming loop (lines 1795-1941), collect completed skill calls into a list (DO NOT write to DB here -- avoid blocking the stream):
+
+```typescript
+const allCompletedSkillCalls: ProviderSkillCall[] = [];
+
+// Inside the for-await loop, before the queue push:
+if (streamItem.completedProviderSkillCalls?.length) {
+  allCompletedSkillCalls.push(...streamItem.completedProviderSkillCalls);
+}
+```
+
+AG-UI events (`TOOL_CALL_START/ARGS/END`) already flow to the client via `streamItem.aguiEvents` on the queue push.
+
+#### Post-stream: persist + emit TOOL_CALL_RESULT
+
+After the streaming loop completes and before `finishInProgressMessage` (~line 1998), persist all accumulated skill calls and emit result events:
+
+```typescript
+const skillResultEvents: BaseEvent[] = [];
+
+for (const skillCall of allCompletedSkillCalls) {
+  const providerSkillMetadata = { _tambo: { providerSkill: true } };
+
+  // Save assistant message with tool call (single insert, no double-write)
+  const skillAssistantMsg = await addMessage(db, {
+    threadId,
+    parentMessageId: currentThreadMessage?.id ?? userMessage.id,
+    role: MessageRole.Assistant,
+    content: [],
+    toolCallRequest: {
+      toolName: skillCall.toolName,
+      parameters: jsonArgsToParameters(skillCall.args),
+    },
+    tool_call_id: skillCall.toolCallId,
+    actionType: ActionType.ToolCall,
+    metadata: providerSkillMetadata,
+  });
+
+  // Save tool response message (single insert)
+  const toolResponseMsg = await addMessage(db, {
+    threadId,
+    parentMessageId: skillAssistantMsg.id,
+    role: MessageRole.Tool,
+    content: [
+      {
+        type: ContentPartType.Text,
+        text:
+          typeof skillCall.result === "string"
+            ? skillCall.result
+            : JSON.stringify(skillCall.result),
+      },
+    ],
+    tool_call_id: skillCall.toolCallId,
+    actionType: ActionType.ToolResponse,
+    metadata: providerSkillMetadata,
+  });
+
+  // Collect TOOL_CALL_RESULT events (emitted to client after DB write)
+  skillResultEvents.push({
+    type: EventType.TOOL_CALL_RESULT,
+    toolCallId: skillCall.toolCallId,
+    messageId: toolResponseMsg.id,
+    content:
+      typeof skillCall.result === "string"
+        ? skillCall.result
+        : JSON.stringify(skillCall.result),
+    timestamp: Date.now(),
+  });
+}
+
+// Emit all TOOL_CALL_RESULT events in one queue push
+if (skillResultEvents.length > 0) {
+  queue.push({ aguiEvents: skillResultEvents });
+}
+```
+
+#### Helper: `jsonArgsToParameters`
+
+The plan references `tryParseJsonToParameters` which doesn't exist. Add a utility:
+
+```typescript
+function jsonArgsToParameters(json: string): ToolCallRequest["parameters"] {
+  try {
+    const parsed: Record<string, unknown> = JSON.parse(json);
+    return Object.entries(parsed).map(([parameterName, parameterValue]) => ({
+      parameterName,
+      parameterValue,
+    }));
+  } catch {
+    // If args aren't valid JSON, store as a single parameter
+    return [{ parameterName: "raw", parameterValue: json }];
+  }
+}
+```
+
+### Research Insights: Performance
+
+**Why post-stream persistence**: Mid-stream DB writes (`appendNewMessageToThread` + `updateMessage`) would add ~30-90ms of blocking latency per skill call (3 sequential awaited operations: verify consistency + INSERT + UPDATE thread timestamp). This creates visible stream stalls for the client. Moving persistence to post-stream eliminates this.
+
+**Why single addMessage**: The plan originally called for `appendNewMessageToThread` (INSERT in transaction with consistency check) followed by `updateMessage` (another UPDATE). That's 6 SQL statements for what should be 3. The `appendNewMessageToThread` consistency check is unnecessary for side-band skill messages that don't need to maintain the main message chain ordering invariant.
+
+**Edge case -- large results**: Provider skill results (code execution output) can be arbitrarily large. Consider logging a warning for results exceeding ~64KB. Not a V1 blocker but worth monitoring.
+
+### Step 5: `thread-to-model-message-conversion.ts` -- Filter skill messages
+
+**File**: `packages/backend/src/util/thread-to-model-message-conversion.ts`
+
+In `threadMessagesToModelMessages` (~line 89), integrate the filter into the existing loop rather than adding a separate `.filter()` pass:
+
+```typescript
+for (let i = 0; i < messages.length; i++) {
+  const message = messages[i];
+  if (isProviderSkillMessage(message)) continue;
+  // ... existing switch on message.role
+}
+```
+
+Use the `isProviderSkillMessage` type guard from Step 1.
+
+### Step 6: Tests
+
+**`packages/backend/src/services/llm/ai-sdk-client.test.ts`**:
+
+- Rewrite "suppresses skill tool calls" -> "emits load_skill TOOL_CALL events for skill tools"
+  - Assert `TOOL_CALL_START` has `toolCallName: "load_skill"`
+  - Assert `TOOL_CALL_ARGS` events contain the arg deltas
+  - Assert `TOOL_CALL_END` fires
+  - Assert `completedProviderSkillCalls` is populated with correct data (toolCallId, args, result)
+  - Assert NO `TOOL_CALL_RESULT` event is emitted (that comes from threads.service.ts)
+- Rewrite "suppresses all TOOL_CALL events" -> assert events ARE emitted
+- Keep "does NOT suppress tools named 'shell' when skill tool is 'code_execution'" (unchanged)
+- Keep "does NOT suppress tools when no skill tool name is set" (unchanged)
+- Update "stitches text segments" -- text stitching should still work
+- Add test: missing tool call ID at tool-result throws Error
+
+**`packages/backend/src/util/thread-to-model-message-conversion.test.ts`**:
+
+- Add test: messages with `metadata._tambo.providerSkill = true` are excluded
+- Add test: non-skill tool messages are unaffected
+
+### Step 7: Update architecture doc
+
+**File**: `devdocs/solutions/architecture/provider-managed-skill-tool-calls.md`
+
+Update to document "Normalize and Emit" approach. Frame as a deliberate reversal based on new observability requirements (TAM-1486), not a refutation of the original suppression reasoning. Keep history of previous approaches as useful context.
+
+## File Change Summary
+
+| File                                                                   | Change                                                                                                              |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `packages/backend/src/services/llm/llm-client.ts`                      | Add `ProviderSkillCall` type (readonly, literal "load_skill"), add `completedProviderSkillCalls` to `LLMStreamItem` |
+| `packages/backend/src/services/llm/ai-sdk-client.ts`                   | Emit `TOOL_CALL_START/ARGS/END` for skill tools, accumulate + yield completed skill calls, fail-fast on missing ID  |
+| `packages/backend/src/services/decision-loop/decision-loop-service.ts` | Add `completedProviderSkillCalls` to `DecisionStreamItem`, pass through                                             |
+| `packages/core/src/` or `packages/backend/src/util/`                   | Add `isProviderSkillMessage` type guard                                                                             |
+| `apps/api/src/threads/threads.service.ts`                              | Accumulate skill calls during streaming, persist post-stream with single addMessage calls, emit `TOOL_CALL_RESULT`  |
+| `packages/backend/src/util/thread-to-model-message-conversion.ts`      | Filter out `providerSkill` messages using type guard in existing loop                                               |
+| `devdocs/solutions/architecture/provider-managed-skill-tool-calls.md`  | Update doc (frame as deliberate reversal)                                                                           |
+| `packages/backend/src/services/llm/ai-sdk-client.test.ts`              | Rewrite suppression tests -> emission tests, add fail-fast test                                                     |
+| `packages/backend/src/util/thread-to-model-message-conversion.test.ts` | Add filtering tests                                                                                                 |
+
+## Edge Cases
+
+1. **Multiple skills per turn**: Each gets separate TOOL_CALL_START/ARGS/END events during streaming and separate messages post-stream. Client sees: text -> tool events -> text -> tool events -> text.
+2. **Missing tool call ID**: Fail fast with Error at tool-result time. Don't silently degrade with empty string.
+3. **Large skill results**: Store verbatim for V1. Monitor for results >64KB and consider truncation later.
+4. **Metadata corruption**: The `isProviderSkillMessage` type guard handles this gracefully via optional chaining -- corrupted metadata just means the message isn't filtered (safe default).
+5. **Concurrent streams**: Post-stream persistence avoids DB connection pool contention during the streaming hot path.


### PR DESCRIPTION
## Summary

Captures provider-managed skill tool usage (OpenAI `shell`, Anthropic `code_execution`) for observability. When a provider loads a skill during streaming:

- Normalizes tool name to `load_skill`
- Emits standard AG-UI events (`TOOL_CALL_START/ARGS/END/RESULT`) so the client sees it as a server-side tool call
- Stores assistant + tool response messages in the DB with `metadata._tambo.providerSkill = true`
- Filters skill messages from LLM conversation history on subsequent turns

Fixes TAM-1486

## Changes

- **`llm-client.ts`**: New `ProviderSkillCall` type (readonly, literal `"load_skill"`), `isProviderSkillMessage` type guard, `completedProviderSkillCalls` field on `LLMStreamItem`
- **`ai-sdk-client.ts`**: Replaces suppression with AG-UI event emission for skill tools, accumulates completed skill calls on a separate pipeline from the main `accumulatedToolCall`
- **`decision-loop-service.ts`**: Passes `completedProviderSkillCalls` through to `DecisionStreamItem`
- **`threads.service.ts`**: Accumulates skill calls during streaming, persists post-stream (avoiding DB latency in the hot path), emits `TOOL_CALL_RESULT` events with real message IDs, includes try/catch to prevent post-stream DB failures from crashing the response
- **`thread-to-model-message-conversion.ts`**: Skips `providerSkill` messages when building LLM conversation
- **Architecture doc**: Updated from "Suppress" to "Normalize and Emit" approach

## Test plan

- [x] Existing ai-sdk-client skill tool tests updated to verify AG-UI event emission instead of suppression
- [x] New test: multiple skills in one stream
- [x] New tests: provider skill message filtering in threadMessagesToModelMessages
- [x] Non-skill tools still pass through normally (shell on Anthropic, code_execution on OpenAI without skills)
- [x] Text stitching across skill boundaries still works
- [x] All 243 backend + 788 API tests pass
- [x] Types check clean
- [x] Lint clean