### PR TITLE
chore: gitignore stainless-transition cache + add investigation doc

### DIFF
--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -36,6 +36,7 @@ permissions:
 env:
   STAINLESS_WORKSPACE: stainless
   DEFAULT_TARGETS: typescript
+  SDK_BRANCH: stlc/auto-regenerate
 
 jobs:
   generate:
@@ -106,8 +107,23 @@ jobs:
           # drift to a minor. For a notable feature, set the version explicitly via
           # a Release-As: footer or a manual edit on the SDK repo's release PR.
           stlc build \
-            --branch main \
+            --branch "$SDK_BRANCH" \
             --output "$RUNNER_TEMP/sdk-output" \
             --push \
             --targets "$DEFAULT_TARGETS" \
             --commit "fix: regenerate SDK from deployed API"
+
+      - name: Open / update PR into the protected main
+        env:
+          GH_TOKEN: ${{ steps.sdk-token.outputs.token }}
+        run: |
+          # main is PR-only (ruleset). stlc pushed generated code to $SDK_BRANCH;
+          # open or update a PR from it into main. release-please then releases.
+          existing=$(gh pr list --repo tambo-ai/typescript-sdk --head "$SDK_BRANCH" --base main --state open --json number --jq '.[0].number')
+          if [ -z "$existing" ]; then
+            gh pr create --repo tambo-ai/typescript-sdk --base main --head "$SDK_BRANCH" \
+              --title "chore: regenerate SDK from API" \
+              --body "Automated SDK regeneration from the deployed API (stlc). Merging publishes via release-please."
+          else
+            echo "PR #$existing already open; stlc force-pushed $SDK_BRANCH so it is updated."
+          fi

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -68,7 +68,6 @@ jobs:
           permission-contents: write
           permission-workflows: write
           permission-pull-requests: write
-          permission-pull-requests: write
 
       # Regenerate the spec from the deployed API so the SDK matches the live
       # contract. Runs on the repo's pinned Node (via setup-tools) before stlc

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -5,19 +5,20 @@ name: Generate TypeScript SDK with stlc
 # (stainless-cloud.yml), which stops working when Stainless is sunset 2026-09-01.
 #
 # Gated on the `deploy` branch (same trigger as the old workflow) so the SDK
-# tracks the production-deployed API contract. The SDK is only PUBLISHED when the
-# release-please PR in tambo-ai/typescript-sdk is merged, so this never publishes
-# ahead of a deploy.
+# tracks the production-deployed API contract.
+#
+# Flow: the SDK repo's `main` is PR-only (branch ruleset), so stlc cannot push
+# to it directly. stlc pushes the regenerated SDK to the unprotected side branch
+# `stlc/auto-regenerate`, and this workflow opens/updates a PR into `main`.
+# Merging that PR lets release-please cut the release — so nothing publishes
+# ahead of a human merge.
 #
 # Auth: mints short-lived GitHub App installation tokens from the org's
 # tambo-automations app (TAMBO_AUTOMATIONS_APP_CLIENT_ID /
-# TAMBO_AUTOMATIONS_APP_PRIVATE_KEY). The tokens request only the permissions
-# this workflow needs (least privilege), narrower than the app's full grant:
-#   - SDK push:    contents:write + workflows:write on typescript-sdk
-#                  (workflows:write is required — the generated SDK contains
-#                  .github/workflows/*; no pull-requests permission needed since
-#                  stlc pushes to main directly, and release-please opens the
-#                  release PR with its own token).
+# TAMBO_AUTOMATIONS_APP_PRIVATE_KEY), least-privilege per repo:
+#   - SDK token:   contents:write + workflows:write (the generated SDK contains
+#                  .github/workflows/*) + pull-requests:write (open the PR) on
+#                  typescript-sdk.
 #   - vendor read: contents:read on stlc-vendor.
 
 on:

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -68,6 +68,7 @@ jobs:
           permission-contents: write
           permission-workflows: write
           permission-pull-requests: write
