### PR TITLE
fix(ci): repair stlc generate pipeline (lineage + protected-main PR flow)

### DIFF
--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -36,6 +36,7 @@ permissions:
 env:
   STAINLESS_WORKSPACE: stainless
   DEFAULT_TARGETS: typescript
+  SDK_BRANCH: stlc/auto-regenerate
 
 jobs:
   generate:
@@ -106,8 +107,23 @@ jobs:
           # drift to a minor. For a notable feature, set the version explicitly via
           # a Release-As: footer or a manual edit on the SDK repo's release PR.
           stlc build \
-            --branch main \
+            --branch "$SDK_BRANCH" \
             --output "$RUNNER_TEMP/sdk-output" \
             --push \
             --targets "$DEFAULT_TARGETS" \
             --commit "fix: regenerate SDK from deployed API"
+
+      - name: Open / update PR into the protected main
+        env:
+          GH_TOKEN: ${{ steps.sdk-token.outputs.token }}
+        run: |
+          # main is PR-only (ruleset). stlc pushed generated code to $SDK_BRANCH;
+          # open or update a PR from it into main. release-please then releases.
+          existing=$(gh pr list --repo tambo-ai/typescript-sdk --head "$SDK_BRANCH" --base main --state open --json number --jq '.[0].number')
+          if [ -z "$existing" ]; then
+            gh pr create --repo tambo-ai/typescript-sdk --base main --head "$SDK_BRANCH" \
+              --title "chore: regenerate SDK from API" \
+              --body "Automated SDK regeneration from the deployed API (stlc). Merging publishes via release-please."
+          else
+            echo "PR #$existing already open; stlc force-pushed $SDK_BRANCH so it is updated."
+          fi

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -68,7 +68,6 @@ jobs:
           permission-contents: write
           permission-workflows: write
           permission-pull-requests: write
-          permission-pull-requests: write
 
       # Regenerate the spec from the deployed API so the SDK matches the live
       # contract. Runs on the repo's pinned Node (via setup-tools) before stlc

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -5,19 +5,20 @@ name: Generate TypeScript SDK with stlc
 # (stainless-cloud.yml), which stops working when Stainless is sunset 2026-09-01.
 #
 # Gated on the `deploy` branch (same trigger as the old workflow) so the SDK
-# tracks the production-deployed API contract. The SDK is only PUBLISHED when the
-# release-please PR in tambo-ai/typescript-sdk is merged, so this never publishes
-# ahead of a deploy.
+# tracks the production-deployed API contract.
+#
+# Flow: the SDK repo's `main` is PR-only (branch ruleset), so stlc cannot push
+# to it directly. stlc pushes the regenerated SDK to the unprotected side branch
+# `stlc/auto-regenerate`, and this workflow opens/updates a PR into `main`.
+# Merging that PR lets release-please cut the release — so nothing publishes
+# ahead of a human merge.
 #
 # Auth: mints short-lived GitHub App installation tokens from the org's
 # tambo-automations app (TAMBO_AUTOMATIONS_APP_CLIENT_ID /
-# TAMBO_AUTOMATIONS_APP_PRIVATE_KEY). The tokens request only the permissions
-# this workflow needs (least privilege), narrower than the app's full grant:
-#   - SDK push:    contents:write + workflows:write on typescript-sdk
-#                  (workflows:write is required — the generated SDK contains
-#                  .github/workflows/*; no pull-requests permission needed since
-#                  stlc pushes to main directly, and release-please opens the
-#                  release PR with its own token).
+# TAMBO_AUTOMATIONS_APP_PRIVATE_KEY), least-privilege per repo:
+#   - SDK token:   contents:write + workflows:write (the generated SDK contains
+#                  .github/workflows/*) + pull-requests:write (open the PR) on
+#                  typescript-sdk.
 #   - vendor read: contents:read on stlc-vendor.
 
 on:

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -68,6 +68,7 @@ jobs:
           permission-contents: write
           permission-workflows: write
           permission-pull-requests: write
+          permission-pull-requests: write
 
       # Regenerate the spec from the deployed API so the SDK matches the live
       # contract. Runs on the repo's pinned Node (via setup-tools) before stlc

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -67,6 +67,7 @@ jobs:
           repositories: typescript-sdk
           permission-contents: write
           permission-workflows: write
