### PR TITLE
chore(deps): migrate dependency automation from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,13 @@
+# Dependabot is used ONLY for security updates. All version updates are handled
+# by Renovate (see .github/renovate.json5).
+#
+# `open-pull-requests-limit: 0` disables version-update PRs for each ecosystem
+# while leaving Dependabot security updates active (security updates have a
+# separate internal limit and are not affected by this setting). Security
+# updates must also be enabled in the repository's security settings.
+#
+# `commit-message` is kept so security-update PR titles use Conventional Commit
+# prefixes and pass the PR title check (.github/workflows/conventional-commits.yml).
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -6,132 +16,19 @@ updates:
       - "/.github/actions/*"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "07:00"
-      timezone: "America/New_York"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
     labels: ["area: github actions", "status: ready"]
-    groups:
-      composite-actions:
-        patterns:
-          # Dependency names for actions all contain the path to the action
-          - ".github/actions/*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
     labels: ["area: dependencies", "status: ready"]
-    # Let package releases bake for a bit before updating,
-    # in case there is a bad release. However, always update
-    # the latest version of the Tambo packages.
-    cooldown:
-      default-days: 5
-      semver-major-days: 7
-      semver-minor-days: 4
-      semver-patch-days: 2
-      include:
-        - "*"
-      exclude:
-        - "@tambo-ai/*"
-        - "ai"
-        - "@ai-sdk/*"
-    ignore:
-      - dependency-name: "react"
-        versions: [">=19"]
-      - dependency-name: "react-dom"
-        versions: [">=19"]
-      - dependency-name: "@types/react"
-        versions: [">=19"]
-      - dependency-name: "@types/react-dom"
-        versions: [">=19"]
-    groups:
-      trpc:
-        patterns:
-          - "@trpc/*"
-      nestjs:
-        patterns:
-          - "@nestjs/*"
-      radix-ui:
-        patterns:
-          - "@radix-ui/*"
-          - "radix-ui"
-      drizzle:
-        # drizzle-kit and drizzle-orm
-        patterns:
-          - "drizzle-kit"
-          - "drizzle-orm"
-      eslint:
-        patterns:
-          - "@eslint/*"
-          - "eslint"
-          - "typescript-eslint"
-          - "eslint-plugin-*"
-          - "eslint-config-*"
-      testing:
-        patterns:
-          - "jest"
-          - "@types/jest"
-          - "jest-*"
-          - "ts-jest"
-          - "@testing-library/*"
-          - "supertest"
-      ai-sdk:
-        patterns:
-          - "ai"
-          - "@ai-sdk/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-      next:
-        patterns:
-          - "next"
-          - "@next/*"
-      t3-oss:
-        patterns:
-          - "@t3-oss/*"
-      tambo-ai:
-        patterns:
-          - "@tambo-ai/*"
-      small-safe-packages:
-        # These aren't related, but these are all generally safe to update
-        # unconditionally, so we lump them together to get one PR
-        patterns:
-          - "posthog-js"
-          - "@splinetool/runtime"
-          - "prettier"
-          - "lint-staged"
-          - "globals"
-          - "lucide-react"
-          - "@opentelemetry/*"
-      sentry:
-        patterns:
-          - "@sentry/*"
-          - sentry-*
-      ag-ui:
-        patterns:
-          - "@ag-ui/*"
-          - "@mastra/*"
-      fumadocs:
-        patterns:
-          - "fumadocs-*"
-      tailwind:
-        patterns:
-          - "tailwindcss"
-          - "tailwind-*"
-          - "@tailwindcss/*"
-      tiptap:
-        patterns:
-          - "@tiptap/*"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,23 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:best-practices",
+    "schedule:daily",
+    "schedule:automergeDaily",
+    ":automergeAll",
+    ":automergePr",
+    ":disableDependencyDashboard"
+  ],
   "labels": ["dependencies"],
   "gitAuthor": "renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>",