+          permission-pull-requests: write
 
       # Regenerate the spec from the deployed API so the SDK matches the live
       # contract. Runs on the repo's pinned Node (via setup-tools) before stlc

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -67,6 +67,7 @@ jobs:
           repositories: typescript-sdk
           permission-contents: write
           permission-workflows: write
+          permission-pull-requests: write
 
       # Regenerate the spec from the deployed API so the SDK matches the live
       # contract. Runs on the repo's pinned Node (via setup-tools) before stlc

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -95,6 +95,22 @@ jobs:
           git config --global user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           gh auth setup-git
 
+      - name: Reset regen branch to main (keeps stlc's push a fast-forward)
+        env:
+          GH_TOKEN: ${{ steps.sdk-token.outputs.token }}
+        run: |
+          # stlc has no --force; each regen commits on top of main, so the
+          # persistent regen branch must be reset to main first. Force-updating
+          # the branch keeps the open PR in place and refreshes its diff.
+          main_sha=$(gh api repos/tambo-ai/typescript-sdk/commits/main --jq .sha)
+          if gh api "repos/tambo-ai/typescript-sdk/git/refs/heads/$SDK_BRANCH" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/tambo-ai/typescript-sdk/git/refs/heads/$SDK_BRANCH" \
+              -F sha="$main_sha" -F force=true >/dev/null
+          else
+            gh api -X POST "repos/tambo-ai/typescript-sdk/git/refs" \
+              -f ref="refs/heads/$SDK_BRANCH" -f sha="$main_sha" >/dev/null
+          fi
+
       - name: Generate SDK and push
         env:
           GH_TOKEN: ${{ steps.sdk-token.outputs.token }}

--- a/.github/workflows/stlc-generate.yml
+++ b/.github/workflows/stlc-generate.yml
@@ -137,11 +137,18 @@ jobs:
         run: |
           # main is PR-only (ruleset). stlc pushed generated code to $SDK_BRANCH;
           # open or update a PR from it into main. release-please then releases.
+          # Skip PR creation when the branch is at main (no-op regen: stlc made no
+          # commit, so creating a PR would error "No commits between...").
+          ahead=$(gh api "repos/tambo-ai/typescript-sdk/compare/main...$SDK_BRANCH" --jq .ahead_by)
+          if [ "$ahead" -eq 0 ]; then
+            echo "No changes vs main — no-op regen, skipping PR."
+            exit 0
+          fi
           existing=$(gh pr list --repo tambo-ai/typescript-sdk --head "$SDK_BRANCH" --base main --state open --json number --jq '.[0].number')
           if [ -z "$existing" ]; then
             gh pr create --repo tambo-ai/typescript-sdk --base main --head "$SDK_BRANCH" \
               --title "chore: regenerate SDK from API" \
               --body "Automated SDK regeneration from the deployed API (stlc). Merging publishes via release-please."
           else
-            echo "PR #$existing already open; stlc force-pushed $SDK_BRANCH so it is updated."
+            echo "PR #$existing already open; stlc pushed new commits to $SDK_BRANCH so it is updated."
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ react-sdk/dist/**
 # Agents
 .claude/settings.local.json
 .claude/**/*.local.md
+.gstack/
+
+# Stainless transition doc cache (scraped from app.stainless.com; not source)
+devdocs/stainless-transition/

--- a/plans/2026-06-04-001-feat-stlc-sdk-migration-plan.md
+++ b/plans/2026-06-04-001-feat-stlc-sdk-migration-plan.md
@@ -202,19 +202,33 @@ Stainless-managed staging repo collapses into the production repo.
 
 ## Key Technical Decisions
 
-### KTD1. Separate SDK repo, work-in-public (`staging_repo == production_repo`)
+### KTD1. Separate SDK repo; regenerate to a side branch + PR into protected `main`
 
 The SDK stays its own repo (`tambo-ai/typescript-sdk`), not folded into the
-monorepo. We set both `staging_repo` and `production_repo` to
-`tambo-ai/typescript-sdk` — stlc's documented "work in public" path.
+monorepo. The SDK repo's `main` is **PR-only** (branch ruleset: `pull_request`,
+`required_status_checks`, `required_linear_history`), so stlc **cannot push to
+`main` directly**. The generate workflow therefore pushes the regenerated SDK to
+an **unprotected side branch** (`stlc/auto-regenerate`) and **opens a PR into
+`main`**; release-please releases on merge. `staging_repo` / `production_repo`
+both point at `tambo-ai/typescript-sdk` (the side branch is the "staging"
+surface within that one repo).
 