+          permission-pull-requests: write
 
       # Regenerate the spec from the deployed API so the SDK matches the live
       # contract. Runs on the repo's pinned Node (via setup-tools) before stlc

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -95,6 +95,22 @@ jobs:
           git config --global user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           gh auth setup-git
 
+      - name: Reset regen branch to main (keeps stlc's push a fast-forward)
+        env:
+          GH_TOKEN: ${{ steps.sdk-token.outputs.token }}
+        run: |
+          # stlc has no --force; each regen commits on top of main, so the
+          # persistent regen branch must be reset to main first. Force-updating
+          # the branch keeps the open PR in place and refreshes its diff.
+          main_sha=$(gh api repos/tambo-ai/typescript-sdk/commits/main --jq .sha)
+          if gh api "repos/tambo-ai/typescript-sdk/git/refs/heads/$SDK_BRANCH" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/tambo-ai/typescript-sdk/git/refs/heads/$SDK_BRANCH" \
+              -F sha="$main_sha" -F force=true >/dev/null
+          else
+            gh api -X POST "repos/tambo-ai/typescript-sdk/git/refs" \
+              -f ref="refs/heads/$SDK_BRANCH" -f sha="$main_sha" >/dev/null
+          fi
+
       - name: Generate SDK and push
         env:
           GH_TOKEN: ${{ steps.sdk-token.outputs.token }}

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -137,11 +137,18 @@ jobs:
         run: |
           # main is PR-only (ruleset). stlc pushed generated code to $SDK_BRANCH;
           # open or update a PR from it into main. release-please then releases.
+          # Skip PR creation when the branch is at main (no-op regen: stlc made no
+          # commit, so creating a PR would error "No commits between...").
+          ahead=$(gh api "repos/tambo-ai/typescript-sdk/compare/main...$SDK_BRANCH" --jq .ahead_by)
+          if [ "$ahead" -eq 0 ]; then
+            echo "No changes vs main — no-op regen, skipping PR."
+            exit 0
+          fi
           existing=$(gh pr list --repo tambo-ai/typescript-sdk --head "$SDK_BRANCH" --base main --state open --json number --jq '.[0].number')
           if [ -z "$existing" ]; then
             gh pr create --repo tambo-ai/typescript-sdk --base main --head "$SDK_BRANCH" \
               --title "chore: regenerate SDK from API" \
               --body "Automated SDK regeneration from the deployed API (stlc). Merging publishes via release-please."
           else
-            echo "PR #$existing already open; stlc force-pushed $SDK_BRANCH so it is updated."
+            echo "PR #$existing already open; stlc pushed new commits to $SDK_BRANCH so it is updated."
           fi

--- a/plans/2026-06-04-001-feat-stlc-sdk-migration-plan.md
+++ b/plans/2026-06-04-001-feat-stlc-sdk-migration-plan.md
@@ -202,19 +202,33 @@ Stainless-managed staging repo collapses into the production repo.
 
 ## Key Technical Decisions
 
-### KTD1. Separate SDK repo, work-in-public (`staging_repo == production_repo`)
+### KTD1. Separate SDK repo; regenerate to a side branch + PR into protected `main`
 
 The SDK stays its own repo (`tambo-ai/typescript-sdk`), not folded into the
-monorepo. We set both `staging_repo` and `production_repo` to
-`tambo-ai/typescript-sdk` — stlc's documented "work in public" path.
+monorepo. The SDK repo's `main` is **PR-only** (branch ruleset: `pull_request`,
+`required_status_checks`, `required_linear_history`), so stlc **cannot push to
+`main` directly**. The generate workflow therefore pushes the regenerated SDK to
+an **unprotected side branch** (`stlc/auto-regenerate`) and **opens a PR into
+`main`**; release-please releases on merge. `staging_repo` / `production_repo`
+both point at `tambo-ai/typescript-sdk` (the side branch is the "staging"
+surface within that one repo).
 
