### PR TITLE
fix(api): remove unused @opentelemetry/exporter-otlp-http

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -38,7 +38,6 @@
     "@nestjs/swagger": "^11.4.4",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.77.0",
-    "@opentelemetry/exporter-otlp-http": "^0.26.0",
     "@opentelemetry/instrumentation-express": "^0.66.0",
     "@opentelemetry/instrumentation-http": "^0.219.0",
     "@opentelemetry/instrumentation-nestjs-core": "^0.64.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "@nestjs/swagger": "^11.4.4",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.77.0",
-        "@opentelemetry/exporter-otlp-http": "^0.26.0",
         "@opentelemetry/instrumentation-express": "^0.66.0",
         "@opentelemetry/instrumentation-http": "^0.219.0",
         "@opentelemetry/instrumentation-nestjs-core": "^0.64.0",
@@ -9773,16 +9772,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/api-metrics": {
-      "version": "0.26.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
     "node_modules/@opentelemetry/auto-instrumentations-node": {
       "version": "0.77.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-node/-/auto-instrumentations-node-0.77.0.tgz",
@@ -10043,74 +10032,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-otlp-http": {
-      "version": "0.26.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-metrics": "0.26.0",
-        "@opentelemetry/core": "1.0.0",
-        "@opentelemetry/resources": "1.0.0",
-        "@opentelemetry/sdk-metrics-base": "0.26.0",
-        "@opentelemetry/sdk-trace-base": "1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "1.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "1.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.0.0",
-        "@opentelemetry/semantic-conventions": "1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.0.0",
-        "@opentelemetry/resources": "1.0.0",
-        "@opentelemetry/semantic-conventions": "1.0.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.0.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
@@ -11872,57 +11793,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics-base": {
-      "version": "0.26.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-metrics": "0.26.0",
-        "@opentelemetry/core": "1.0.0",
-        "@opentelemetry/resources": "1.0.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/core": {
-      "version": "1.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/resources": {
-      "version": "1.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.0.0",
-        "@opentelemetry/semantic-conventions": "1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.2"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.0.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/sdk-node": {


### PR DESCRIPTION
## What

Removes the **`@opentelemetry/exporter-otlp-http`** dependency from `apps/api`.

## Why

Resolves Dependabot alert **GHSA-8988-4f7v-96qf** (medium): "OpenTelemetry Core: Unbounded memory allocation in W3C Baggage propagation" (`@opentelemetry/core < 2.8.0`).

`@opentelemetry/exporter-otlp-http@0.26.0` is a deprecated, long-unmaintained package pinned to the **1.x** OpenTelemetry line. It dragged `@opentelemetry/core@1.0.0` (plus `resources`, `sdk-trace-base`, `semantic-conventions` at 1.0.0) into the tree — those `1.0.0` copies are what matched the `< 2.8.0` advisory range.

It was **never imported**: `apps/api/src/telemetry.ts` builds its `NodeSDK` from `@opentelemetry/sdk-node` + the instrumentation packages and uses the default exporter. Removing the dead dependency drops all pre-2.x otel packages. The actively-used `@opentelemetry/core` is already at **2.8.0** (patched).

## Verification
- After removal the lockfile contains a single `@opentelemetry/core` at **2.8.0**; no `1.x` copies remain.
- `npm run check-types -w @tambo-ai-cloud/api` passes.
- Diff is a pure removal (manifest line + the package's lockfile subtree).