-**Why:** the SDK repo is already 100% generated commits, so there is no churn or
-review value in a private staging buffer; collapsing removes one repo, one PAT,
-and the entire promote workflow. Folding the SDK into the monorepo was
-considered and rejected — stlc's `build` operates on a cloned SDK repo as its
-output unit (custom code lives in `refs/stainless/*` on that repo), so a
-monorepo subtree fights the tool, and the lockstep-release upside is not worth
-the generated-code churn in monorepo PR diffs.
+**Why not work-in-public direct-to-main (original choice, reversed):** that
+assumed the bot could push straight to `main`. It can't — the ruleset rejects
+direct pushes and won't be relaxed. A separate staging _repo_ would also work
+but is unnecessary: an unprotected side branch in the same repo serves as
+stlc's writable surface, and the PR into `main` honors the ruleset.
+
+**Custom-code lineage:** the tracking file at
+`stainless/custom-code/typescript/` pins `base` = the stlc-generated baseline
+(`90c6c35`, #280's seal base) and `integrated` = the SDK `main` HEAD (reachable
+from `origin/main`). This was required because the parallel **#280** migration
+PR was **squash-merged**, orphaning its stlc seals from `main` — so neither the
+old Stainless seal (conflicts) nor #280's seal (no shared history) applied.
+Pinning `integrated` to a real `main` commit makes the custom-code patch
+3-way-apply cleanly. Validated: a `workflow_dispatch` run goes green end-to-end
+(generate → apply custom code → push side branch → open PR #284, diff = one
+tooling file).
 (Decision history: see `plans/stainless-migration.md`.)
 
 ### KTD2. Generation stays gated on the `deploy` branch