-**Why:** the SDK repo is already 100% generated commits, so there is no churn or
-review value in a private staging buffer; collapsing removes one repo, one PAT,
-and the entire promote workflow. Folding the SDK into the monorepo was
-considered and rejected — stlc's `build` operates on a cloned SDK repo as its
-output unit (custom code lives in `refs/stainless/*` on that repo), so a
-monorepo subtree fights the tool, and the lockstep-release upside is not worth
-the generated-code churn in monorepo PR diffs.
+**Why not work-in-public direct-to-main (original choice, reversed):** that
+assumed the bot could push straight to `main`. It can't — the ruleset rejects
+direct pushes and won't be relaxed. A separate staging _repo_ would also work
+but is unnecessary: an unprotected side branch in the same repo serves as
+stlc's writable surface, and the PR into `main` honors the ruleset.
+
+**Custom-code lineage:** the tracking file at
+`stainless/custom-code/typescript/` pins `base` = the stlc-generated baseline
+(`90c6c35`, #280's seal base) and `integrated` = the SDK `main` HEAD (reachable
+from `origin/main`). This was required because the parallel **#280** migration
+PR was **squash-merged**, orphaning its stlc seals from `main` — so neither the
+old Stainless seal (conflicts) nor #280's seal (no shared history) applied.
+Pinning `integrated` to a real `main` commit makes the custom-code patch
+3-way-apply cleanly. Validated: a `workflow_dispatch` run goes green end-to-end
+(generate → apply custom code → push side branch → open PR #284, diff = one
+tooling file).
 (Decision history: see `plans/stainless-migration.md`.)
 
 ### KTD2. Generation stays gated on the `deploy` branch

--- a/stainless/custom-code/typescript/1780592816577-custom-code.json
+++ b/stainless/custom-code/typescript/1780592816577-custom-code.json
@@ -1,0 +1,6 @@
+{
+  "base": "90c6c35b6bebf47d4defdff53d296b2a64e294d0",
+  "integrated": "44e7c41072affff375b4c733396e23662c38390a",
+  "branch": "main",
+  "filename": "1780592816577-custom-code.json"
+}

--- a/stainless/custom-code/typescript/2026-06-03T22-01-05-912Z-custom-code.json
+++ b/stainless/custom-code/typescript/2026-06-03T22-01-05-912Z-custom-code.json
@@ -1,6 +1,0 @@
-{
-  "base": "ce1d7f96413db3346f1c54a289ef16be5a7f4604",
-  "integrated": "8f2cc36bebcdfe8d0dd15afde9769ed891e4c257",
-  "branch": "main",
-  "filename": "2026-06-03T22-01-05-912Z-custom-code.json"
-}


### PR DESCRIPTION
## Fix the stlc generate pipeline (custom-code lineage + protected-main PR flow)

The generate pipeline merged in #2915 failed on its first real run. Two issues, both fixed here and **validated green end-to-end** via `workflow_dispatch`.

### 1. Custom-code lineage broken by #280's squash-merge
The parallel SDK-repo migration (`tambo-ai/typescript-sdk#280`) was squash-merged, which orphaned stlc's custom-code seals from `main`. The committed tracking file (old Stainless seal `8f2cc36`) no longer applied, and #280's seal (`fd0b83c`) had "no shared history."
**Fix:** point the tracking file at `base` = the real stlc-generated baseline (`90c6c35`) and `integrated` = current SDK `main` HEAD (reachable from `origin/main`), so the custom-code patch 3-way-applies cleanly.

### 2. stlc can't push to the protected `main`
The SDK repo's `main` is PR-only (ruleset). stlc's work-in-public model pushed directly to `main` → rejected (`GH013`).
**Fix:** push the regenerated SDK to an unprotected side branch (`stlc/auto-regenerate`) and open a PR into `main`; release-please releases on merge. Reset the side branch to `main` each run so the push is a fast-forward. Grant the app token `pull-requests: write`.

### Validated
`workflow_dispatch` run is fully green: mint tokens → regenerate spec → `stlc build` (apply custom code + seal) → push side branch → open PR. The regen PR diff was a single tooling file (`scripts/mock`) — no behavioral/src drift.

### Files
- `.github/workflows/stlc-generate.yml` — side-branch + PR flow, branch reset, token permissions, updated comments.
- `stainless/custom-code/typescript/1780592816577-custom-code.json` — corrected tracking file (replaces the stale `2026-06-03…` one).
- Plan doc updated (KTD1 reversed: side-branch+PR, not direct-to-main).
