### PR TITLE
fix(deps): bump dompurify to ^3.4.11

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,7 +66,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "drizzle-orm": "^0.45.2",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.29.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
     "@tambo-ai/typescript-sdk": "^0.96.1",
     "@tambo-ai/ui-registry": "*",
     "class-variance-authority": "^0.7.1",
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "framer-motion": "^12.29.0",
     "fumadocs-core": "15.8.5",
     "fumadocs-mdx": "^13.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -472,7 +472,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
-        "dompurify": "^3.4.9",
+        "dompurify": "^3.4.11",
         "drizzle-orm": "^0.45.2",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.29.0",
@@ -1041,7 +1041,7 @@
         "@tambo-ai/typescript-sdk": "^0.96.1",
         "@tambo-ai/ui-registry": "*",
         "class-variance-authority": "^0.7.1",
-        "dompurify": "^3.4.9",
+        "dompurify": "^3.4.11",
         "framer-motion": "^12.29.0",
         "fumadocs-core": "15.8.5",
         "fumadocs-mdx": "^13.0.8",
@@ -22870,9 +22870,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
-      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -40656,7 +40656,7 @@
         "@vercel/og": "^1.0.0",
         "autoprefixer": "^10.4.27",
         "class-variance-authority": "^0.7.1",
-        "dompurify": "^3.4.9",
+        "dompurify": "^3.4.11",
         "framer-motion": "^12.29.0",
         "geist": "^1.5.1",
         "highlight.js": "^11.11.1",

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -39,7 +39,7 @@
     "@vercel/og": "^1.0.0",
     "autoprefixer": "^10.4.27",
     "class-variance-authority": "^0.7.1",
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "framer-motion": "^12.29.0",
     "geist": "^1.5.1",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
## What

Bumps **dompurify** `^3.4.9` → `^3.4.11` in `apps/web`, `docs`, and `showcase` (the three workspaces that declare it directly). Lockfile now resolves the single hoisted `dompurify` to **3.4.11**.

Resolves Dependabot alert **GHSA-cmwh-pvxp-8882** (medium): permanent `ALLOWED_ATTR` pollution via `setConfig()` bypassing the hook clone-guard (incomplete fix of the 3.4.7 hook-pollution patch). Patched in 3.4.11.

Transitive consumers (`mermaid` `^3.3.1`, `posthog-js` `^3.3.2`) both allow 3.4.11 and dedupe to the same entry.

## Verification
- Single `node_modules/dompurify` entry in the lockfile at 3.4.11 (no duplicates).
- Lockfile diff scoped to dompurify only (12 lines).