### PR TITLE
fix(ci): block fork PRs from triggering db migration

### DIFF
--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -14,10 +14,20 @@ on:
 jobs:
   deploy-migrations:
     name: Deploy Database Migrations
-    # Skip if the actor is dependabot, or if the triggering workflow failed
-    if: github.actor != 'dependabot[bot]' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    # Only trusted pushes from this repo (never fork PRs)
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_repository.full_name == github.repository &&
+          github.event.workflow_run.head_branch == 'main' &&
+          github.event.workflow_run.conclusion == 'success'
+        )
+      )
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

`migrate-db.yml` runs as a `workflow_run` after CI completes. That context is **privileged**: it has `secrets.DATABASE_URL` and a `GITHUB_TOKEN`, and the job checks out `github.event.workflow_run.head_sha` then executes repo-local code from it (`./.github/actions/setup-tools` → `npm ci` lifecycle scripts, then `npm run db:migrate`).

The `workflow_run` trigger's `branches: [main]` filter is evaluated against the **upstream run's head branch**, not the repo. A fork PR whose source branch is named `main` satisfies it, so attacker-controlled code could run with `DATABASE_URL` available — a classic "pwn request". The old `if:` only excluded dependabot and checked `conclusion == 'success'`, neither of which keeps forks out.

## Fix

Gate the job so it only runs for:
- manual `workflow_dispatch`, or
- a `workflow_run` whose **upstream trigger was a `push`** from **this repository** on `main`.

`workflow_run.event == 'push'` can never be satisfied by a fork PR (those arrive as `pull_request`), and `head_repository.full_name == github.repository` confirms origin.

## Notes
- Also worth checking Settings → Actions: require approval for fork-PR workflows from outside collaborators.
- No evidence yet that a fork PR reached this path; rotate `DATABASE_URL` only if Actions history shows a `Migrate Database` run from a non-`tambo-ai/tambo` head repo.

---

Reported by [@Wang-Haimin](https://github.com/Wang-Haimin) — thanks for the find.