--- a/plans/stainless-migration.md
+++ b/plans/stainless-migration.md
@@ -1,0 +1,145 @@
+# Stainless → stlc: SDK generation migration plan
+
+Status: investigation complete; migration path confirmed (stlc). Execution pending.
+Last updated: 2026-06-03.
+
+## Why
+
+Anthropic acquired Stainless (announced 2026-05-18) and is sunsetting all
+hosted Stainless products. **Hard deadline: September 1st, 2026** — after that
+the Stainless API and build infrastructure shut off for our account and the
+`stainless-sdks` staging repos become read-only.
+
+Stainless provides a sanctioned replacement: **stlc**, a source-available CLI
+that replicates the platform — it generates/updates existing Stainless SDKs
+from the OpenAPI spec + `stainless.yml`, runs locally and in our CI. License is
+perpetual, internal-use only (no redistribution, no commercial resale, no
+AI/ML training use), provided as-is. Migration support from the Stainless team
+is available until 2026-09-01 via Slack or transition@stainless.com.
+
+Account-specific transition guide: <https://app.stainless.com/hydra-ai/transition/docs/overview>.
+A full text capture of all 18 guide pages plus the exported project bundle is
+cached in `devdocs/stainless-transition/` (so no Stainless login is needed to
+reference them).
+
+- [Anthropic announcement](https://www.anthropic.com/news/anthropic-acquires-stainless)
+- [TechCrunch coverage](https://techcrunch.com/2026/05/18/anthropic-has-acquired-the-dev-tools-startup-used-by-openai-google-and-cloudflare/)
+
+## Current state (verified 2026-06-03)
+
+- Pipeline still running: `stainless-app[bot]` released
+  `@tambo-ai/typescript-sdk` **0.96.2** on 2026-06-03. The monorepo pins
+  0.96.1 (`apps/web`, `packages/client`, `packages/ui-registry`,
+  `packages/react-ui-base`).
+- Flow today: `apps/api` generates the OpenAPI spec from NestJS Swagger
+  (`npm run generate-config`); `.github/workflows/stainless-cloud.yml` uploads
+  it to Stainless project **`hydra-ai`** on push to `deploy`; Stainless
+  regenerates the SDK, opens a release PR in
+  [`tambo-ai/typescript-sdk`](https://github.com/tambo-ai/typescript-sdk), and
+  publishes to npm on merge.
+- **Project bundle exported and saved** at
+  `devdocs/stainless-transition/stainless-hydra-ai.zip`, containing:
+  - `stainless/openapi.json` (109 KB spec snapshot)
+  - `stainless/openapi.stainless.yml` (9.7 KB — the full Stainless config,
+    previously only in Stainless Studio; now recovered)
+  - `stainless/custom-code/typescript/…custom-code.json` — a tracking pointer
+    (base/integrated SHAs). The actual custom code lives as git refs in the
+    staging repo, which is why mirroring it preserves custom code.
+- Targets per the config:
+  - `typescript` → production `tambo-ai/typescript-sdk`, staging
+    `stainless-sdks/hydra-ai-typescript` (exists, accessible, active today),
+    npm publish via OIDC.
+  - `python` → production `tambo-ai/python-sdk`, which **does not exist** (404).
+    The python target was configured but never shipped. Decide during
+    migration: drop the target or stand it up properly.
+- Org access already activated for `stlc`, `stlc-typescript`, and
+  `stlc-python` (per the transition guide's install matrix).
+
+## Target architecture (mirrors how the SaaS works today)
+
+Three GitHub Actions stages, all owned by us:
+
+1. **Generate** (`stlc-generate.yml` in the config repo — this monorepo):
+   spec change merges → `stlc build` regenerates SDKs → pushes to each staging
+   repo's `main`. Optional PR-time preview posts SDK diffs on spec PRs.
+2. **Promote** (`stlc-promote.yml` in each staging repo): staging `main`
+   advances → opens/updates a release PR against the production repo.
+3. **Release** (`release-please.yml` + `publish-npm.yml` in each production
+   repo): promote PR merges → version bump, changelog, tag, npm publish.
+
+Daily loop after migration: change the API → regenerate spec → `stlc build`.
+Estimated one-time effort per the guide: 1–2 hours for our shape (1 active SDK
+
+- a little custom code), mostly GitHub setup.
+
+## Prerequisites (gather before starting)
+
+- GitHub org admin on `tambo-ai` (uninstall Stainless GitHub App, add secrets,
+  create repos).
+- **`SDK_WRITE_TOKEN`**: fine-grained PAT — Contents r/w, Pull requests r/w,
+  Workflows r/w — scoped to the config repo, staging repo(s), and production
+  repo(s). Powers promote + doubles as `RELEASE_PLEASE_TOKEN`.
+- **`STLC_READ_TOKEN`**: classic PAT with `repo` scope, used in CI to clone
+  the private `stainless/stlc*` packages. Can only be minted after accepting
+  the GitHub invites (request via the transition guide "Activate stlc access"
+  page).
+- Node.js **24+** for running stlc (repo standard is Node >=22 — CI jobs that
+  run stlc need 24; check `mise.toml` implications).
+- `unzip` on PATH; TypeScript toolchain for local builds.
+
+## Migration steps (from the account-specific guide, adapted to us)
+
+0. **Pre-flight**: merge any open Stainless release PRs on
+   `tambo-ai/typescript-sdk` (aligns `next` and `main`); stop editing custom
+   code in Stainless Studio from bundle-download onward; decide what to do
+   with the dead `python` target.
+1. **Activate access**: each team member who needs stlc requests GitHub
+   invites via the guide, accepts them, then mints `STLC_READ_TOKEN`. Mark
+   "migration started" in the Stainless dashboard (org admin).
+2. **Install**: `npm install -g git+https://github.com/stainless/stlc.git
+git+https://github.com/stainless/stlc-typescript.git` (HTTPS auth via
+   `gh auth setup-git`).
+3. **Initialize**: create private staging repo (suggested
+   `tambo-ai/typescript-sdk-staging`), mirror `stainless-sdks/hydra-ai-typescript`
+   into it (preserves history + custom-code tracking refs). Then, in the
+   config repo, `stlc init --from-cloud ./stainless-hydra-ai.zip` — download a
+   **fresh** bundle at execution time; the one cached in devdocs is a
+   point-in-time backup. When prompted, set the typescript `staging_repo` to
+   the new repo. Decide where the workspace lives — the guide suggests the
+   repo that owns the spec, i.e. this monorepo (a `stainless/` dir at root).
+4. **First build**: `stlc build --commit "feat: initial stlc build"`,
+   `stlc test`, then `stlc build --push`. Commit
+   `stainless/custom-code/` tracking files to the config repo.
+5. **Validate parity**: `git diff HEAD~1 HEAD` in the SDK repo (stlc-build vs
+   app-built commit) and `git diff origin/main HEAD` vs published SDK.
+   Header/format drift is fine; type/signature/behavior drift is not — escalate
+   to transition@stainless.com before cutover.
+6. **Automate**: wire the three workflows (templates in the cached guide pages
+   `codegen.txt`, `promote.txt`, `release.txt`), add secrets, then dry-run a
+   full round trip with a trivial spec change.
+7. **Cutover**: remove `STAINLESS_API_KEY` secret and delete
+   `.github/workflows/stainless-cloud.yml`; uninstall the Stainless GitHub App
+   from the `tambo-ai` org; mark migration complete in the dashboard
+   (choose **read-only**, not shutdown, so bundle exports stay retrievable);
+   update `RELEASING.md` and `AGENTS.md`.
+
+## Repo changes in this monorepo (when executing)
+
+- Add `stainless/` workspace (spec, `stainless.yml`, custom-code tracking,
+  `workspace.json`) — replaces the config that lived in Stainless Studio.
+- Replace `.github/workflows/stainless-cloud.yml` with
+  `.github/workflows/stlc-generate.yml` (+ `.github/actions/setup-stlc`).
+  Note the trigger likely moves from "push to `deploy`" to "spec change merged"
+  — keep the spec snapshot in-repo and regenerated via
+  `npm run generate-config` so the workflow can diff it.
+- Update `RELEASING.md` (API client + Stainless Studio sections) and
+  `AGENTS.md` references.
+
+## Open decisions
+
+1. Drop or ship the `python` target (no production repo exists today).
+2. Workspace location: this monorepo root vs a dedicated config repo.
+3. Staging repo naming (`tambo-ai/typescript-sdk-staging` suggested).
+4. Long-term: stlc is unsupported after 2026-09-01. It buys us continuity;
+   re-evaluate Speakeasy/Fern/TypeSpec emitters only if stlc becomes a
+   maintenance burden later.

--- a/stainless/custom-code/typescript/1780592816577-custom-code.json
+++ b/stainless/custom-code/typescript/1780592816577-custom-code.json
@@ -1,0 +1,6 @@
+{
+  "base": "90c6c35b6bebf47d4defdff53d296b2a64e294d0",
+  "integrated": "44e7c41072affff375b4c733396e23662c38390a",
+  "branch": "main",
+  "filename": "1780592816577-custom-code.json"
+}

--- a/stainless/custom-code/typescript/2026-06-03T22-01-05-912Z-custom-code.json
+++ b/stainless/custom-code/typescript/2026-06-03T22-01-05-912Z-custom-code.json
@@ -1,6 +1,0 @@
-{
-  "base": "ce1d7f96413db3346f1c54a289ef16be5a7f4604",
-  "integrated": "8f2cc36bebcdfe8d0dd15afde9769ed891e4c257",
-  "branch": "main",
-  "filename": "2026-06-03T22-01-05-912Z-custom-code.json"
-}


### PR DESCRIPTION
Leftover cleanup from the stlc migration:
- `.gitignore`: ignore `devdocs/stainless-transition/` (scraped Stainless transition docs; account-specific, not source) and `.gstack/`.
- `plans/stainless-migration.md`: the initial investigation doc that preceded the formal plan in `plans/2026-06-04-001-feat-stlc-sdk-migration-plan.md`.