-  "enabledManagers": ["nvm", "nodenv", "mise", "npm", "custom.jsonata"],
-  "dependencyDashboard": false,
+  "enabledManagers": [
+    "nvm",
+    "nodenv",
+    "mise",
+    "npm",
+    "github-actions",
+    "custom.jsonata"
+  ],
   // Custom manager to match Node.js version from devEngines.runtime in package.json
   "customManagers": [
     {
@@ -19,6 +32,7 @@
     }
   ],
   "packageRules": [
+    // --- Node.js version management ---
     {
       "description": "Group all Node.js version updates into a single PR",
       "matchDatasources": ["node-version"],
@@ -30,41 +44,195 @@
       "commitMessageTopic": "Node.js"
     },
     {
-      "description": "Auto-merge Node.js patch updates",
-      "matchDatasources": ["node-version"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
-    },
-    {
+      // automerge is enabled globally via :automergeAll; keep Node minor/major gated on review.
       "description": "Require review for Node.js minor/major updates",
       "matchDatasources": ["node-version"],
       "matchUpdateTypes": ["minor", "major"],
       "automerge": false
     },
     {
-      "description": "Disable all npm dependency updates (only enable volta node/npm)",
-      "matchManagers": ["npm"],
-      "matchDepTypes": [
-        "dependencies",
-        "devDependencies",
-        "peerDependencies",
-        "optionalDependencies",
-        "engines"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Enable volta node/npm updates",
+      "description": "Group volta node/npm updates with the Node.js version update",
       "matchManagers": ["npm"],
       "matchDepTypes": ["volta"],
-      "enabled": true,
       "groupName": "node version",
       "groupSlug": "node"
+    },
+
+    // --- npm release cooldown (migrated from Dependabot `cooldown`) ---
+    // config:best-practices already enforces a 3-day npm wait via
+    // security:minimumReleaseAgeNpm; these rules tune it per update type.
+    {
+      "description": "Cooldown: npm major updates bake for 7 days",
+      "matchDatasources": ["npm"],
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Cooldown: npm minor updates bake for 4 days",
+      "matchDatasources": ["npm"],
+      "matchUpdateTypes": ["minor"],
+      "minimumReleaseAge": "4 days"
+    },
+    {
+      "description": "Cooldown: npm patch updates bake for 2 days",
+      "matchDatasources": ["npm"],
+      "matchUpdateTypes": ["patch"],
+      "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "Always update Tambo and AI SDK packages immediately (no cooldown)",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@tambo-ai/*", "ai", "@ai-sdk/*"],
+      "minimumReleaseAge": "0 days"
+    },
+
+    // --- Version constraints (migrated from Dependabot `ignore`) ---
+    {
+      "description": "Stay on React 18 until we migrate (block v19+)",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "allowedVersions": "<19"
+    },
+
+    // --- npm groups (migrated from Dependabot `groups`) ---
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@trpc/*"],
+      "groupName": "trpc"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@nestjs/*"],
+      "groupName": "nestjs"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@radix-ui/*", "radix-ui"],
+      "groupName": "radix-ui"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["drizzle-kit", "drizzle-orm"],
+      "groupName": "drizzle"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@eslint/*",
+        "eslint",
+        "typescript-eslint",
+        "eslint-plugin-*",
+        "eslint-config-*"
+      ],
+      "groupName": "eslint"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "jest",
+        "@types/jest",
+        "jest-*",
+        "ts-jest",
+        "@testing-library/*",
+        "supertest"
+      ],
+      "groupName": "testing"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["ai", "@ai-sdk/*"],
+      "groupName": "ai-sdk"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ],
+      "groupName": "react"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["next", "@next/*"],
+      "groupName": "next"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@t3-oss/*"],
+      "groupName": "t3-oss"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@tambo-ai/*"],
+      "groupName": "tambo-ai"
+    },
+    {
+      // These aren't related, but are all generally safe to update
+      // unconditionally, so we lump them together to get one PR.
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "posthog-js",
+        "@splinetool/runtime",
+        "prettier",
+        "lint-staged",
+        "globals",
+        "lucide-react",
+        "@opentelemetry/*"
+      ],
+      "groupName": "small-safe-packages"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@sentry/*", "sentry-*"],
+      "groupName": "sentry"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@ag-ui/*", "@mastra/*"],
+      "groupName": "ag-ui"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["fumadocs-*"],
+      "groupName": "fumadocs"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["tailwindcss", "tailwind-*", "@tailwindcss/*"],
+      "groupName": "tailwind"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@tiptap/*"],
+      "groupName": "tiptap"
+    },
+
+    // --- GitHub Actions (migrated from Dependabot github-actions ecosystem) ---
+    {
+      "description": "Group composite action updates into a single PR",
+      "matchManagers": ["github-actions"],
+      "matchFileNames": [".github/actions/**"],
+      "groupName": "composite-actions"
+    },
+
+    // --- Labels (migrated from Dependabot per-ecosystem labels) ---
+    {
+      "description": "Label npm dependency PRs",
+      "matchManagers": ["npm"],
+      "addLabels": ["area: dependencies", "status: ready"]
+    },
+    {
+      "description": "Label GitHub Actions PRs",
+      "matchManagers": ["github-actions"],
+      "addLabels": ["area: github actions", "status: ready"]
     }
   ],
-  "schedule": ["before 9am on monday"],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
## What & why

Moves all dependency **version updates** to Renovate and leaves Dependabot for **security updates only**. Consolidates the two tools so dependency automation lives in one place with a single, best-practices-based config.

## Renovate (`.github/renovate.json5`)

- Adopt the `config:best-practices` base plus `schedule:daily`, `schedule:automergeDaily`, `:automergeAll`, `:automergePr`, `:disableDependencyDashboard`.
- Drop settings the presets now own: explicit `dependencyDashboard: false`, the weekly `schedule`, and the Node patch-automerge rule.
- Re-enable npm and add the `github-actions` manager.
- Migrate **all 17 Dependabot npm groups** to `packageRules` (`groupName` + glob `matchPackageNames`).
- Port Dependabot `cooldown` → `minimumReleaseAge` per update type (major 7d / minor 4d / patch 2d); `@tambo-ai/*`, `ai`, `@ai-sdk/*` update immediately.
- Port the React `ignore` (≥19) → `allowedVersions: "<19"`.
- Port the `composite-actions` group → `matchFileNames: [".github/actions/**"]`.
- Port per-ecosystem labels → `addLabels` rules.
- Keep the Node minor/major review gate (`automerge: false`) as an explicit override of `:automergeAll`.

## Dependabot (`.github/dependabot.yml`)

- Strip all version-update config (groups, cooldown, ignore, schedule details).
- Set `open-pull-requests-limit: 0` per ecosystem — disables version PRs, keeps security PRs.
- Keep `commit-message` so security-update PR titles stay Conventional-Commit-compliant (the PR title check runs on bot PRs too).

## Notes / follow-ups

- ⚠️ **`:automergeAll` auto-merges majors** once CI passes and cooldown elapses (only Node minor/major still needs review). Swap to `:automergeMinor` if that's too aggressive.
- **Initial pin wave expected:** `config:best-practices` pulls in `:pinDevDependencies` and `helpers:pinGitHubActionDigests`, so the first run will open a batch of pinning PRs.
- **Action required:** Dependabot security updates must be enabled in **Settings → Code security** — the yml only disables version updates.

Config validated with `renovate-config-validator` (v43) and Prettier.
